### PR TITLE
Fixing KF1.3 issues on  openshift 4.6/4.7

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -465,17 +465,29 @@ func (r *ProfileReconciler) updateAnyUIDScc(ctx context.Context, profileIns *pro
 	 		logger.Info("Successfully Created SCC")
 		}
 	} else {
-		 logger.Info("SCC already exists" + "scc-"+profileIns.Name)
-		 logger.Info("scc found", "blabla", foundscc)
+		 logger.Info("SCC already exists " + "scc-"+profileIns.Name)
+		 logger.Info("scc found", "found", foundscc)
 		 // update SCC
-		 updatedscc, err5 := securityCLientset.SecurityContextConstraints().Update(ctx, foundscc, metav1.UpdateOptions{})
-		 if err5 != nil {
-			logger.Info("Error updating SCC ")
-			return err5
-		}
-		if updatedscc != nil {
-	 		logger.Info("Successfully Updated SCC")
-		}
+		 if !reflect.DeepEqual(foundscc, scc) {
+			 // Could not find an easier way to copy the data, we cannot blindly say foundscc=scc it has different metadata
+			foundscc.Priority = scc.Priority
+			foundscc.AllowPrivilegedContainer = scc.AllowPrivilegedContainer
+			foundscc.AllowHostNetwork = scc.AllowHostNetwork
+			foundscc.AllowHostPorts = scc.AllowHostPorts
+			foundscc.SELinuxContext = scc.SELinuxContext
+			foundscc.RunAsUser = scc.RunAsUser
+			foundscc.FSGroup = scc.FSGroup
+			foundscc.Users = scc.Users
+			foundscc.Groups = scc.Groups
+		    updatedscc, err5 := securityCLientset.SecurityContextConstraints().Update(ctx, foundscc, metav1.UpdateOptions{})
+		    if err5 != nil {
+			    logger.Info("Error updating SCC ")
+			     return err5
+		    }
+		    if updatedscc != nil {
+	 		    logger.Info("Successfully Updated SCC:", "updated", updatedscc)
+		    }
+		 }
 	} 
 	return nil
 }
@@ -526,13 +538,16 @@ func (r *ProfileReconciler) updateNetworkAttachmentDefinition(ctx context.Contex
 		 logger.Info(" NetworkAttachmentDefinition already exists" + "scc-"+profileIns.Name)
 		 logger.Info(" NetworkAttachmentDefinition found", "blabla", foundnet)
 		 // update SCC
-		 updatedscc, err5 := networkCLientset.NetworkAttachmentDefinitions(profileIns.Name).Update(ctx, foundnet, metav1.UpdateOptions{})
-		 if err5 != nil {
-			logger.Info("Error updating NetworkAttachmentDefinition")
-			return err5
-		}
-		if updatedscc != nil {
-	 		logger.Info("Successfully Updated NetworkAttachmentDefinition")
+		 if !reflect.DeepEqual(foundnet, net) {
+			 foundnet.Spec= net.Spec
+		 	updatedscc, err5 := networkCLientset.NetworkAttachmentDefinitions(profileIns.Name).Update(ctx, foundnet, metav1.UpdateOptions{})
+		 	if err5 != nil {
+				logger.Info("Error updating NetworkAttachmentDefinition")
+				return err5
+			}
+			if updatedscc != nil {
+	 			logger.Info("Successfully Updated NetworkAttachmentDefinition")
+			}
 		}
 	} 
 	return nil

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -134,11 +134,12 @@ func (r *ProfileReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error)
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{"owner": instance.Spec.Owner.Name},
 			// inject istio sidecar to all pods in target namespace by default.
-			Labels: map[string]string{
-				istioInjectionLabel: "enabled",
-			},
+			//Labels: map[string]string{
+			//	istioInjectionLabel: "enabled",
+			//},
             //Disabling istio injection for now, need to fix the istio sidecar injection of fsgrp 1377
-            //Labels: map[string]string{},
+			// This needs to be enabled when integrating with an authentication tool. 
+            Labels: map[string]string{},
 			Name: instance.Name,
 		},
 	}
