### PR TITLE
Fix openshift-sar on notebook OAuth proxy

### DIFF
--- a/components/odh-notebook-controller/README.md
+++ b/components/odh-notebook-controller/README.md
@@ -50,7 +50,7 @@ flag in the OAuth proxy:
     "verb":"get",
     "resource":"notebooks",
     "resourceAPIGroup":"kubeflow.org",
-    "name":"example",
+    "resourceName":"example",
     "namespace":"opendatahub"
 }
 ```

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -253,7 +253,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 									"--email-domain=*",
 									"--skip-provider-button",
 									`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +
-										`"name":"` + Name + `","namespace":"$(NAMESPACE)"}`,
+										`"resourceName":"` + Name + `","namespace":"$(NAMESPACE)"}`,
 								},
 								Ports: []corev1.ContainerPort{{
 									Name:          OAuthServicePortName,

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -69,7 +69,7 @@ func InjectOAuthProxy(notebook *nbv1.Notebook, oauth OAuthConfig) error {
 			"--email-domain=*",
 			"--skip-provider-button",
 			`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +
-				`"name":"` + notebook.Name + `","namespace":"$(NAMESPACE)"}`,
+				`"resourceName":"` + notebook.Name + `","namespace":"$(NAMESPACE)"}`,
 		},
 		Ports: []corev1.ContainerPort{{
 			Name:          OAuthServicePortName,


### PR DESCRIPTION
Use `resourceName` instead of `name` as it is not supported in Openshift SAR:

```shell
oc explain subjectaccessreview --api-version=authorization.openshift.io/v1
```
