### PR TITLE
Fix race condition in notebook controller reconciliation

### DIFF
--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -181,4 +181,4 @@ envtest: ## Download setup-envtest locally if necessary.
 KTUNNEL = $(LOCALBIN)/ktunnel
 .PHONY: ktunnel
 ktunnel: ## Download ktunnel locally if necessary.
-	GOBIN=$(LOCALBIN) go install github.com/omrikiei/ktunnel@v1.4.7
+	GOBIN=$(LOCALBIN) go install github.com/omrikiei/ktunnel@v1.4.8

--- a/components/odh-notebook-controller/config/development/ktunnel.yaml
+++ b/components/odh-notebook-controller/config/development/ktunnel.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: ktunnel
-          image: quay.io/omrikiei/ktunnel:v1.4.7
+          image: quay.io/omrikiei/ktunnel:v1.4.8
           imagePullPolicy: IfNotPresent
           command:
             - /ktunnel/ktunnel

--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -25,6 +25,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - kubeflow.org

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -57,7 +57,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
-	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
+	golang.org/x/sys v0.0.0-20211107104306-e0b2ad06fe42 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/components/odh-notebook-controller/go.sum
+++ b/components/odh-notebook-controller/go.sum
@@ -690,8 +690,9 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 h1:M69LAlWZCshgp0QSzyDcSsSIejIEeuaCVpmwcKwyLMk=
 golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211107104306-e0b2ad06fe42 h1:G2DDmludOQZoWbpCr7OKDxnl478ZBGMcOhrv+ooX/Q4=
+golang.org/x/sys v0.0.0-20211107104306-e0b2ad06fe42/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=


### PR DESCRIPTION
When a notebook is created by specifying an image from the internal registry:

```yaml
---
apiVersion: kubeflow.org/v1
kind: Notebook
metadata:
  name: thoth-minimal-oauth-from-is-notebook
  annotations:
    notebooks.opendatahub.io/inject-oauth: "true"
spec:
  template:
    spec:
      containers:
        - name: thoth-minimal-oauth-from-is-notebook
          image: image-registry.openshift-image-registry.svc:5000/opendatahub/thoth-minimal-notebook:v0.3.0
...
```

Sometimes it cannot be pulled because the notebook pod starts before the notebook service account mounts the pull secret.

```
1. Kubeflow notebook controller creates the STS.
2. ODH notebook controller creates the SA (and other objects).
3. Kubernetes controller manager scales schedules the STS pod but sa.secrets is empty.
4. Notebook pod can't start because can't pull the image.
```

Solution is injecting the annotation `kubeflow-resource-stopped: odh-notebook-controller-lock` and remove it when the ODH notebook controller reconciliation is completed.