@@ -431,7 +432,10 @@ func (r *ProfileReconciler) updateAnyUIDScc(ctx context.Context, profileIns *pro
 		FSGroup: securityv1.FSGroupStrategyOptions{
 			Type: securityv1.FSGroupStrategyRunAsAny,
 		},
-		Users: []string{"system:serviceaccount:"+profileIns.Name, "system:serviceaccount:"+profileIns.Name+":default-editor"},
+		//This needs to be removed, since sa default-editor is attached to notebooks and it fails to use volume when an scc is present
+		//Users: []string{"system:serviceaccount:"+profileIns.Name, "system:serviceaccount:"+profileIns.Name+":default-editor"},
+		// switched to default that is used by kfserving for serving pods
+		Users: []string{"system:serviceaccount:"+profileIns.Name, "system:serviceaccount:"+profileIns.Name+":default"},
 		Groups: []string{"system:cluster-admins"},
 	}
 	if err := controllerutil.SetControllerReference(profileIns, scc, r.Scheme); err != nil {

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -40,9 +40,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	// These are imports for creating the scc needed for sidecar and knative on OCP 4.7
+	// These are imports for creating the scc needed for istio sidecar and knative on OCP 4.7
 	securityv1 "github.com/openshift/api/security/v1"
 	securityclientv1 "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
+	networkattachv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	networkattachclientv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	rest "k8s.io/client-go/rest"
 )
 
 const AUTHZPOLICYISTIO = "ns-owner-access-istio"
@@ -131,11 +134,11 @@ func (r *ProfileReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error)
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{"owner": instance.Spec.Owner.Name},
 			// inject istio sidecar to all pods in target namespace by default.
-			//Labels: map[string]string{
-			//	istioInjectionLabel: "enabled",
-			//},
-            //Disabling istio injection for now, need to fix the istio sidecat injection of fsgrp 1377
-            Labels: map[string]string{},
+			Labels: map[string]string{
+				istioInjectionLabel: "enabled",
+			},
+            //Disabling istio injection for now, need to fix the istio sidecar injection of fsgrp 1377
+            //Labels: map[string]string{},
 			Name: instance.Name,
 		},
 	}
@@ -195,10 +198,21 @@ func (r *ProfileReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error)
 		}
 	}
 
-	// Add anyuid SCC for Openshift 
-	if err = r.createAnyUIDScc(ctx, instance); err != nil {
-		logger.Error(err, "error adding anyuid SCC", "namespace", instance.Name)
-		IncRequestErrorCounter("error adding anyuid SCC", SEVERITY_MAJOR)
+	// Update anyuid SCC for Openshift installation
+	// this allows any pod running in new profile namespaces to run as anyuid for user and group
+	// Ths is needed for both Istio side car and Knative in OCP 4.6/4.7
+	if err = r.updateAnyUIDScc(ctx, instance); err != nil {
+		logger.Error(err, "error updating anyuid SCC", "namespace", instance.Name)
+		IncRequestErrorCounter("error updating anyuid SCC", SEVERITY_MAJOR)
+		return reconcile.Result{}, err
+	}
+
+	// Update NetworkAttachmentDefinition
+	// this is needed for isito on OCP using istio-cni
+	// refer to documentation here: https://istio.io/latest/docs/setup/platform-setup/openshift/
+	if err = r.updateNetworkAttachmentDefinition(ctx, instance); err != nil {
+		logger.Error(err, "error updating NetworkAttachmentDefinition", "namespace", instance.Name)
+		IncRequestErrorCounter("error updating NetworkAttachmentDefinition", SEVERITY_MAJOR)
 		return reconcile.Result{}, err
 	}
 
@@ -340,12 +354,20 @@ func (r *ProfileReconciler) appendErrorConditionAndReturn(ctx context.Context, i
 }
 
 func (r *ProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := securityv1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+	if err := networkattachv1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&profilev1.Profile{}).
 		Owns(&corev1.Namespace{}).
 		Owns(&istioSecurityClient.AuthorizationPolicy{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.RoleBinding{}).
+		Owns(&securityv1.SecurityContextConstraints{}).
+		Owns(&networkattachv1.NetworkAttachmentDefinition{}).
 		Complete(r)
 }
 
@@ -381,24 +403,27 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 	}
 }
 
