### PR TITLE
WIP: [odh-notebook-controller] controllers/notebook_controller.go: set MaxConcurrentReconciles=4

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -215,7 +216,8 @@ func (r *OpenshiftNotebookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&routev1.Route{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.Secret{})
+		Owns(&corev1.Secret{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10})
 
 	err := builder.Complete(r)
 	if err != nil {


### PR DESCRIPTION
This `WIP` PR aims at testing if setting `MaxConcurrentReconciles=4` improves or solves the performance issues we see with the Notebook Controllers as part of our scale test.

## Description
Setting `MaxConcurrentReconciles=4` in the controller configuration to allow running multiple workers to process Reconciliation loops in parallel.


## How Has This Been Tested?
One the PR image is built and mirrored in `quay.io`, I will run a 2000 user scale test against it to study the performance of the notebook controllers.


## Merge criteria:

- [x] **DO NOT MERGE, WORK IN PROGRESS.**
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
