### PR TITLE
feat: add roles to the notebook service account

### DIFF
--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   - secrets
   - serviceaccounts
   - services
+  - pods
   verbs:
   - create
   - get
@@ -70,3 +71,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -58,9 +58,10 @@ type OpenshiftNotebookReconciler struct {
 // +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks/status,verbs=get
 // +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks/finalizers,verbs=update
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets;configmaps;pods,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.
 func CompareNotebooks(nb1 nbv1.Notebook, nb2 nbv1.Notebook) bool {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds role to the service account created for the notebook to grant it some basic capabilities including viewing pods and configmaps.

Fixes #158 

## How Has This Been Tested?
1. Replace the image used in `odh-notebook-controller-manager` deployment with `quay.io/opendatahub/odh-notebook-controller:pr-227`.
2. Manually update the role `odh-notebook-controller-manager-role` in namespace `opendatahub` with content of `components/odh-notebook-controller/config/rbac/role.yaml` in this PR. Note: this is a temporary hack for verification. Any help identifying how configs for `odh-notebook-controller` are updated in cluster is appreciated.
3. Create a workbench.
4. Run `oc get pods`, `oc get configmaps` from terminal. It should list resources from the namespace of the DSP.

## Merge criteria:

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