-// createAnyUIDScc creates an SCC for anyuids
-func (r *ProfileReconciler) createAnyUIDScc(ctx context.Context, profileIns *profilev1.Profile) error {
+
+// updateAnyUIDScc Update anyuid SCC for Openshift installation
+// this allows any pod running in new profile namespaces to run as anyuid for user and group
+// Ths is needed for both Istio side car and Knative in OCP 4.6/4.7
+func (r *ProfileReconciler) updateAnyUIDScc(ctx context.Context, profileIns *profilev1.Profile) error {
 	logger := r.Log.WithValues("profile", profileIns.Name)
-	logger.Info("Creating anyuid SCC for profile", profileIns.Name)
+	logger.Info("Creating anyuid SCC for profile")
 	//ctx := context.Background()
 	var priority int32 = 10
 	//actual, err := client.SecurityContextConstraints().Create(ctx, required, metav1.CreateOptions{})
 	scc := &securityv1.SecurityContextConstraints{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "istioanyuid",
+			Name: "scc-"+profileIns.Name,
 		},
 		Priority:                 &priority,
-		AllowPrivilegedContainer: false,
+		AllowPrivilegedContainer: true,
 		AllowHostNetwork:         false,
 		AllowHostPorts:           false,
 		//Volumes:                  ["*"],
 		SELinuxContext: securityv1.SELinuxContextStrategyOptions{
-			Type: securityv1.SELinuxStrategyRunAsAny,
+			Type: securityv1.SELinuxStrategyMustRunAs,
 		},
 		RunAsUser: securityv1.RunAsUserStrategyOptions{
 			Type: securityv1.RunAsUserStrategyRunAsAny,
@@ -406,17 +431,108 @@ func (r *ProfileReconciler) createAnyUIDScc(ctx context.Context, profileIns *pro
 		FSGroup: securityv1.FSGroupStrategyOptions{
 			Type: securityv1.FSGroupStrategyRunAsAny,
 		},
-		Users: []string{},
-		Groups: []string{},
+		Users: []string{"system:serviceaccount:"+profileIns.Name, "system:serviceaccount:"+profileIns.Name+":default-editor"},
+		Groups: []string{"system:cluster-admins"},
 	}
-	securityInterface := securityclientv1.SecurityContextConstraintsGetter.SecurityContextConstraints()
-	actual, err := securityInterface.Create(ctx, scc, metav1.CreateOptions{})
-	
-	//actual, err := client.SecurityContextConstraints().Create(ctx, required, metav1.CreateOptions{})
-	//securityclientv1.SecurityContextConstraintsGetter
+	if err := controllerutil.SetControllerReference(profileIns, scc, r.Scheme); err != nil {
+		return err
+	}
+
+	config, err1 := rest.InClusterConfig()
+	if err1 != nil{
+		logger.Info("Error getting config for K8 client")
+		return err1
+	}
+	securityCLientset, err2 := securityclientv1.NewForConfig(config)
+	if err2 != nil{
+		logger.Info("Error setting config for K8 client")
+		return err2
+	}
+	// Check if the scc already exists first
+	foundscc, err3 := securityCLientset.SecurityContextConstraints().Get(ctx, "scc-"+profileIns.Name, metav1.GetOptions{})
+	if errors.IsNotFound(err3) {
+		// Create SCC
+		actual, err4 := securityCLientset.SecurityContextConstraints().Create(ctx, scc, metav1.CreateOptions{})
+		if err4 != nil {
+			logger.Info("Error creating SCC ")
+			return err4
+		}
+		if actual != nil {
+	 		logger.Info("Successfully Created SCC")
+		}
+	} else {
+		 logger.Info("SCC already exists" + "scc-"+profileIns.Name)
+		 logger.Info("scc found", "blabla", foundscc)
+		 // update SCC
+		 updatedscc, err5 := securityCLientset.SecurityContextConstraints().Update(ctx, foundscc, metav1.UpdateOptions{})
+		 if err5 != nil {
+			logger.Info("Error updating SCC ")
+			return err5
+		}
+		if updatedscc != nil {
+	 		logger.Info("Successfully Updated SCC")
+		}
+	} 
 	return nil
 }
 
+// Update NetworkAttachmentDefinition
+// this is needed for isito on OCP using istio-cni
+// refer to documentation here: https://istio.io/latest/docs/setup/platform-setup/openshift/
+func (r *ProfileReconciler) updateNetworkAttachmentDefinition(ctx context.Context, profileIns *profilev1.Profile) error {
+	logger := r.Log.WithValues("profile", profileIns.Name)
+	logger.Info("Updating NetworkAttachmentDefinition")
+	net := &networkattachv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio-cni",
+			Namespace: profileIns.Name,
+		},
+		//Spec: netv1.NetworkAttachmentDefinitionSpec{
+		//	Config: config,
+		//},
+	}
+	if err := controllerutil.SetControllerReference(profileIns, net, r.Scheme); err != nil {
+		return err
+	}
+
+	config, err1 := rest.InClusterConfig()
+	if err1 != nil{
+		logger.Info("Error getting config for K8 client")
+		return err1
+	}
+	//NewForConfig creates a new K8sCniCncfIoV1Client for the given config.
+	networkCLientset, err2 := networkattachclientv1.NewForConfig(config)
+	if err2 != nil{
+		logger.Info("Error setting config for K8 client")
+		return err2
+	}
+	// Check if the NetworkAttachmentDefinition already exists first
+	foundnet, err3 := networkCLientset.NetworkAttachmentDefinitions(profileIns.Name).Get(ctx, "istio-cni", metav1.GetOptions{})
+	if errors.IsNotFound(err3) {
+		// Create SCC
+		actual, err4 := networkCLientset.NetworkAttachmentDefinitions(profileIns.Name).Create(ctx, net, metav1.CreateOptions{})
+		if err4 != nil {
+			logger.Info("Error creating NetworkAttachmentDefinition ")
+			return err4
+		}
+		if actual != nil {
+	 		logger.Info("Successfully Created NetworkAttachmentDefinition")
+		}
+	} else {
+		 logger.Info(" NetworkAttachmentDefinition already exists" + "scc-"+profileIns.Name)
+		 logger.Info(" NetworkAttachmentDefinition found", "blabla", foundnet)
+		 // update SCC
+		 updatedscc, err5 := networkCLientset.NetworkAttachmentDefinitions(profileIns.Name).Update(ctx, foundnet, metav1.UpdateOptions{})
+		 if err5 != nil {
+			logger.Info("Error updating NetworkAttachmentDefinition")
+			return err5
+		}
+		if updatedscc != nil {
+	 		logger.Info("Successfully Updated NetworkAttachmentDefinition")
+		}
+	} 
+	return nil
+}
 
 // updateIstioAuthorizationPolicy create or update Istio AuthorizationPolicy
 // resources in target namespace owned by "profileIns". The goal is to allow

