### PR TITLE
Adjust go mod download as per go version 1.19 rules

### DIFF
--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -17,7 +17,7 @@ COPY common /workspace/common
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN cd /workspace/notebook-controller && go mod download
+RUN cd /workspace/notebook-controller && go mod download all
 
 WORKDIR /workspace/notebook-controller
 

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -15,7 +15,7 @@ COPY odh-notebook-controller /workspace/odh-notebook-controller
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN cd /workspace/odh-notebook-controller && go mod download
+RUN cd /workspace/odh-notebook-controller && go mod download all
 
 WORKDIR /workspace/odh-notebook-controller
 


### PR DESCRIPTION
Adjust go mod download as per go version 1.19 rules

## Description

From go version 1.18, `go mod download`, doesn't download transitive dependency.

`To also download source code for transitive dependencies, use go mod download all.`
https://tip.golang.org/doc/go1.18
https://go.dev/ref/mod#go-mod-download


fixes:
Try: 
```
cd components
podman build -t kfnb -f odh-notebook-controller/Dockerfile .
```

```
[2/2] STEP 5/6: COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/hashicorp
Error: building at STEP "COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/hashicorp": checking on sources under "/home/hnalla/.local/share/containers/storage/overlay/81cc48f4c808785128af9e37578c43b6edf13746082befdb569b4446047ca9ca/merged": copier: stat: "/go/pkg/mod/github.com/hashicorp": no such file or directory
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
cd components
podman build -t kfnb -f odh-notebook-controller/Dockerfile .
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
