### PR TITLE
Add GitHub action to dispatch changes in notebook controller manifests

### DIFF
--- a/.github/workflows/nb_controller_sync_manifests_dispatch.yaml
+++ b/.github/workflows/nb_controller_sync_manifests_dispatch.yaml
@@ -1,0 +1,28 @@
+name: Sync odh-manifests repository with kubeflow notebook controller manifests
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+    paths:
+      - 'components/notebook-controller/config/**'
+      - 'components/odh-notebook-controller/config/**'
+
+jobs:
+  sync-with-odh-manifests:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send dispatch to odh-manifests
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const result = await github.rest.actions.createWorkflowDispatch({
+            owner: 'opendatahub-io',
+            repo: 'odh-manifests',
+            workflow_id: 'sync_kubeflow_manifests.yaml',
+            ref: 'actions/kubeflow-sync'
+          })
+          console.log(result)


### PR DESCRIPTION
Resolves:#56

Adds GitHub action that sends a dispatch to opendatahub-io/odh-manifests repository once new changes in notebook-controller and odh-notebook-controller config manifests are merged.

## How Has This Been Tested?
Not fully tested yet

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
