### PR TITLE
RHOAIENG-72: Update Dockerfile for {odh-}notebook-controller component

### DIFF
--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -55,8 +55,6 @@ WORKDIR /home/rhods
 ## Copy kf-notebook-controller-manager binary from builder stage
 COPY --from=builder /workspace/notebook-controller/bin/manager /manager
 COPY --from=builder /workspace/notebook-controller/third_party/license.txt third_party/license.txt
-# in builder image, `go env GOPATH` outputs `/opt/app-root/src/go`
-COPY --from=builder /opt/app-root/src/go/pkg/mod/github.com/hashicorp third_party/hashicorp
 
 ## Switch to a non-root user
 USER rhods

--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -3,32 +3,62 @@
 # The Docker context is expected to be:
 #
 # ${PATH_TO_KUBEFLOW/KUBEFLOW repo}/components
-#
-# This is necessary because the Jupyter controller now depends on
-# components/common
-ARG GOLANG_VERSION=1.20
-FROM golang:${GOLANG_VERSION} as builder
 
+
+# Build arguments
+ARG SOURCE_CODE=.
+ARG GOLANG_VERSION=1.20
+
+# Use ubi8/go-toolset as base image
+FROM registry.redhat.io/ubi8/go-toolset:${GOLANG_VERSION} as builder
+
+## Build args to be used at this step
+ARG SOURCE_CODE
+
+# Set building workdir
 WORKDIR /workspace
 
 # Copy the Go Modules manifests
-COPY notebook-controller /workspace/notebook-controller
-COPY common /workspace/common
+COPY ${SOURCE_CODE}/notebook-controller ./notebook-controller
+# This is necessary because the Jupyter controller now depends on
+# components/common
+COPY ${SOURCE_CODE}/common ./common
 
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN cd /workspace/notebook-controller && go mod download all
-
+# Update building workdir
 WORKDIR /workspace/notebook-controller
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -mod=mod -o manager main.go
+## Build the kf-notebook-controller
+USER root
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:debug
-WORKDIR /
-COPY --from=builder /workspace/notebook-controller/manager .
+RUN if [ -z ${CACHITO_ENV_FILE} ]; then \
+       go mod download all; \
+    else \
+       source ${CACHITO_ENV_FILE}; \
+    fi
+
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -mod=mod \
+        -o ./bin/manager main.go
+
+# Use ubi8/ubi-minimal as base image
+FROM registry.redhat.io/ubi8/ubi-minimal:latest
+
+## Install additional packages
+RUN microdnf install -y shadow-utils &&\
+    microdnf clean all
+
+## Create a non-root user with UID 1001
+RUN useradd --uid 1001 --create-home --user-group --system rhods
+
+## Set workdir directory to user home
+WORKDIR /home/rhods
+
+## Copy kf-notebook-controller-manager binary from builder stage
+COPY --from=builder /workspace/notebook-controller/bin/manager /manager
 COPY --from=builder /workspace/notebook-controller/third_party/license.txt third_party/license.txt
-COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/hashicorp
-ENTRYPOINT ["/manager"]
+# in builder image, `go env GOPATH` outputs `/opt/app-root/src/go`
+COPY --from=builder /opt/app-root/src/go/pkg/mod/github.com/hashicorp third_party/hashicorp
+
+## Switch to a non-root user
+USER rhods
+
+ENTRYPOINT [ "/manager" ]

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -53,9 +53,6 @@ WORKDIR /home/rhods
 ## Copy kf-notebook-controller-manager binary from builder stage
 COPY --from=builder /workspace/odh-notebook-controller/bin/manager /manager
 COPY --from=builder /workspace/odh-notebook-controller/third_party/license.txt third_party/license.txt
-# in builder image, `go env GOPATH` outputs `/opt/app-root/src/go`
-COPY --from=builder //opt/app-root/src/go/pkg/mod/github.com/hashicorp third_party/hashicorp
-
 
 ## Switch to a non-root user
 USER rhods

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -4,33 +4,60 @@
 #
 # ${PATH_TO_KUBEFLOW/KUBEFLOW repo}/components
 #
-ARG GOLANG_VERSION=1.20
-FROM golang:${GOLANG_VERSION} as builder
 
+# Build arguments
+ARG SOURCE_CODE=.
+ARG GOLANG_VERSION=1.20
+
+# Use ubi8/go-toolset as base image
+FROM registry.redhat.io/ubi8/go-toolset:${GOLANG_VERSION} as builder
+
+## Build args to be used at this step
+ARG SOURCE_CODE
+
+# Set building workdir
 WORKDIR /workspace
 
 # Copy the Go Modules manifests
-COPY notebook-controller /workspace/notebook-controller
-COPY odh-notebook-controller /workspace/odh-notebook-controller
+COPY ${SOURCE_CODE}/notebook-controller ./notebook-controller
+COPY ${SOURCE_CODE}/odh-notebook-controller ./odh-notebook-controller
 
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN cd /workspace/odh-notebook-controller && go mod download all
-
+# Update building workdir
 WORKDIR /workspace/odh-notebook-controller
 
-# Build
-RUN if [ "$(uname -m)" = "aarch64" ]; then \
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on go build -a -mod=mod -o manager main.go; \
+## Build the kf-notebook-controller
+USER root
+
+RUN if [ -z ${CACHITO_ENV_FILE} ]; then \
+       go mod download all; \
     else \
-        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=mod -o manager main.go; \
+       source ${CACHITO_ENV_FILE}; \
     fi
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:debug
-WORKDIR /
-COPY --from=builder /workspace/odh-notebook-controller/manager .
+RUN go build \
+        -o ./bin/manager main.go
+
+# Use ubi8/ubi-minimal as base image
+FROM registry.redhat.io/ubi8/ubi-minimal:latest
+
+## Install additional packages
+RUN microdnf install -y shadow-utils &&\
+    microdnf clean all
+
+## Create a non-root user with UID 1001
+RUN useradd --uid 1001 --create-home --user-group --system rhods
+
+## Set workdir directory to user home
+WORKDIR /home/rhods
+
+## Copy kf-notebook-controller-manager binary from builder stage
+COPY --from=builder /workspace/odh-notebook-controller/bin/manager /manager
 COPY --from=builder /workspace/odh-notebook-controller/third_party/license.txt third_party/license.txt
-COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/hashicorp
-ENTRYPOINT ["/manager"]
+# in builder image, `go env GOPATH` outputs `/opt/app-root/src/go`
+COPY --from=builder //opt/app-root/src/go/pkg/mod/github.com/hashicorp third_party/hashicorp
+
+
+## Switch to a non-root user
+USER rhods
+
+ENTRYPOINT [ "/manager" ]


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72, this does not fix the issue, but takes the first step towards fixing it in a subsequent PR.

The new Dockerfile in this PR closely corresponds to what is used in OpenShift AI downstream build. This way we will have closer match between what we release upstream and downstream.

## Description
This commit modifies the Dockerfile for the odh-notebook-controller component in the Kubeflow project. The changes include updating the base image, specifying the Golang version to 1.20, and configuring a non-root user for execution. More robust and secure build processes are now used including different steps for package installation, code copying, and building the notebook-controller.

## How Has This Been Tested?
```
docker build -f notebook-controller/Dockerfile . --progress plain
docker build -f odh-notebook-controller/Dockerfile . --progress plain
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
