### PR TITLE
chores: fix the unit test for notebook-controller

### DIFF
--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -148,7 +148,7 @@ kustomize: ## Download kustomize locally if necessary.
 ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/components/notebook-controller/config/rbac/role.yaml
+++ b/components/notebook-controller/config/rbac/role.yaml
@@ -26,10 +26,10 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch
-  - delete
 - apiGroups:
   - ""
   resources:

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -80,7 +80,7 @@ type NotebookReconciler struct {
 	EventRecorder record.EventRecorder
 }
 
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs="*"
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs="*"

--- a/components/notebook-controller/pkg/culler/culler.go
+++ b/components/notebook-controller/pkg/culler/culler.go
@@ -59,8 +59,8 @@ type KernelStatus struct {
 // Each terminal of the Notebook Server has a status.
 // TerminalStatus struct:
 type TerminalStatus struct {
-	Name           string `json:"name"`
-	LastActivity   string `json:"last_activity"`
+	Name         string `json:"name"`
+	LastActivity string `json:"last_activity"`
 }
 
 // Some Utility Functions
@@ -261,7 +261,6 @@ func getNotebookRecentTime(t []string, api string) string {
 	return recentTime.Format(time.RFC3339)
 }
 
-
 // Update LAST_ACTIVITY_ANNOTATION
 func UpdateNotebookLastActivityAnnotation(meta *metav1.ObjectMeta) bool {
 	log := log.WithValues("notebook", getNamespacedNameFromMeta(*meta))
@@ -286,10 +285,10 @@ func UpdateNotebookLastActivityAnnotation(meta *metav1.ObjectMeta) bool {
 	}
 
 	log.Info("last-activity annotation exists. Checking /api/kernels")
-	kernels :=  getNotebookApiKernels(nm, ns)
+	kernels := getNotebookApiKernels(nm, ns)
 	log.Info("last-activity annotation exists. Checking /api/terminals")
-	terminals :=  getNotebookApiTerminals(nm, ns)
-	if kernels == nil  && terminals == nil{
+	terminals := getNotebookApiTerminals(nm, ns)
+	if kernels == nil && terminals == nil {
 		log.Info("Could not GET the notebook status. Will not update last-activity.")
 		return false
 	}

--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -196,7 +196,7 @@ kustomize: ## Download kustomize locally if necessary.
 ENVTEST = $(LOCALBIN)/setup-envtest
 .PHONY: envtest
 envtest: ## Download setup-envtest locally if necessary.
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
 
 KTUNNEL = $(LOCALBIN)/ktunnel
 .PHONY: ktunnel

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/kubeflow/kubeflow/components/notebook-controller v0.0.0-20220728153354-fc09bd1eefb8
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
-	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
+	github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.1

--- a/components/odh-notebook-controller/go.sum
+++ b/components/odh-notebook-controller/go.sum
@@ -388,8 +388,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible h1:6il8W875Oq9vycPkRV5TteLP9IfMEX3lyOl5yN+CtdI=
-github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad h1:MiZEukiPd7ll8BQDwBfc3LKBxbqyeXIx+wl4CzVj5EQ=
+github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=


### PR DESCRIPTION
chores: fix the unit test for notebook-controller 


The module sigs.k8s.io/controller-runtime/tools/setup-envtest@latest  has 
https://github.com/kubernetes-sigs/controller-runtime/blob/cc2a25b511876693d61c8ad07936824647a8f233/tools/setup-envtest/go.mod#L20
Which requires the base go lang version to be updated.
To fix, this currently, we reverting it to an older version
based on: https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest?tab=versions



Fixes: https://github.com/opendatahub-io/kubeflow/issues/203

