### PR TITLE
removing the cluster-domain env var from the deployment

### DIFF
--- a/components/notebook-controller/config/manager/manager.yaml
+++ b/components/notebook-controller/config/manager/manager.yaml
@@ -36,11 +36,6 @@ spec:
               configMapKeyRef:
                 name: config
                 key: ISTIO_GATEWAY
-          - name: CLUSTER_DOMAIN
-            valueFrom:
-              configMapKeyRef:
-                name: config
-                key: CLUSTER_DOMAIN
           - name: ENABLE_CULLING
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removing the cluster-domain env var from the deployment.
The odh-operator v2.0, while deploying the notebook-controller, notices the reconciliation on this env var.
due to which the pods keep crash looping.

Related-to: https://github.com/opendatahub-io/kubeflow/pull/173#issuecomment-1719564143

NOTE: we have the default set to the same: https://github.com/opendatahub-io/kubeflow/blob/816b1ef2595117cc2beada23e385ef392db10edf/components/notebook-controller/pkg/culler/culler.go#L29

https://github.com/opendatahub-io/kubeflow/blob/816b1ef2595117cc2beada23e385ef392db10edf/components/notebook-controller/config/manager/params.env#L3
