### PR TITLE
chore: add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# https://docs.github.com/en/code-security/dependabot
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(gha)"
+
+  # only open security update PRs (see linked docs for explanation of `open-pull-requests-limit: 0`)
+  #  https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
+
+  # security PRs need to be further enabled in repository settings
+  #  https://docs.github.com/en/code-security/dependabot/dependabot-auto-triage-rules/customizing-auto-triage-rules-to-prioritize-dependabot-alerts
+
+  - package-ecosystem: "gomod"
+    open-pull-requests-limit: 0
+    directory: "/components/notebook-controller"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "gomod"
+    open-pull-requests-limit: 0
+    directory: "/components/odh-notebook-controller"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Description

A new `dependabot.yml` file has been added to the `.github` directory. This configuration file enables Dependabot to check for updates in our package ecosystems (i.e., `github-actions` and `gomod`) on a weekly schedule, focusing on security updates for the `gomod` ecosystem specifically.

### Enabling this in repo settings

![image](https://github.com/opendatahub-io/kubeflow/assets/442720/255edc93-9f4b-41df-afc9-44b3fed10334)

Then, in the rules, create rules for the manifests we want to keep up-to-date regarding security updates. Here are the two rules I created,

![image](https://github.com/opendatahub-io/kubeflow/assets/442720/c4e9f4c8-ed16-4c36-8ba7-1543e4260c01)

They are set-up like this

![image](https://github.com/opendatahub-io/kubeflow/assets/442720/05f80ef0-1f4d-4cac-9896-3f21bfefe4d0)

## How Has This Been Tested?
https://github.com/jiridanek/kubeflow/pulls shows protobuf updates, which is a security update

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