--- a/components/profile-controller/go.mod
+++ b/components/profile-controller/go.mod
@@ -49,6 +49,10 @@ require (
 	k8s.io/utils v0.0.0-20201015054608-420da100c033 // indirect
 	sigs.k8s.io/controller-runtime v0.6.3
 	sigs.k8s.io/structured-merge-diff/v4 v4.0.2 // indirect
+        // Needed for OCP scc
+        github.com/openshift/api v0.0.0-20200827090112-c05698d102cf
+	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
+	github.com/openshift/library-go v0.0.0-20201013192036-5bd7c282e3e7
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/components/profile-controller/main.go
+++ b/components/profile-controller/main.go
@@ -22,6 +22,8 @@ import (
 	profilev1 "github.com/kubeflow/kubeflow/components/profile-controller/api/v1"
 	"github.com/kubeflow/kubeflow/components/profile-controller/controllers"
 	istioSecurityClient "istio.io/client-go/pkg/apis/security/v1beta1"
+        securityv1 "github.com/openshift/api/security/v1"
+        networkattachv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -44,6 +46,8 @@ func init() {
 
 	_ = profilev1.AddToScheme(scheme)
 	_ = istioSecurityClient.AddToScheme(scheme)
+        _ = securityv1.AddToScheme(scheme)
+        _ = networkattachv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
Addressing some of the  the issues for KF 1.3 on OCP 4.6/4.7 here https://github.com/kubeflow/manifests/issues/1867. This specifically enables anyuid for service account "default" in user namespaces. This is needed for KFServing to run inference pods in that namespace. To test this:
1. Install Kubeflow with KFServing.
2. Replace the profile controller image to point to quay.io/kubeflow/profile-controller:v0.12.0. Or you can build the code and use your image.
3. Delete all profiles, and either create a new profile, or access the Kubeflow dashboard to create one there.
4. Try this KFServing example: https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1beta1/tensorflow
5. To run the curl command, and depending on your cluster you might need to use port forwarding ```oc port-forward --namespace istio-system svc/istio-ingressgateway 8080:80```