### PR TITLE
Revert "Add volume mounts to the base notebook template"

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -392,24 +392,10 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 	}
 
 	podSpec := &ss.Spec.Template.Spec
-	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-		Name: "shm",
-		VolumeSource: corev1.VolumeSource{
-		EmptyDir: &corev1.EmptyDirVolumeSource{
-			Medium: corev1.StorageMediumMemory,
-			},
-		},
-	})
-	
-	
 	container := &podSpec.Containers[0]
 	if container.WorkingDir == "" {
 		container.WorkingDir = "/home/jovyan"
 	}
-	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name: "shm",
-		MountPath: "/dev/shm",
-	})
 	if container.Ports == nil {
 		container.Ports = []corev1.ContainerPort{
 			{


### PR DESCRIPTION
Revert "Add volume mounts to the base notebook template default shared memory limit for notebooks"
This reverts commit 41baf497ee3559890a6a5fa1f4ba4eb4a69c61a2.


Related-to: https://github.com/opendatahub-io/kubeflow/issues/145
https://github.com/opendatahub-io/kubeflow/issues/111


## Description

As we don't want to disrupt long-running notebooks, we are reverting these changes
it would be introduced via Notebook CR, instead of statefulset injection.

## How Has This Been Tested?

Deploy a ODH cluster.
create a notebook and
show the notebook-controller image to `1.7-49727cc`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
