### PR TITLE
fix(docker): splits COPY with go.mod first

### DIFF
--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -9,13 +9,14 @@ FROM golang:${GOLANG_VERSION} as builder
 
 WORKDIR /workspace
 
-# Copy the Go Modules manifests
-COPY notebook-controller /workspace/notebook-controller
-COPY odh-notebook-controller /workspace/odh-notebook-controller
+COPY odh-notebook-controller/go.* /workspace/odh-notebook-controller/
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN cd /workspace/odh-notebook-controller && go mod download
+
+COPY notebook-controller /workspace/notebook-controller
+COPY odh-notebook-controller /workspace/odh-notebook-controller
 
 WORKDIR /workspace/odh-notebook-controller
 


### PR DESCRIPTION
## Description

Currently the entire code is copied in the first step, even thought the comment states different intent:

> cache deps before building and copying source so that we don't need to re-download as much
> and so that source changes don't invalidate our downloaded layer

This PR splits copying of `go.{mod,sum}` and fetches dependencies first, and only then the next layer with code. This way pure code changes won't result in fetching go dependencies unnecessarily, as it will use a cached layer.

If this change makes sense I'm happy to contribute to upstream modules separately.

## How Has This Been Tested?
I ran container builds with changes to relevant layers to see if they get rebuild.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
