### PR TITLE
fix: update logic to add notebook label on create and restart

### DIFF
--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -122,6 +122,11 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 
 	if *from.Spec.Replicas != *to.Spec.Replicas {
 		*to.Spec.Replicas = *from.Spec.Replicas
+		// Copy the pod template labels, but reconcilation is not required
+		// exclusively based on ths pod template labels
+		if !reflect.DeepEqual(to.Spec.Template.ObjectMeta.Labels, from.Spec.Template.ObjectMeta.Labels) {
+			to.Spec.Template.ObjectMeta.Labels = from.Spec.Template.ObjectMeta.Labels
+		}
 		requireUpdate = true
 	}
 

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -51,6 +51,7 @@ const DefaultServingPort = 80
 const AnnotationRewriteURI = "notebooks.kubeflow.org/http-rewrite-uri"
 const AnnotationHeadersRequestSet = "notebooks.kubeflow.org/http-headers-request-set"
 const AnnotationNotebookRestart = "notebooks.opendatahub.io/notebook-restart"
+const WorkbenchLabel = "opendatahub.io/workbenches"
 
 const PrefixEnvVar = "NB_PREFIX"
 
@@ -417,6 +418,7 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 					"statefulset":   instance.Name,
 					"notebook-name": instance.Name,
+					WorkbenchLabel:  "true",
 				}},
 				Spec: *instance.Spec.Template.Spec.DeepCopy(),
 			},

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -2,6 +2,11 @@ module github.com/kubeflow/kubeflow/components/notebook-controller
 
 go 1.19
 
+// use our version of kubeflow/components/common module for reconcilehelper utility differences related to image-field reconciliation
+replace (
+	github.com/kubeflow/kubeflow/components/common => ../common
+)
+
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/kubeflow/kubeflow/components/common v0.0.0-20220218084159-4ad0158e955e

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -34,10 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-const (
-	WorkbenchLabel = "opendatahub.io/workbenches"
-)
-
 //+kubebuilder:webhook:path=/mutate-notebook-v1,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=notebooks,verbs=create;update,versions=v1,name=notebooks.opendatahub.io,admissionReviewVersions=v1
 
 // NotebookWebhook holds the webhook configuration.
@@ -240,7 +236,6 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 
 	// Inject the reconciliation lock only on new notebook creation
 	if req.Operation == admissionv1.Create {
-		AddWorkbenchLabel(notebook)
 		err = InjectReconciliationLock(&notebook.ObjectMeta)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
@@ -251,10 +246,6 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
-	}
-
-	if req.Operation == admissionv1.Update {
-		AddWorkbenchLabel(notebook)
 	}
 
 	// Inject the OAuth proxy if the annotation is present but only if Service Mesh is disabled
@@ -281,13 +272,6 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 func (w *NotebookWebhook) InjectDecoder(d *admission.Decoder) error {
 	w.Decoder = d
 	return nil
-}
-
-// AddWorkbenchLabel adds an exclusive static label to the Notebook pods
-func AddWorkbenchLabel(notebook *nbv1.Notebook) {
-	currentLabels := notebook.ObjectMeta.GetLabels()
-	notebook.ObjectMeta.Labels[WorkbenchLabel] = "true"
-	notebook.ObjectMeta.SetLabels(currentLabels)
 }
 
 // CheckAndMountCACertBundle checks if the odh-trusted-ca-bundle ConfigMap is present


### PR DESCRIPTION
## Description
The PR is a follow up to #265 .
New notebooks and restarted notebooks should contain the label `opendatahub.io/workbenches`

## How Has This Been Tested?
After updating image of `notebook-controller-deployment` to the built image:
1. Existing notebook pods shouldn't have the label `opendatahub.io/workbenches`.
2. Creating new notebooks should have the label `opendatahub.io/workbenches`.
3. Restarting old notebooks should add the mentioned label.


- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
