### PR TITLE
fix: remove replace from go.mod file

### DIFF
--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -122,11 +122,6 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 
 	if *from.Spec.Replicas != *to.Spec.Replicas {
 		*to.Spec.Replicas = *from.Spec.Replicas
-		// Copy the pod template labels, but reconcilation is not required
-		// exclusively based on ths pod template labels
-		if !reflect.DeepEqual(to.Spec.Template.ObjectMeta.Labels, from.Spec.Template.ObjectMeta.Labels) {
-			to.Spec.Template.ObjectMeta.Labels = from.Spec.Template.ObjectMeta.Labels
-		}
 		requireUpdate = true
 	}
 

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -159,6 +159,15 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.Error(err, "error getting Statefulset")
 		return ctrl.Result{}, err
 	}
+
+	// Copy the pod template labels, but reconcilation is not required
+	// exclusively based on ths pod template labels
+	if *ss.Spec.Replicas != *foundStateful.Spec.Replicas {
+		if !reflect.DeepEqual(foundStateful.Spec.Template.ObjectMeta.Labels, ss.Spec.Template.ObjectMeta.Labels) {
+			foundStateful.Spec.Template.ObjectMeta.Labels = ss.Spec.Template.ObjectMeta.Labels
+		}
+	}
+
 	// Update the foundStateful object and write the result back if there are any changes
 	if !justCreated && reconcilehelper.CopyStatefulSetFields(ss, foundStateful) {
 		log.Info("Updating StatefulSet", "namespace", ss.Namespace, "name", ss.Name)

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -2,11 +2,6 @@ module github.com/kubeflow/kubeflow/components/notebook-controller
 
 go 1.19
 
-// use our version of kubeflow/components/common module for reconcilehelper utility differences related to image-field reconciliation
-replace (
-	github.com/kubeflow/kubeflow/components/common => ../common
-)
-
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/kubeflow/kubeflow/components/common v0.0.0-20220218084159-4ad0158e955e


### PR DESCRIPTION
Follow up to #292 as using replace in `go.mod` was causing build to fail.

## Description
Remove replace statement from `go.mod`

Related-to: https://issues.redhat.com/browse/RHOAIENG-2220

## How Has This Been Tested?
Update the image of notebook-controller-deployment with `quay.io/opendatahub/kubeflow-notebook-controller:pr-303`, then test the following steps:

1. Existing notebook pods shouldn't have the label opendatahub.io/workbenches.
2. Creating new notebooks should have the label opendatahub.io/workbenches.
3. Restarting old notebooks should add the mentioned label.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
