### PR TITLE
Update memory limits for odh-notebook-controller to allow for more simultaneous notebooks on a cluster.

### DIFF
--- a/components/notebook-controller/config/overlays/openshift/manager_openshift_patch.yaml
+++ b/components/notebook-controller/config/overlays/openshift/manager_openshift_patch.yaml
@@ -34,7 +34,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 4Gi
             requests:
               cpu: 500m
               memory: 256Mi

--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -46,7 +46,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 256Mi
+              memory: 4Gi
             requests:
               cpu: 500m
               memory: 256Mi


### PR DESCRIPTION
## Description
Upped the memory limit to 4Gi to allow for more simultaneous notebooks.
Fixes https://github.com/opendatahub-io/kubeflow/issues/33

## How Has This Been Tested?
Created 200 notebooks until out of memory crashloop.  Changed memory limit to 4Gi and continued creating notebooks until 2000 was achieved.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
