### PR TITLE
Change log from error to info

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -504,7 +504,7 @@ func SetContainerImageFromRegistry(ctx context.Context, config *rest.Config, not
 							// List imagestreams in the specified namespace
 							imagestreams, err := dynamicClient.Resource(ims).Namespace(namespace).List(ctx, metav1.ListOptions{})
 							if err != nil {
-								log.Error(err, "Cannot list imagestreams", "namespace", namespace)
+								log.Info("Cannot list imagestreams", "error", err)
 								continue
 							}
 


### PR DESCRIPTION
This is a follow up enhancement to cover this discussion: https://github.com/opendatahub-io/kubeflow/pull/329#discussion_r1606963288  

Related to: https://issues.redhat.com/browse/RHOAIENG-8232


## How Has This Been Tested?
Replace the odh-notebook-controller deployment with the following image: `quay.io/rh_ee_atheodor/odh-notebook-controller:log-info2`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
