### PR TITLE
Remove skip-provider-button flag from oauth configs

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -439,7 +439,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 									"--upstream=http://localhost:8888",
 									"--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 									"--email-domain=*",
-									"--skip-provider-button",
 									`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +
 										`"resourceName":"` + Name + `","namespace":"$(NAMESPACE)"}`,
 									"--logout-url=https://example.notebook-url/notebook/" + Namespace + "/" + Name,

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -19,8 +19,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	configv1 "github.com/openshift/api/config/v1"
 	"net/http"
+
+	configv1 "github.com/openshift/api/config/v1"
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	"github.com/kubeflow/kubeflow/components/notebook-controller/pkg/culler"
@@ -91,7 +92,6 @@ func InjectOAuthProxy(notebook *nbv1.Notebook, oauth OAuthConfig) error {
 			"--upstream=http://localhost:8888",
 			"--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 			"--email-domain=*",
-			"--skip-provider-button",
 			`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +
 				`"resourceName":"` + notebook.Name + `","namespace":"$(NAMESPACE)"}`,
 		},


### PR DESCRIPTION
This PR resolves the https://github.com/opendatahub-io/kubeflow/issues/109 issue of encountering an "infinite" login screen following the redirection of the unauthorized 403 page, as illustrated in the .gif below. 

![login-page-stuck](https://github.com/opendatahub-io/kubeflow/assets/42587738/034b643f-8e10-4fa0-9213-4273e6c04910)

By removing the --skip-provider-button from the OAuth configurations. Consequently, after the redirection, users are able to be directed to the desired route path of the notebook.

```
https://jupyter-nb-ldap-2dadmin1-rhods-notebooks.apps.atheo1.7ojc.s1.devshift.org
```

However, on the route is missing `/notebook/${nb_namespace}/${nb_name}` suffix, which is added by the dashboard when a user access a notebook from the dashboard. 

The route is unable to redirect from `/` -> `/notebook/${nb_namespace}/${nb_name}`, resulting in users encountering the JupyterLab 404 page, as shown below. Therefore, the user needs to manually press the Jupyter icon to be redirected to their notebook.

A separate issue is tracking the work for the redirection https://github.com/opendatahub-io/kubeflow/issues/150

![Screenshot from 2023-07-31 17-51-48](https://github.com/opendatahub-io/kubeflow/assets/42587738/5288635f-dd4e-4817-99ed-6f1e93eb9db6)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
