### PR TITLE
Add logout-url to OAuthProxy container

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -40,6 +40,7 @@ import (
 const (
 	AnnotationInjectOAuth             = "notebooks.opendatahub.io/inject-oauth"
 	AnnotationValueReconciliationLock = "odh-notebook-controller-lock"
+	AnnotationLogoutUrl               = "notebooks.opendatahub.io/oauth-logout-url"
 )
 
 // OpenshiftNotebookReconciler holds the controller configuration.

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -180,8 +180,9 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					"app.kubernetes.io/instance": Name,
 				},
 				Annotations: map[string]string{
-					"notebooks.opendatahub.io/inject-oauth": "true",
-					"notebooks.opendatahub.io/foo":          "bar",
+					"notebooks.opendatahub.io/inject-oauth":     "true",
+					"notebooks.opendatahub.io/foo":              "bar",
+					"notebooks.opendatahub.io/oauth-logout-url": "https://example.notebook-url/notebook/" + Namespace + "/" + Name,
 				},
 			},
 			Spec: nbv1.NotebookSpec{
@@ -214,9 +215,10 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					"app.kubernetes.io/instance": Name,
 				},
 				Annotations: map[string]string{
-					"notebooks.opendatahub.io/inject-oauth": "true",
-					"notebooks.opendatahub.io/foo":          "bar",
-					"kubeflow-resource-stopped":             "odh-notebook-controller-lock",
+					"notebooks.opendatahub.io/inject-oauth":     "true",
+					"notebooks.opendatahub.io/foo":              "bar",
+					"notebooks.opendatahub.io/oauth-logout-url": "https://example.notebook-url/notebook/" + Namespace + "/" + Name,
+					"kubeflow-resource-stopped":                 "odh-notebook-controller-lock",
 				},
 			},
 			Spec: nbv1.NotebookSpec{
@@ -256,6 +258,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 									"--skip-provider-button",
 									`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +
 										`"resourceName":"` + Name + `","namespace":"$(NAMESPACE)"}`,
+									"--logout-url=https://example.notebook-url/notebook/" + Namespace + "/" + Name,
 								},
 								Ports: []corev1.ContainerPort{{
 									Name:          OAuthServicePortName,

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -147,6 +147,12 @@ func InjectOAuthProxy(notebook *nbv1.Notebook, oauth OAuthConfig) error {
 		},
 	}
 
+	// Add logout url if logout annotation is present in the notebook
+	if notebook.ObjectMeta.Annotations[AnnotationLogoutUrl] != "" {
+		proxyContainer.Args = append(proxyContainer.Args,
+			"--logout-url="+notebook.ObjectMeta.Annotations[AnnotationLogoutUrl])
+	}
+
 	// Add the sidecar container to the notebook
 	notebookContainers := &notebook.Spec.Template.Spec.Containers
 	proxyContainerExists := false


### PR DESCRIPTION
The PR adds `--logout-url` flag to the OAuthProxy container given that `notebooks.opendatahub.io/oauth-logout-url` is set.

Related to https://github.com/opendatahub-io/odh-dashboard/issues/305#issuecomment-1189989878 