### PR TITLE
Change shared memory limit for notebooks

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -392,10 +392,24 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 	}
 
 	podSpec := &ss.Spec.Template.Spec
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: "shm",
+		VolumeSource: corev1.VolumeSource{
+		EmptyDir: &corev1.EmptyDirVolumeSource{
+			Medium: corev1.StorageMediumMemory,
+			},
+		},
+	})
+	
+	
 	container := &podSpec.Containers[0]
 	if container.WorkingDir == "" {
 		container.WorkingDir = "/home/jovyan"
 	}
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name: "shm",
+		MountPath: "/dev/shm",
+	})
 	if container.Ports == nil {
 		container.Ports = []corev1.ContainerPort{
 			{


### PR DESCRIPTION
Resolves:opendatahub-io/kubeflow#111
Add volume mounts to the base notebook template to change the default 64MB shared memory limit for notebooks.

## Description
Changed the notebook-controller to add the following
```
spec:
    containers:
      -  ...
         volumeMounts:
         - mountPath: /dev/shm
           name: shm

volumes:
    - name: shm
      emptyDir:
        medium: Memory
```
 the base notebook template during reconcilement.

## How Has This Been Tested?
1. Deploy notebook controller
2. Deploy a sample notebook
3. Check notebook's StatefulSet and Pod specs if they include the volume mount

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [] The developer has manually tested the changes and verified that the changes work
