### PR TITLE
Add terminal activity to notebook controller culler logic

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -227,7 +227,7 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if !podFound {
 		// Delete LAST_ACTIVITY_ANNOTATION annotations for CR objects
 		// that do not have a pod.
-		log.Info("Notebook has not Pod running. Will remove last-activity annotation")
+		log.Info("Notebook has no Pod running. Will remove last-activity annotation")
 		meta := instance.ObjectMeta
 		if meta.GetAnnotations() == nil {
 			log.Info("No annotations found")

--- a/components/notebook-controller/pkg/culler/culler.go
+++ b/components/notebook-controller/pkg/culler/culler.go
@@ -184,6 +184,9 @@ func getNotebookApiKernels(nm, ns string) []KernelStatus {
 	// Get the Kernels' status from the Server's `/api/kernels` endpoint
 
 	resp := getNotebookResourceResponse(nm, ns, "kernels")
+	if resp == nil {
+		return nil
+	}
 
 	var kernels []KernelStatus
 
@@ -201,6 +204,9 @@ func getNotebookApiKernels(nm, ns string) []KernelStatus {
 func getNotebookApiTerminals(nm, ns string) []TerminalStatus {
 	// Get the Terminals' status from the Server's `/api/terminals` endpoint
 	resp := getNotebookResourceResponse(nm, ns, "terminals")
+	if resp == nil {
+		return nil
+	}
 
 	var terminals []TerminalStatus
 


### PR DESCRIPTION
Adds `last_activity` of the jupyter server `api/terminals` endpoint.

Cherry-pick from https://github.com/kubeflow/kubeflow/pull/6594 

## Description

This improvement takes into account terminal activity for culling, current culler logic only takes into account kernel activity.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
