### PR TITLE
add additional notebook env var REQUESTS_CA_BUNDLE if proxy spec trus…

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -281,6 +281,7 @@ func (w *NotebookWebhook) ClusterWideProxyIsEnabled() bool {
 				proxyEnvVars["NO_PROXY"] = proxy.Status.NoProxy
 				if proxy.Spec.TrustedCA.Name != "" {
 					proxyEnvVars["PIP_CERT"] = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+					proxyEnvVars["REQUESTS_CA_BUNDLE"] = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 				}
 				return true
 			}


### PR DESCRIPTION
add env var to notebook named REQUESTS_CA_BUNDLE if cluster proxy spec.trustedCA is present
solves #105

<!--- Provide a general summary of your changes in the Title above -->

## Description
@Jooho added path to cluster CA bundle of system and addional trusted CAs as value for env var REQUESTS_CA_BUNDLE used by python in requests.get


## How Has This Been Tested?
see manual tests in #105, working as intended, similar to PIP_CERT for pip and non-publicly-trusted certs, as long as they are specifified as trusted in proxy CA bundle config.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
