### PR TITLE
Deactivated development mode for controller logging to prevent flooding with debug messages

### DIFF
--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -60,7 +60,7 @@ func init() {
 func main() {
 	var metricsAddr, probeAddr, oauthProxyImage string
 	var webhookPort int
-	var enableLeaderElection bool
+	var enableLeaderElection, enableDebugLogging bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080",
 		"The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081",
@@ -72,8 +72,9 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&enableDebugLogging, "debug-log", false, "Enable debug logging mode.")
 	opts := zap.Options{
-		Development: true,
+		Development: enableDebugLogging,
 		TimeEncoder: zapcore.TimeEncoderOfLayout(time.RFC3339),
 	}
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
Resolves:#60

Disabled the development mode for loggers to fix the flooding of debug log messages.

## How Has This Been Tested?
Deployed the odh-notebook-controller to a cluster with a test notebook, and checked logs in odh-notebook-controller manager and deployment pods.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
