### PR TITLE
Fix typo in odh-notebook-controller README

### DIFF
--- a/components/odh-notebook-controller/README.md
+++ b/components/odh-notebook-controller/README.md
@@ -32,7 +32,7 @@ metadata:
 A [mutating webhook](./controllers/notebook_webhook.go) is part of the ODH
 notebook controller, it will add the sidecar to the notebook deployment. The
 controller will create all the objects needed by the proxy as explained in the
-follow diagram:
+following diagram:
 
 ![ODH Notebook Controller OAuth injection
 diagram](./assets/odh-notebook-controller-oauth-diagram.png)


### PR DESCRIPTION
This PR fixes a grammatical error in the README of `odh-notebook-controller`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
