### PR TITLE
OSSM: Add SM overlays to notebook-controller manifests

### DIFF
--- a/components/notebook-controller/config/overlays/service-mesh/OWNERS
+++ b/components/notebook-controller/config/overlays/service-mesh/OWNERS
@@ -1,0 +1,10 @@
+# Each list is sorted alphabetically, additions should maintain that order
+approvers:
+- aslakknutsen
+- bartoszmajsak
+- cam-garrison
+
+reviewers:
+- aslakknutsen
+- bartoszmajsak
+- cam-garrison

--- a/components/notebook-controller/config/overlays/service-mesh/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/service-mesh/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+- ../openshift
 
 configMapGenerator:
 - name: config

--- a/components/notebook-controller/config/overlays/service-mesh/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/service-mesh/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+
+configMapGenerator:
+- name: config
+  behavior: merge
+  envs:
+  - ossm.env

--- a/components/notebook-controller/config/overlays/service-mesh/ossm.env
+++ b/components/notebook-controller/config/overlays/service-mesh/ossm.env
@@ -1,0 +1,3 @@
+# defaults. will be overwritten if needed when using OSSM component
+USE_ISTIO=true
+ISTIO_GATEWAY=opendatahub/odh-gateway

--- a/components/odh-notebook-controller/config/overlays/service-mesh/OWNERS
+++ b/components/odh-notebook-controller/config/overlays/service-mesh/OWNERS
@@ -1,0 +1,10 @@
+# Each list is sorted alphabetically, additions should maintain that order
+approvers:
+- aslakknutsen
+- bartoszmajsak
+- cam-garrison
+
+reviewers:
+- aslakknutsen
+- bartoszmajsak
+- cam-garrison

--- a/components/odh-notebook-controller/config/overlays/service-mesh/kustomization.yaml
+++ b/components/odh-notebook-controller/config/overlays/service-mesh/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+
+## FIXME: Temporary until nb-controller PR is merged into v1.7
+images:
+- name: quay.io/opendatahub/odh-notebook-controller
+  newName: quay.io/maistra-dev/odh-notebook-controller
+  newTag: service-mesh-integration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds Service Mesh overlays to the two notebook controller manifests. This is needed as v2 operator pulls manifests from kubeflow:v1.7 branch rather than from odh-manifests as it previously did. 

The overlays changes are very minimal - in kf-notebook-controller, the service mesh overlay patches the configmap to ensure USE_ISTIO=true, and that the default gateway is `opendatahub/odh-gateway`. In odh-notebook-controller, the only patch is to the image to use our latest maistra build - once PR #172 is merged, we can safely remove this overlay. 

Since the changes in this PR are contained to service-mesh overlays, these changes should not interfere with non-service mesh deployments. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

To test and ensure that the overlays work as intended, ran commands: 

- `kustomize build components/odh-notebook-controller/config/overlays/service-mesh`
- `kustomize build components/notebook-controller/config/overlays/service-mesh`

to ensure that 
A: kustomize can build the overlay without errors
B: patches are applied correctly.  

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
