### PR TITLE
[RHOAIENG-5033] Odd number of arguments passed as key-value pairs for…

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -317,7 +317,7 @@ func CheckAndMountCACertBundle(ctx context.Context, cli client.Client, notebook 
 	cm := workbenchConfigMap
 	if cm.Name == workbenchConfigMapName {
 		// Inject the trusted-ca volume and environment variables
-		log.Info("Injecting trusted-ca volume and environment variables", notebook.Name, "namespace", notebook.Namespace)
+		log.Info("Injecting trusted-ca volume and environment variables")
 		return InjectCertConfig(notebook, workbenchConfigMapName)
 	}
 	return nil


### PR DESCRIPTION
… logging

Fix the dpanic for log in notebook controller while injecting the trusted CA bundle configuration.

https://issues.redhat.com/browse/RHOAIENG-5033

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Following steps:

1. Install latest ODH-nightly build on your cluster
2. Create the `test` DS project
3. Scale down the `opendatahub-operator-controller-manager` Deployment in `openshift-operators` namespace to 0
4. Update the image referenced by `odh-notebook-controller-manager` Deployment to quay.io/opendatahub/odh-notebook-controller:pr-331
5. Create a `nb-test` workbench
6. See the `odh-notebook-controller-manager` pod log

```
{"level":"info","ts":"2024-05-23T15:51:50Z","logger":"controllers.Notebook","msg":"workbench-trusted-ca-bundle ConfigMap is not present, start creating it...","notebook":"nb-test","namespace":"test"}
{"level":"info","ts":"2024-05-23T15:51:50Z","logger":"controllers.Notebook","msg":"Created workbench-trusted-ca-bundle ConfigMap","notebook":"nb-test","namespace":"test"}
{"level":"info","ts":"2024-05-23T15:51:50Z","logger":"controllers.Notebook","msg":"Injecting trusted-ca volume and environment variables","notebook":"nb-test","namespace":"test"}
{"level":"info","ts":"2024-05-23T15:51:50Z","logger":"controllers.Notebook","msg":"Internal registry found. Will pickup the default value from image field.","notebook":"nb-test","namespace":"test"}
{"level":"info","ts":"2024-05-23T15:51:50Z","logger":"controllers.Notebook","msg":"Updating workbench-trusted-ca-bundle ConfigMap","namespace":"test","notebook":"nb-test"}
{"level":"info","ts":"2024-05-23T15:51:50Z","logger":"controllers.Notebook","msg":"Creating Network Policy","name":"nb-test-ctrl-np"}
{"level":"info","ts":"2024-05-23T15:51:51Z","logger":"controllers.Notebook","msg":"Creating Network Policy","name":"nb-test-oauth-np"}
{"level":"info","ts":"2024-05-23T15:51:51Z","logger":"controllers.Notebook","msg":"Creating Service Account","notebook":"nb-test","namespace":"test"}
{"level":"info","ts":"2024-05-23T15:51:51Z","logger":"controllers.Notebook","msg":"Creating OAuth Service","notebook":"nb-test","namespace":"test"}
{"level":"info","ts":"2024-05-23T15:51:51Z","logger":"controllers.Notebook","msg":"Creating OAuth Secret","notebook":"nb-test","namespace":"test"}
{"level":"info","ts":"2024-05-23T15:51:51Z","logger":"controllers.Notebook","msg":"Creating Route","notebook":"nb-test","namespace":"test"}
{"level":"info","ts":"2024-05-23T15:51:51Z","logger":"controllers.Notebook","msg":"Removing reconciliation lock","notebook":"nb-test","namespace":"test"}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
