### PR TITLE
Perform update of the notebook controller without surge

### DIFF
--- a/components/notebook-controller/config/manager/manager.yaml
+++ b/components/notebook-controller/config/manager/manager.yaml
@@ -10,6 +10,10 @@ kind: Deployment
 metadata:
   name: deployment
 spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: "100%"
   template:
     metadata:
       labels:

--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: system
 spec:
   replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: "100%"
   template:
     metadata:
       annotations:


### PR DESCRIPTION
## Description
This allows updating the notebook controller without increasing the
resources requirements of ODH during the update, which means it can
better tolerates situation such as the Openshift cluster being full.

This means the notebook controller will be unavailable during the
update. However, this has not visible consequences except for a slight
delay in the notebooks CR reconciliation, until the new controller pod
start reconciling.

This should help fix https://issues.redhat.com/browse/RHODS-8152
