### PR TITLE
Remove GOARCH from the go build

### DIFF
--- a/components/notebook-controller/Dockerfile.ci
+++ b/components/notebook-controller/Dockerfile.ci
@@ -22,11 +22,7 @@ RUN cd /workspace/notebook-controller && go mod download
 WORKDIR /workspace/notebook-controller
 
 # Build
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on go build -a -mod=mod -o manager main.go; \
-    else \
-        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=mod -o manager main.go; \
-    fi
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -mod=mod -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
GOARCH will be set by default to the target architecture, explicit mention of GOARCH is not necessary. This change will give flexibility to build this image on non-amd64 platform.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
