### PR TITLE
set notebook container env var SSL_CERT_FILE in odh notebook controll…

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -285,6 +285,7 @@ func (w *NotebookWebhook) ClusterWideProxyIsEnabled() bool {
 				if proxy.Spec.TrustedCA.Name != "" {
 					proxyEnvVars["PIP_CERT"] = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 					proxyEnvVars["REQUESTS_CA_BUNDLE"] = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+					proxyEnvVars["SSL_CERT_FILE"] = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 				}
 				return true
 			}


### PR DESCRIPTION
…er to point to optional proxy CA trust bundle

openshift proxy config CA trust bundle (openshift system publicly trusted and private CAs / self-signed certs) add env 
var SSL_CERT_FILE to point minio S3 client (connects to any S3 compatible storage, i.e. an on-prem IBM S3 with non-publicly-trusted server certificates) without raising SSL trust error.

fixes #233 

## Description
env SSL_CERT_FILE points to ca bundle location at "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem 

## How Has This Been Tested?
on-prem Openshift 4.12 with on-prem IBM COS server that is using a certificate based in a non-public, corporate CA.
Once I set SSL_CERT_FILE env var manually for the notebook / workbench via odh dashboard GUI, submitting a pipeline and S3 connectivity to IBM COS worked fine.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
