### PR TITLE
Revert "Remove skip-provider-button flag from oauth configs"

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -439,6 +439,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 									"--upstream=http://localhost:8888",
 									"--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 									"--email-domain=*",
+									"--skip-provider-button",
 									`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +
 										`"resourceName":"` + Name + `","namespace":"$(NAMESPACE)"}`,
 									"--logout-url=https://example.notebook-url/notebook/" + Namespace + "/" + Name,

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-
 	configv1 "github.com/openshift/api/config/v1"
+	"net/http"
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	"github.com/kubeflow/kubeflow/components/notebook-controller/pkg/culler"
@@ -92,6 +91,7 @@ func InjectOAuthProxy(notebook *nbv1.Notebook, oauth OAuthConfig) error {
 			"--upstream=http://localhost:8888",
 			"--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 			"--email-domain=*",
+			"--skip-provider-button",
 			`--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org",` +
 				`"resourceName":"` + notebook.Name + `","namespace":"$(NAMESPACE)"}`,
 		},


### PR DESCRIPTION
Revert "Remove skip-provider-button flag from oauth configs"
This reverts commit fb769e53ec58fa7ba6a27655e2949d8aa075a518.

## Description

As the issue is postponed: https://github.com/opendatahub-io/kubeflow/issues/109
Reverting the changes in the v1.7 branch as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NA

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
