### PR TITLE
Fix setting up custom value for K8s_NAMESPACE

### DIFF
--- a/components/notebook-controller/config/overlays/openshift/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/openshift/kustomization.yaml
@@ -19,5 +19,6 @@ configMapGenerator:
       - USE_ISTIO=false
       - ADD_FSGROUP=false
 patchesStrategicMerge:
+  - remove_namespace_patch.yaml
   - manager_openshift_patch.yaml
   - manager_service_openshift_patch.yaml

--- a/components/notebook-controller/config/overlays/openshift/remove_namespace_patch.yaml
+++ b/components/notebook-controller/config/overlays/openshift/remove_namespace_patch.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: notebook-controller-system


### PR DESCRIPTION
This commit fixes setting up custom value for K8s_NAMESPACE when namespace is not already created.
The notebook-controller explicitly creates '*-system' namespace. The changes include removing any namespace created by
the controller and replacing namespace values for all resources