### PR TITLE
fix: add GIT_SSL_CAINFO env variable in odh-notebook-controller

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -375,7 +375,7 @@ func (r *OpenshiftNotebookReconciler) UnsetNotebookCertConfig(notebook *nbv1.Not
 	log := r.Log.WithValues("notebook", notebook.Name, "namespace", notebook.Namespace)
 
 	// Get the notebook object
-	envVars := []string{"PIP_CERT", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "PIPELINES_SSL_SA_CERTS"}
+	envVars := []string{"PIP_CERT", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "PIPELINES_SSL_SA_CERTS", "GIT_SSL_CAINFO"}
 	notebookSpecChanged := false
 	patch := client.MergeFrom(notebook.DeepCopy())
 	copyNotebook := notebook.DeepCopy()

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -335,6 +335,7 @@ func InjectCertConfig(notebook *nbv1.Notebook, configMapName string) error {
 		"REQUESTS_CA_BUNDLE":     configMapMountPath,
 		"SSL_CERT_FILE":          configMapMountPath,
 		"PIPELINES_SSL_SA_CERTS": configMapMountPath,
+		"GIT_SSL_CAINFO":         configMapMountPath,
 	}
 
 	notebookContainers := &notebook.Spec.Template.Spec.Containers


### PR DESCRIPTION
Fixes [RHOAIENG-6410](https://issues.redhat.com/browse/RHOAIENG-6410).

## Description
This PR adds environment variable to the `odh-notebook-controller`

## How Has This Been Tested?

Able to see the environemnet variable mounted for the notebook pod:

<img width="892" alt="Screenshot 2024-05-14 at 7 14 13 PM" src="https://github.com/opendatahub-io/kubeflow/assets/23582438/3d7253be-15e2-4562-a087-2373082be187">


## Merge criteria:

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
