### PR TITLE
HotFix: Catch the configmap notfound and logged

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -283,7 +283,8 @@ func CheckAndMountCACertBundle(ctx context.Context, cli client.Client, notebook 
 	// get configmap based on its name and the namespace
 	configMap := &corev1.ConfigMap{}
 	if err := cli.Get(ctx, client.ObjectKey{Namespace: notebook.Namespace, Name: configMapName}, configMap); err != nil {
-		log.Error(err, "Unable to fetch ConfigMap", "configMap", configMapName)
+		log.Info("Unable to fetch ConfigMap", "configMap", configMapName)
+		return nil
 	}
 
 	// Search for the odh-trusted-ca-bundle ConfigMap


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
HotFix: Catch the configmap notfound and logged


## Description
<!--- Describe your changes in detail -->
Related-to: https://issues.redhat.com/browse/RHOAIENG-4165

If the configmap is not present , it complains about:
`"configMap":"odh-trusted-ca-bundle","error":"ConfigMap \"odh-trusted-ca-bundle\" not found","stacktrace":"...`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Use the PR image in deployment.
2. Create a notebook in  a namespace without `odh-trusted-ca-bundle` configmap
3. check for the error

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
