### PR TITLE
Image change trigger plugin exclude image field from reconciliation

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -53,11 +54,47 @@ const AnnotationRewriteURI = "notebooks.kubeflow.org/http-rewrite-uri"
 const AnnotationHeadersRequestSet = "notebooks.kubeflow.org/http-headers-request-set"
 const AnnotationNotebookRestart = "notebooks.opendatahub.io/notebook-restart"
 
+// annotation that makes OpenShift ImagePolicy admission plug-in resolve the image-field from an imagestream name:tag reference
+const AnnotationImageChangeTrigger = "image.openshift.io/triggers"
+
 const PrefixEnvVar = "NB_PREFIX"
 
 // The default fsGroup of PodSecurityContext.
 // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podsecuritycontext-v1-core
 const DefaultFSGroup = int64(100)
+
+func getContainerNamesFromAnnotationImageChangeFieldPaths(dataJson string, log logr.Logger) []string {
+	annotationImageChangeContent := AnnotationImageChangeContent{}
+	err := json.Unmarshal([]byte(dataJson), &annotationImageChangeContent)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Notebook image change trigger annotation image.openshift.io/triggers JSON array decode error, check for correct annotation value JSON format : %s", dataJson))
+		return nil
+	}
+
+	containerNameSlice := make([]string, len(annotationImageChangeContent))
+
+	for i := 0; i < len(annotationImageChangeContent); i++ {
+		re := regexp.MustCompile(`"[^"]+"`)
+		newStrs := re.FindAllString(annotationImageChangeContent[i].FieldPath, -1)
+		for _, s := range newStrs {
+			containerNameSlice[i] = (s[1 : len(s)-1])
+		}
+	}
+
+	return containerNameSlice
+}
+
+func getImageChangeTriggerReferencedContainerNames(meta metav1.ObjectMeta, log logr.Logger) []string {
+	if meta.GetAnnotations() == nil {
+		return nil
+	}
+
+	if valAnnotationImageChangeTrigger, ok := meta.GetAnnotations()[AnnotationImageChangeTrigger]; ok {
+		return getContainerNamesFromAnnotationImageChangeFieldPaths(valAnnotationImageChangeTrigger, log)
+	} else {
+		return nil
+	}
+}
 
 /*
 We generally want to ignore (not requeue) NotFound errors, since we'll get a
@@ -69,6 +106,15 @@ func ignoreNotFound(err error) error {
 		return nil
 	}
 	return err
+}
+
+type AnnotationImageChangeContent []struct {
+	From struct {
+		Kind      string `json:"kind"`
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"from"`
+	FieldPath string `json:"fieldPath"`
 }
 
 // NotebookReconciler reconciles a Notebook object
@@ -159,8 +205,12 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.Error(err, "error getting Statefulset")
 		return ctrl.Result{}, err
 	}
+
+	isImageChangeTriggerSet := metav1.HasAnnotation(instance.ObjectMeta, AnnotationImageChangeTrigger)
+	imageChangeTriggerReferencedContainerNames := getImageChangeTriggerReferencedContainerNames(instance.ObjectMeta, log)
+
 	// Update the foundStateful object and write the result back if there are any changes
-	if !justCreated && reconcilehelper.CopyStatefulSetFields(ss, foundStateful) {
+	if !justCreated && reconcilehelper.CopyStatefulSetFields(ss, foundStateful, isImageChangeTriggerSet, imageChangeTriggerReferencedContainerNames, log) {
 		log.Info("Updating StatefulSet", "namespace", ss.Namespace, "name", ss.Name)
 		err = r.Update(ctx, foundStateful)
 		if err != nil {
@@ -402,10 +452,19 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 		replicas = 0
 	}
 
+	annotations := make(map[string]string)
+	meta := instance.ObjectMeta
+
+	// keep Notebook image change trigger annotation key and value and use it later in StatefulSet metadata
+	if annotationImageChangeTriggerVal, ok := meta.GetAnnotations()[AnnotationImageChangeTrigger]; ok {
+		annotations[AnnotationImageChangeTrigger] = annotationImageChangeTriggerVal
+	}
+
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name,
-			Namespace: instance.Namespace,
+			Name:        instance.Name,
+			Namespace:   instance.Namespace,
+			Annotations: annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -2,6 +2,11 @@ module github.com/kubeflow/kubeflow/components/notebook-controller
 
 go 1.19
 
+// use our version of kubeflow/components/common module for reconcilehelper utility differences related to image-field reconciliation and affected containers exclude
+replace (
+	github.com/kubeflow/kubeflow/components/common => ../common
+)
+
 require (
 	github.com/go-logr/logr v1.2.0
 	github.com/kubeflow/kubeflow/components/common v0.0.0-20220218084159-4ad0158e955e


### PR DESCRIPTION
fixes #6829

to be tested in conjunction with [ODH dashboard PR-800](https://github.com/opendatahub-io/odh-dashboard/pull/800/files)

Looking for feedback before thinking of merging. AFIK, this should be pretty close to being mergeable, though.

seems to build alright locally, except unclear to me how to update the common/components, where reconcilehelper lies.
Got an error that is probably easy to resolve and dependent on the build chain:

```
#13 51.49 controllers/notebook_controller.go:213:58: too many arguments in call to "github.com/kubeflow/kubeflow/components/common/reconcilehelper".CopyStatefulSetFields                                                                                                     
#13 51.49 	have (*"k8s.io/api/apps/v1".StatefulSet, *"k8s.io/api/apps/v1".StatefulSet, bool, []string, logr.Logger)
#13 51.49 	want (*"k8s.io/api/apps/v1".StatefulSet, *"k8s.io/api/apps/v1".StatefulSet)
```

**that Problem was resolved by referencing our version of the reconcilehelper utilities-module under /components/common in notebook controlller go.mod:**

```
// use our version of kubeflow/components/common module for reconcilehelper utility differences related to image-field reconciliation and affected containers exclude
replace (
	github.com/kubeflow/kubeflow/components/common => ../common
)
```

Key idea:

Updating notebook controller logic and reconcilehelper util logic to take into account optional [Openshift image policy admission plug-in](https://docs.openshift.com/container-platform/4.10/openshift_images/triggering-updates-on-imagestream-changes.html#images-triggering-updates-imagestream-changes-kubernetes-about_triggering-updates-on-imagestream-changes) image-change trigger annotation with one or more containers and their related imagestreams (json array) that leads to container image-field update and to avoid overwriting the updated image-field value by the notebook controller.

[Discussed problem](https://github.com/openshift/openshift-apiserver/issues/339#issuecomment-1343192025) with @bparees , received input from @VaishnaviHire, member of [Open Data Hub (a RedHat project for Openshift) ](https://github.com/opendatahub-io) team. Also [discussed how to resolve the issue in Notebook reconciler with Ben](https://github.com/openshift/openshift-apiserver/issues/339#issuecomment-1357612359).

Context: Notebook yaml contains the (optional) metadata annotation

```
 annotations:
    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"s2i-generic-data-science-notebook:v0.0.5", "namespace":"odhsven"},"fieldPath":"spec.template.spec.containers[?(@.name==\"jupyter-nb-sven\")].image"}]'
```

referencing imagestream name and tag, imagestream namespace, and fieldPath reference to the image-value to be replaced by the image policy admission plug-in for a given container name. This annotation can reference one or more containers, in the form of a json array. This image-name resolve by the image policy admission plug-in happens in basic Kubernetes objects, not in the Notebook yaml itself, but in the StatefulSet derived from the Notebook yaml. The resolved image-name is set briefly after application of the StatefulSet to the server.

Or, referencing the openshift documentation:

_When one of the core Kubernetes resources contains both a pod template and this annotation, OpenShift Container Platform attempts to update the object by using the image currently associated with the image stream tag that is referenced by trigger. The update is performed against the fieldPath specified._

To ensure that image-fields referenced via this annotation in the StatefulSet are not overwritten by the kubeflow notebook controller reconcile process, we set image-fields-values before change and after change to be equal, thus leading to DeepEqual returning false even when the image-field value changes. 

Because the annotation is optional, checks are introduced in the code to ensure any custom logic is only done when the annotation is present.

Background: 

making image-field value independent of internal openshift registry and supporting ImageContentSourcePolicy for Openshift environments with a third-party Docker repo, like VMWare Harbor. This is archieved by using the imagestream abstraction. Referencing imagestream name and tag instead of image-digest-values directly. [Imagestreams are kind of an abstraction in openshift](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/images/managing-image-streams).

See what happens to the image-field cause of the image policy admission plug-in doing its work:

- Without open shift registry:

`<image stream name>:<image stream tag>` references in image-field or annotation of a Kubernetes object (Deployment, StatefulSet, Pod etc.) always resolve to external image reference from imagestream spec.tags[tagname].from.name regardless of whether spec.tags[tagname].referencePolicy.type is set to Local or Source in image stream--> perfect for air gapped and ImageContentSourcePolicy use or if one just wants to pull directly from the external location when there is no internal openshift registry.
```
containers:
    - name: testissource
      image: >-
         quay.io/thoth-station/s2i-generic-data-science notebook@sha256:3f619c61501218f03d39d97541336dee024f446e64f3a47e2bc7e62cddeb2e58
```

- With openshift registry:

if  spec.tags[tagname].referencePolicy.type of the imagestream is set to Source then `<image stream name>:<image stream tag>` references in image-field or annotation of a Kubernetes object (Deployment, StatefulSet, Pod etc.) resolves to the remote repo location:

```
containers:
    - name: testissource
      image: >-
         quay.io/thoth-station/s2i-generic-data-science-notebook@sha256:3f619c61501218f03d39d97541336dee024f446e64f3a47e2bc7e62cddeb2e58
```

if  spec.tags[tagname].referencePolicy.type of the imagestream is set to Local then `<image stream name>:<image stream tag>` references in image-field or annotation of a Kubernetes object (Deployment, StatefulSet, Pod etc.) resolves to the namespace-specific location of the image in the open shift-internal registry:
```
containers
    - name: testisreflocal
      image: >-
        image-registry.openshift-image-registry.svc:5000/testis/jupyter-tensorflow-notebook@sha256:fc52e4fbc8c1c70dfa22dbfe6b0353f5165c507c125df4438fca6a3f31fe976e
```