### PR TITLE
exclude image-field from notebook controller reconciliation for all containers present in annotation

### DIFF
--- a/components/common/go.mod
+++ b/components/common/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubeflow/kubeflow/components/common
 
-go 1.12
+go 1.17

--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -134,8 +134,7 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet, isImageChangeTriggerSet
           for containerNameFromAnnotation := range imageChangeTriggerReferencedContainerNames {
               for container := range to.Spec.Template.Spec.Containers {
                  if (to.Spec.Template.Spec.Containers[container].Name == imageChangeTriggerReferencedContainerNames[containerNameFromAnnotation]) {
-                   log.Info("Image Change Trigger Annotation is set", "excluding new container image-field value", to.Spec.Template.Spec.Containers[container].Image, "from DeepEqual and making it 
-the single version of truth by making from/image equal to to/image for container name", to.Spec.Template.Spec.Containers[container].Name)
+                   log.Info("Image Change Trigger Annotation is set", "excluding new container image-field value", to.Spec.Template.Spec.Containers[container].Image, "from DeepEqual and making it the single version of truth by making from/image equal to to/image for container name", to.Spec.Template.Spec.Containers[container].Name)
                    from.Spec.Template.Spec.Containers[container].Image = to.Spec.Template.Spec.Containers[container].Image
                  }
              }

--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -134,7 +134,8 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet, isImageChangeTriggerSet
           for containerNameFromAnnotation := range imageChangeTriggerReferencedContainerNames {
               for container := range to.Spec.Template.Spec.Containers {
                  if (to.Spec.Template.Spec.Containers[container].Name == imageChangeTriggerReferencedContainerNames[containerNameFromAnnotation]) {
-                   log.Info("excluding new container image-field value", to.Spec.Template.Spec.Containers[container].Image, "from DeepEqual and making it the single version of truth by making from/image equal to to/image for container name", to.Spec.Template.Spec.Containers[container].Name)
+                   log.Info("Image Change Trigger Annotation is set", "excluding new container image-field value", to.Spec.Template.Spec.Containers[container].Image, "from DeepEqual and making it 
+the single version of truth by making from/image equal to to/image for container name", to.Spec.Template.Spec.Containers[container].Name)
                    from.Spec.Template.Spec.Containers[container].Image = to.Spec.Template.Spec.Containers[container].Image
                  }
              }

--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -100,11 +100,12 @@ func VirtualService(ctx context.Context, r client.Client, virtualServiceName, na
 	return nil
 }
 
-// Reference: https://github.com/pwittrock/kubebuilder-workshop/blob/master/pkg/util/util.go
+// Reference: https://github.com/pwittrock/kubebuilder-workshop/blob/master/util/util.go
 
 // CopyStatefulSetFields copies the owned fields from one StatefulSet to another
 // Returns true if the fields copied from don't match to.
-func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
+// Also takes into account Openshift image policy admission plug-in on Notebook/StatefulSet metadata annotation to exclude image-field(s) from reconciliation when Pod spec container image field value is done by that plugin
+func CopyStatefulSetFields(from, to *appsv1.StatefulSet, isImageChangeTriggerSet bool, imageChangeTriggerReferencedContainerNames []string, log logr.Logger) bool {
 	requireUpdate := false
 	for k, v := range to.Labels {
 		if from.Labels[k] != v {
@@ -124,6 +125,23 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 		*to.Spec.Replicas = *from.Spec.Replicas
 		requireUpdate = true
 	}
+
+        // https://stackoverflow.com/questions/47134293/compare-structs-except-one-field-golang
+        // set container image field of "from" to equal container image field of "to" for all affected container names referenced in image change trigger annotation, if annotation is present
+        // in that case, to.Spec.Template.Spec.Containers[container].Image is the desired reconcile image value single version of truth, even if it differs from whatever was present in the image field before
+        // this makes DeepEqual work in this special exclude-image-field from reconciliation/compare scenario, too
+        if (isImageChangeTriggerSet) {
+          for containerNameFromAnnotation := range imageChangeTriggerReferencedContainerNames {
+              for container := range to.Spec.Template.Spec.Containers {
+                 if (to.Spec.Template.Spec.Containers[container].Name == imageChangeTriggerReferencedContainerNames[containerNameFromAnnotation]) {
+                   log.Info("excluding new container image-field value", to.Spec.Template.Spec.Containers[container].Image, "from DeepEqual and making it the single version of truth by making from/image equal to to/image for container name", to.Spec.Template.Spec.Containers[container].Name)
+                   from.Spec.Template.Spec.Containers[container].Image = to.Spec.Template.Spec.Containers[container].Image
+                 }
+             }
+          }
+        }
+
+        if !reflect.DeepEqual(to.Spec.Template.Spec, from.Spec.Template.Spec) {
 
 	if !reflect.DeepEqual(to.Spec.Template.Spec, from.Spec.Template.Spec) {
 		requireUpdate = true

--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -141,8 +141,6 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet, isImageChangeTriggerSet
           }
         }
 
-        if !reflect.DeepEqual(to.Spec.Template.Spec, from.Spec.Template.Spec) {
-
 	if !reflect.DeepEqual(to.Spec.Template.Spec, from.Spec.Template.Spec) {
 		requireUpdate = true
 	}

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+        "regexp"
 	"strings"
 	"time"
 
@@ -52,12 +53,47 @@ const DefaultContainerPort = 8888
 const DefaultServingPort = 80
 const AnnotationRewriteURI = "notebooks.kubeflow.org/http-rewrite-uri"
 const AnnotationHeadersRequestSet = "notebooks.kubeflow.org/http-headers-request-set"
+// annotation that makes OpenShift ImagePolicy admission plug-in resolve the image-field from an imagestream name:tag reference
+const AnnotationImageChangeTrigger = "image.openshift.io/triggers"
 
 const PrefixEnvVar = "NB_PREFIX"
 
 // The default fsGroup of PodSecurityContext.
 // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podsecuritycontext-v1-core
 const DefaultFSGroup = int64(100)
+
+func getContainerNamesFromAnnotationImageChangeFieldPaths(dataJson string) []string {
+	annotationImageChangeContent := AnnotationImageChangeContent{}
+	err := json.Unmarshal([]byte(dataJson), &annotationImageChangeContent)
+	if err != nil {
+		fmt.Println("JSON decode error!")
+		return nil
+	}
+
+	containerNameSlice := make([]string, len(annotationImageChangeContent))
+
+	for i := 0; i < len(annotationImageChangeContent); i++ {
+		re := regexp.MustCompile(`"[^"]+"`)
+		newStrs := re.FindAllString(annotationImageChangeContent[i].FieldPath, -1)
+		for _, s := range newStrs {
+			containerNameSlice[i] = (s[1 : len(s)-1])
+		}
+	}
+
+	return containerNameSlice
+}
+
+func getImageChangeTriggerReferencedContainerNames(meta metav1.ObjectMeta) []string {
+        if meta.GetAnnotations() == nil {
+                return nil
+        }
+
+        if valAnnotationImageChangeTrigger, ok := meta.GetAnnotations()[AnnotationImageChangeTrigger]; ok {
+                return getContainerNamesFromAnnotationImageChangeFieldPaths(valAnnotationImageChangeTrigger)
+        } else {
+                return nil
+        }
+}
 
 /*
 We generally want to ignore (not requeue) NotFound errors, since we'll get a
@@ -69,6 +105,15 @@ func ignoreNotFound(err error) error {
 		return nil
 	}
 	return err
+}
+
+type AnnotationImageChangeContent []struct {
+	From struct {
+		Kind      string `json:"kind"`
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"from"`
+	FieldPath string `json:"fieldPath"`
 }
 
 // NotebookReconciler reconciles a Notebook object
@@ -159,8 +204,12 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.Error(err, "error getting Statefulset")
 		return ctrl.Result{}, err
 	}
+
+        isImageChangeTriggerSet := metav1.HasAnnotation(instance.ObjectMeta, AnnotationImageChangeTrigger)
+        imageChangeTriggerReferencedContainerNames := getImageChangeTriggerReferencedContainerNames(instance.ObjectMeta)
+
 	// Update the foundStateful object and write the result back if there are any changes
-	if !justCreated && reconcilehelper.CopyStatefulSetFields(ss, foundStateful) {
+	if !justCreated && reconcilehelper.CopyStatefulSetFields(ss, foundStateful, isImageChangeTriggerSet, imageChangeTriggerReferencedContainerNames, log) {
 		log.Info("Updating StatefulSet", "namespace", ss.Namespace, "name", ss.Name)
 		err = r.Update(ctx, foundStateful)
 		if err != nil {
@@ -421,10 +470,19 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 		replicas = 0
 	}
 
+        annotations := make(map[string]string)
+        meta := instance.ObjectMeta
+
+        // keep Notebook image change trigger annotation key and value and use it later in StatefulSet metadata
+        if annotationImageChangeTriggerVal, ok := meta.GetAnnotations()[AnnotationImageChangeTrigger]; ok {  
+                annotations[AnnotationImageChangeTrigger] = annotationImageChangeTriggerVal
+        }
+
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
+                        Annotations: annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-        "regexp"
+	"regexp"
 	"strings"
 	"time"
 

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -2,6 +2,11 @@ module github.com/kubeflow/kubeflow/components/notebook-controller
 
 go 1.17
 
+// use our version of kubeflow/components/common module for reconcilehelper utility differences related to image-field reconciliation and affected containers exclude
+replace (
+	github.com/kubeflow/kubeflow/components/common => ../common
+)
+
 require (
 	github.com/go-logr/logr v1.2.0
 	github.com/kubeflow/kubeflow/components/common v0.0.0-20220218084159-4ad0158e955e


### PR DESCRIPTION
fixes #6829

[superseded by PR against v1.7-branch in PR-133](https://github.com/opendatahub-io/kubeflow/pull/133)
Looking for feedback before thinking of merging. AFIK, this should be pretty close to being mergeable, though.

seems to build alright locally, except unclear to me how to update the common/components, where reconcilehelper lies.
Got an error that is probably easy to resolve and dependent on the build chain:

```
#13 51.49 controllers/notebook_controller.go:213:58: too many arguments in call to "github.com/kubeflow/kubeflow/components/common/reconcilehelper".CopyStatefulSetFields                                                                                                     
#13 51.49 	have (*"k8s.io/api/apps/v1".StatefulSet, *"k8s.io/api/apps/v1".StatefulSet, bool, []string, logr.Logger)
#13 51.49 	want (*"k8s.io/api/apps/v1".StatefulSet, *"k8s.io/api/apps/v1".StatefulSet)
```

**that Problem was resolved by referencing our version of the reconcilehelper utilities-module under /components/common in notebook controlller go.mod:**

```
// use our version of kubeflow/components/common module for reconcilehelper utility differences related to image-field reconciliation and affected containers exclude
replace (
	github.com/kubeflow/kubeflow/components/common => ../common
)
```

Key idea:

Updating notebook controller logic and reconcilehelper util logic to take into account optional [Openshift image policy admission plug-in](https://docs.openshift.com/container-platform/4.10/openshift_images/triggering-updates-on-imagestream-changes.html#images-triggering-updates-imagestream-changes-kubernetes-about_triggering-updates-on-imagestream-changes) image-change trigger annotation with one or more containers and their related imagestreams (json array) that leads to container image-field update and to avoid overwriting the updated image-field value by the notebook controller.

[Discussed problem](https://github.com/openshift/openshift-apiserver/issues/339#issuecomment-1343192025) with @bparees , received input from @VaishnaviHire, member of [Open Data Hub (a RedHat project for Openshift) ](https://github.com/opendatahub-io) team. Also [discussed how to resolve the issue in Notebook reconciler with Ben](https://github.com/openshift/openshift-apiserver/issues/339#issuecomment-1357612359).

Context: Notebook yaml contains the (optional) metadata annotation

```
 annotations:
    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"s2i-generic-data-science-notebook:v0.0.5", "namespace":"odhsven"},"fieldPath":"spec.template.spec.containers[?(@.name==\"jupyter-nb-sven\")].image"}]'
```

referencing imagestream name and tag, imagestream namespace, and fieldPath reference to the image-value to be replaced by the image policy admission plug-in for a given container name. This annotation can reference one or more containers, in the form of a json array. This image-name resolve by the image policy admission plug-in happens in basic Kubernetes objects, not in the Notebook yaml itself, but in the StatefulSet derived from the Notebook yaml. The resolved image-name is set briefly after application of the StatefulSet to the server.

Or, referencing the openshift documentation:

_When one of the core Kubernetes resources contains both a pod template and this annotation, OpenShift Container Platform attempts to update the object by using the image currently associated with the image stream tag that is referenced by trigger. The update is performed against the fieldPath specified._

To ensure that image-fields referenced via this annotation in the StatefulSet are not overwritten by the kubeflow notebook controller reconcile process, we set image-fields-values before change and after change to be equal, thus leading to DeepEqual returning false even when the image-field value changes. 

Because the annotation is optional, checks are introduced in the code to ensure any custom logic is only done when the annotation is present.

Background: 

making image-field value independent of internal openshift registry and supporting ImageContentSourcePolicy for Openshift environments with a third-party Docker repo, like VMWare Harbor. This is archieved by using the imagestream abstraction. Referencing imagestream name and tag instead of image-digest-values directly. [Imagestreams are kind of an abstraction in openshift](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/images/managing-image-streams).

See what happens to the image-field cause of the image policy admission plug-in doing its work:

- Without open shift registry:

`<image stream name>:<image stream tag>` references in image-field or annotation of a Kubernetes object (Deployment, StatefulSet, Pod etc.) always resolve to external image reference from imagestream spec.tags[tagname].from.name regardless of whether spec.tags[tagname].referencePolicy.type is set to Local or Source in image stream--> perfect for air gapped and ImageContentSourcePolicy use or if one just wants to pull directly from the external location when there is no internal openshift registry.
```
containers:
    - name: testissource
      image: >-
         quay.io/thoth-station/s2i-generic-data-science notebook@sha256:3f619c61501218f03d39d97541336dee024f446e64f3a47e2bc7e62cddeb2e58
```

- With openshift registry:

if  spec.tags[tagname].referencePolicy.type of the imagestream is set to Source then `<image stream name>:<image stream tag>` references in image-field or annotation of a Kubernetes object (Deployment, StatefulSet, Pod etc.) resolves to the remote repo location:

```
containers:
    - name: testissource
      image: >-
         quay.io/thoth-station/s2i-generic-data-science-notebook@sha256:3f619c61501218f03d39d97541336dee024f446e64f3a47e2bc7e62cddeb2e58
```

if  spec.tags[tagname].referencePolicy.type of the imagestream is set to Local then `<image stream name>:<image stream tag>` references in image-field or annotation of a Kubernetes object (Deployment, StatefulSet, Pod etc.) resolves to the namespace-specific location of the image in the open shift-internal registry:
```
containers
    - name: testisreflocal
      image: >-
        image-registry.openshift-image-registry.svc:5000/testis/jupyter-tensorflow-notebook@sha256:fc52e4fbc8c1c70dfa22dbfe6b0353f5165c507c125df4438fca6a3f31fe976e
```