### PR TITLE
chore: add `.snyk` config file to ignore directories that we don't build ODH from

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,14 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities
+version: v1.25.0
+exclude:
+  global:
+    - components/access-management/**
+    - components/admission-webhook/**
+    - components/centraldashboard/**
+    - components/centraldashboard-angular/**
+    - components/crud-web-apps/**
+    - components/example-notebook-servers/**
+    - components/profile-controller/**
+    - components/tensorboard-controller/**
+    - docs/**
+    - testing/**


### PR DESCRIPTION
## Description

Currently there are a lot of folders/paths in kubeflow that we do not user (e.g. profile-controller, or the front end). We should look into adding a .snyk file to exclude these paths.

This is the kubeflow version of
* https://github.com/opendatahub-io/data-science-pipelines-tekton/pull/175

## How Has This Been Tested?

Without the ignore file, the below command produces lots of warnings in various places in the repo. With it, I see only the single one in odh-notebook-controller.

```
jdanek@fedora:~/repos/kubeflow/kubeflow$ snyk code test --org=xxx-yyy-zzz-aaa-bbb

Testing /home/jdanek/repos/kubeflow/kubeflow ...

 ✗ [Low] Improper Certificate Validation 
   Path: components/odh-notebook-controller/e2e/helper_test.go, line 103 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.


✔ Test completed

Organization:      xxx-yyy-zzz-aaa-bbb
Test type:         Static code analysis
Project path:      /home/jdanek/repos/kubeflow/kubeflow

Summary:

  1 Code issues found
  1 [Low] 
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
