### PR TITLE
feat: add static label to notebook pods

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -36,6 +36,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+const (
+	WorkbenchLabel = "opendatahub.io/workbenches"
+)
+
 //+kubebuilder:webhook:path=/mutate-notebook-v1,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=notebooks,verbs=create;update,versions=v1,name=notebooks.opendatahub.io,admissionReviewVersions=v1
 
 // NotebookWebhook holds the webhook configuration.
@@ -238,6 +242,7 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 
 	// Inject the reconciliation lock only on new notebook creation
 	if req.Operation == admissionv1.Create {
+		AddWorkbenchLabel(notebook)
 		err = InjectReconciliationLock(&notebook.ObjectMeta)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
@@ -247,6 +252,10 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
+	}
+
+	if req.Operation == admissionv1.Update {
+		AddWorkbenchLabel(notebook)
 	}
 
 	// Inject the OAuth proxy if the annotation is present but only if Service Mesh is disabled
@@ -273,6 +282,13 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 func (w *NotebookWebhook) InjectDecoder(d *admission.Decoder) error {
 	w.Decoder = d
 	return nil
+}
+
+// AddWorkbenchLabel adds an exclusive static label to the Notebook pods
+func AddWorkbenchLabel(notebook *nbv1.Notebook) {
+	currentLabels := notebook.ObjectMeta.GetLabels()
+	notebook.ObjectMeta.Labels[WorkbenchLabel] = "true"
+	notebook.ObjectMeta.SetLabels(currentLabels)
 }
 
 // CheckAndMountCACertBundle checks if the odh-trusted-ca-bundle ConfigMap is present


### PR DESCRIPTION
## Description

The PR enables notebook controller to add a static label to the Notebook pods. The labels should be added for newly created workbenches or workbenches that have been restarted.

## How Has This Been Tested?

* The image for `odh-notebook-controller` needs to be replaced with [quay.io/rpattnai/odh-notebook-controller:nb-label](quay.io/rpattnai/odh-notebook-controller:nb-label). [Eg](https://github.com/opendatahub-io/kubeflow/issues/165#issuecomment-1709529807)
* Create a new notebook. Upon checking the yaml for the notebook pod, you should be able to see the label `opendatahub.io/workbenches: 'true'`.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
