### PR TITLE
Fix Controller Rbac Generation

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -56,7 +56,8 @@ type OpenshiftNotebookReconciler struct {
 // +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks/status,verbs=get
 // +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks/finalizers,verbs=update
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.
 func CompareNotebooks(nb1 nbv1.Notebook, nb2 nbv1.Notebook) bool {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When the rbac files are [updated](https://github.com/opendatahub-io/kubeflow/commit/68992a61ef15568d72ac94d4a7a5eaaacebcffbf#diff-ab777cb449395602e93883f45139b6f07476829dbf382695ee2d2739b00a291fR14), we need to make sure that `kubebuilder`  annotations are updated in the controller files. Failing to do this results in errors while running `make deploy`

Note: This change is specific to the developer flow(local manifests) and do not affect `odh-manifests`
