### PR TITLE
update go version to 1.19 in relevant sections

### DIFF
--- a/components/common/go.mod
+++ b/components/common/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubeflow/kubeflow/components/common
 
-go 1.12
+go 1.19

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/kubeflow/components/notebook-controller
 
-go 1.17
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.0

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/kubeflow/components/odh-notebook-controller
 
-go 1.17
+go 1.19
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
fixes #203 

## Description
unit tests for kubeflow notebook controller and odh notebook controller need go 1.19

```
# go.uber.org/multierr
/go/pkg/mod/go.uber.org/multierr@v1.10.0/error.go:224:13: undefined: atomic.Bool
note: module requires Go 1.19
```

unsure why multierr resolves to 1.10.0, but then again I am not a golang expert
https://github.com/search?q=repo%3Aopendatahub-io%2Fkubeflow%20multierr&type=code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
