### PR TITLE
Enable culling in notebook controller

### DIFF
--- a/components/notebook-controller/config/overlays/openshift/manager_openshift_patch.yaml
+++ b/components/notebook-controller/config/overlays/openshift/manager_openshift_patch.yaml
@@ -13,6 +13,24 @@ spec:
                 configMapKeyRef:
                   name: config
                   key: ADD_FSGROUP
+            - name: ENABLE_CULLING
+              valueFrom:
+                configMapKeyRef:
+                  name: notebook-controller-culler-config
+                  key: ENABLE_CULLING
+                  optional: true
+            - name: CULL_IDLE_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: notebook-controller-culler-config
+                  key: CULL_IDLE_TIME
+                  optional: true
+            - name: IDLENESS_CHECK_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  name: notebook-controller-culler-config
+                  key: IDLENESS_CHECK_PERIOD
+                  optional: true
           resources:
             limits:
               cpu: 500m

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -249,7 +249,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 									"--tls-key=/etc/tls/private/tls.key",
 									"--upstream=http://localhost:8888",
 									"--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-									"--skip-auth-regex=^/api$",
+									"--skip-auth-regex=^(?:/notebook/$(NAMESPACE)/" + notebook.Name + ")?/api$",
 									"--email-domain=*",
 									"--skip-provider-button",
 									`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -65,7 +65,7 @@ func InjectOAuthProxy(notebook *nbv1.Notebook, oauth OAuthConfig) error {
 			"--tls-key=/etc/tls/private/tls.key",
 			"--upstream=http://localhost:8888",
 			"--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-			"--skip-auth-regex=^/api$",
+			"--skip-auth-regex=^(?:/notebook/$(NAMESPACE)/" + notebook.Name + ")?/api$",
 			"--email-domain=*",
 			"--skip-provider-button",
 			`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +


### PR DESCRIPTION
- Add culling environment variables to the notebook controller deployment.
- Add culling health-check to oauth proxy `skip-auth-regex` flag.

The culling configuration will be managed in `odh-manifests` by creating a configmap similar to this:

```yaml
cat <<EOF | oc apply -f -
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: notebook-controller-culler-config
data:
  ENABLE_CULLING: "true"
  CULL_IDLE_TIME: "60" # In minutes (1 hour)
  IDLENESS_CHECK_PERIOD: "5" # In minutes
EOF
```

Find docs at https://docs.arrikto.com/ops/kubeflow/culling.html