### PR TITLE
create configmap and mount for the first workbench in NS

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -165,6 +165,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("By simulating the existence of odh-trusted-ca-bundle ConfigMap")
 			// Create a ConfigMap similar to odh-trusted-ca-bundle for simulation
+			workbenchTrustedCACertBundle := "workbench-trusted-ca-bundle"
 			trustedCACertBundle := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "odh-trusted-ca-bundle",
@@ -219,7 +220,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				Name: "trusted-ca",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: trustedCACertBundle.Name},
+						LocalObjectReference: corev1.LocalObjectReference{Name: workbenchTrustedCACertBundle},
 						Optional:             pointer.Bool(true),
 						Items: []corev1.KeyToPath{
 							{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
create config map and mount for the first workbench in NS

## Description
<!--- Describe your changes in detail -->
Fixes: https://issues.redhat.com/browse/RHOAIENG-5025

This PR fixes the issue linked above.
Currently, if the workbench is the first workbench in the namespace,
it fails to setup the config map: `workbench-trusted-ca-bundle`
This PR would create and mount the first workbench as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Pre-requisite: https://access.redhat.com/documentation/en-us/red_hat_openshift_ai_cloud_service/1/html/installing_and_uninstalling_openshift_ai_cloud_service/working-with-certificates_certs

1. Deploy the PR 
2. Create a DS project and start a workbench 
3. Check for the configmap `workbench-trusted-ca-bundle`
4. Verify if the workbench is mounted with values.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x ] The developer has manually tested the changes and verified that the changes work
