### PR TITLE
Add git to quay tag mirroring action

### DIFF
--- a/.github/workflows/quay_tag.yaml
+++ b/.github/workflows/quay_tag.yaml
@@ -1,0 +1,46 @@
+name: quay.tag
+
+# This GitHub action activates whenever a new tag is created on the repo
+# and creates a copy of the image of the associated commit hash with the
+# appropriate tag name.
+
+run-name: Creating new tag in quay based on pushed tag in Github.
+on:
+  push:
+    tags:
+      - '*'
+env:
+    QUAY_ODH_NOTEBOOK_CONTROLLER_IMAGE_REPO: ${{ secrets.QUAY_ODH_NOTEBOOK_CONTROLLER_IMAGE_REPO }}
+jobs:
+  copy-tag-to-quay:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: Install skopeo
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install skopeo
+      - name: Login to quay.io
+        shell: bash
+        env:
+          QUAY_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
+          QUAY_ROBOT_USERNAME: ${{ secrets.QUAY_ROBOT_USERNAME }}
+        run: |
+         skopeo login quay.io -u ${QUAY_ROBOT_USERNAME} -p ${QUAY_TOKEN}
+      - name: Get latest tag name
+        id: tag
+        run: echo "tag=$(git describe --tags)" >> ${GITHUB_OUTPUT}
+      - name: Get latest hash
+        id: hash
+        run: echo "hash=$(git rev-parse --short HEAD)" >> ${GITHUB_OUTPUT}
+      - name: Create new tag
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          HASH: ${{ steps.hash.outputs.hash }}
+        run: |
+          skopeo copy docker://${QUAY_ODH_NOTEBOOK_CONTROLLER_IMAGE_REPO}:main-${{ env.HASH }} docker://${QUAY_ODH_NOTEBOOK_CONTROLLER_IMAGE_REPO}:${{ env.TAG }}


### PR DESCRIPTION
Resolves #44 
Closed #45

## Description
This PR adds essentially a copy of this PR: https://github.com/opendatahub-io/odh-dashboard/pull/796
but modified to make changes to the odh-notebook-controller quay repo and using a different robot account (should there be multiple?)

This PR requires the following secrets to be added to this repo:
QUAY_ODH_NOTEBOOK_CONTROLLER_IMAGE_REPO
QUAY_ROBOT_TOKEN
QUAY_ROBOT_USERNAME


## How Has This Been Tested?
Tested in the same way as the PR mentioned above

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
