### PR TITLE
fix: remove handler for notebook update event

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -248,11 +248,6 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		}
 	}
 
-	// Add the workbench label on notebook update
-	if req.Operation == admissionv1.Update {
-		AddWorkbenchLabel(notebook)
-	}
-
 	// Inject the OAuth proxy if the annotation is present
 	if OAuthInjectionIsEnabled(notebook.ObjectMeta) {
 		err = InjectOAuthProxy(notebook, w.OAuthConfig)


### PR DESCRIPTION
This PR removes handler for notebook update event.
**Note: The handler should have been removed in #306 but got missed somehow.**

