### PR TITLE
Updates odh-controller Makefile

### DIFF
--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -3,6 +3,9 @@
 IMG ?= quay.io/opendatahub/odh-notebook-controller
 TAG ?= $(shell git describe --tags --always)
 
+KF_IMG ?= quay.io/opendatahub/kubeflow-notebook-controller
+KF_TAG ?= 1.6-9ae9413
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
@@ -118,14 +121,18 @@ endif
 
 .PHONY: setup-kf
 setup-kf: kustomize ## Replace Kustomize manifests with your environment configuration.
-	sed -i'' -e 's@namespace: .*@namespace: '"${K8S_NAMESPACE}"'@' \
+	sed -i'' -e 's,namespace: .*,namespace: '"${K8S_NAMESPACE}"',' \
 		../notebook-controller/config/overlays/openshift/kustomization.yaml
+	sed -i'' -e 's,newName: .*,newName: '"${KF_IMG}"',' \
+		../notebook-controller/config/overlays/openshift/kustomization.yaml
+	sed -i'' -e 's,newTag: .*,newTag: '"${KF_TAG}"',' \
+ 	../notebook-controller/config/overlays/openshift/kustomization.yaml
 
 .PHONY: setup
 setup: manifests kustomize ## Replace Kustomize manifests with your environment configuration.
-	sed -i'' -e 's@namespace: .*@namespace: '"${K8S_NAMESPACE}"'@' ./config/default/kustomization.yaml
-	sed -i'' -e 's@newName: .*@newName: '"${IMG}"'@' ./config/base/kustomization.yaml
-	sed -i'' -e 's@newTag: .*@newTag: '"${TAG}"'@' ./config/base/kustomization.yaml
+	sed -i'' -e 's,namespace: .*,namespace: '"${K8S_NAMESPACE}"',' ./config/default/kustomization.yaml
+	sed -i'' -e 's,newName: .*,newName: '"${IMG}"',' ./config/base/kustomization.yaml
+	sed -i'' -e 's,newTag: .*,newTag: '"${TAG}"',' ./config/base/kustomization.yaml
 
 .PHONE: deploy-kf
 deploy-kf: setup-kf ## Deploy kubeflow controller to the Openshift cluster.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates Makefile with following changes
- Update `sed` delimeter to support images with `@`
- Make use of custom KF Controller image instead of `latest` when [deploying](https://github.com/opendatahub-io/kubeflow/blob/v1.6-branch/components/notebook-controller/config/overlays/openshift/kustomization.yaml#L14) controllers

## How Has This Been Tested?
- Deployed Manifests using custom KFNBC image

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
