### PR TITLE
Add logic to restart pod when based on annotation value

### DIFF
--- a/components/notebook-controller/config/rbac/role.yaml
+++ b/components/notebook-controller/config/rbac/role.yaml
@@ -29,6 +29,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Restart pod if annotation has been added suggesting so.

## Description
The PR adds logic to check for annotation and update the pod for the Notebook if needed.

Fixes #165 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
