### PR TITLE
RHOAIENG-72: Specify numeric UID in Dockerfiles

### DIFF
--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -57,6 +57,6 @@ COPY --from=builder /workspace/notebook-controller/bin/manager /manager
 COPY --from=builder /workspace/notebook-controller/third_party/license.txt third_party/license.txt
 
 ## Switch to a non-root user
-USER rhods
+USER 1001:0
 
 ENTRYPOINT [ "/manager" ]

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -55,6 +55,6 @@ COPY --from=builder /workspace/odh-notebook-controller/bin/manager /manager
 COPY --from=builder /workspace/odh-notebook-controller/third_party/license.txt third_party/license.txt
 
 ## Switch to a non-root user
-USER rhods
+USER 1001:0
 
 ENTRYPOINT [ "/manager" ]


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-72

This resolves the

```
Error: container has runAsNonRoot and image has non-numeric user (rhods), cannot verify user is non-root
```

issue.

OpenShift (by default)
runs images under a random user id and the root user group.

See https://access.redhat.com/documentation/cn/openshift_container_platform/4.15/html/images/creating-images#use-uid_create-images

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
