### PR TITLE
[Stable] Update kustomization to use params env and yml on notebook-controller and odh-notebook-controller

### DIFF
--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -82,12 +82,10 @@ jobs:
         run: |
           set -x
 
-          cd components/odh-notebook-controller/config/default
+          cd components/odh-notebook-controller/config/base
           kubectl create ns opendatahub
 
-          export CURRENT_NOTEBOOK_IMG=quay.io/opendatahub/odh-notebook-controller:latest
-          export PR_NOTEBOOK_IMG=localhost/${{env.IMG}}:${{env.TAG}}
-          kustomize edit set image ${CURRENT_NOTEBOOK_IMG}=${PR_NOTEBOOK_IMG}
+          echo "odh-notebook-controller-image=localhost/${{env.IMG}}:${{env.TAG}}" > params.env
 
           cat <<EOF | oc apply -f -
           ---

--- a/components/notebook-controller/config/overlays/openshift/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/openshift/kustomization.yaml
@@ -8,17 +8,27 @@ commonLabels:
   app.kubernetes.io/part-of: odh-notebook-controller
   component.opendatahub.io/name: kf-notebook-controller
   opendatahub.io/component: "true"
-images:
-  - name: docker.io/kubeflownotebookswg/notebook-controller
-    newName: quay.io/opendatahub/kubeflow-notebook-controller
-    newTag: 1.7-9f0db5d
+configurations:
+  - params.yaml
 configMapGenerator:
+  - name: kf-notebook-controller-image-parameters
+    env: params.env
   - name: config
     behavior: merge
     literals:
       - USE_ISTIO=false
       - ADD_FSGROUP=false
+generatorOptions:
+  disableNameSuffixHash: true
 patchesStrategicMerge:
   - remove_namespace_patch.yaml
   - manager_openshift_patch.yaml
   - manager_service_openshift_patch.yaml
+vars:
+- name: odh-kf-notebook-controller-image
+  objref:
+    kind: ConfigMap
+    name: kf-notebook-controller-image-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-kf-notebook-controller-image

--- a/components/notebook-controller/config/overlays/openshift/manager_openshift_patch.yaml
+++ b/components/notebook-controller/config/overlays/openshift/manager_openshift_patch.yaml
@@ -32,6 +32,7 @@ spec:
                   name: notebook-controller-culler-config
                   key: IDLENESS_CHECK_PERIOD
                   optional: true
+          image: $(odh-kf-notebook-controller-image)
           resources:
             limits:
               cpu: 500m

--- a/components/notebook-controller/config/overlays/openshift/params.env
+++ b/components/notebook-controller/config/overlays/openshift/params.env
@@ -1,0 +1,1 @@
+odh-kf-notebook-controller-image=quay.io/opendatahub/kubeflow-notebook-controller:1.7-35b81f5

--- a/components/notebook-controller/config/overlays/openshift/params.yaml
+++ b/components/notebook-controller/config/overlays/openshift/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/template/spec/containers/image
+  kind: Deployment

--- a/components/odh-notebook-controller/config/base/kustomization.yaml
+++ b/components/odh-notebook-controller/config/base/kustomization.yaml
@@ -3,7 +3,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../default
-images:
-  - name: quay.io/opendatahub/odh-notebook-controller
-    newName: quay.io/opendatahub/odh-notebook-controller
-    newTag: 1.7-9f0db5d
+
+configMapGenerator:
+- name: odh-notebook-controller-image-parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+- name: odh-notebook-controller-image
+  objref:
+    kind: ConfigMap
+    name: odh-notebook-controller-image-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-notebook-controller-image

--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,0 +1,1 @@
+odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:1.7-35b81f5

--- a/components/odh-notebook-controller/config/manager/kustomization.yaml
+++ b/components/odh-notebook-controller/config/manager/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 resources:
   - manager.yaml
   - service.yaml
+configurations:
+- params.yaml

--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: quay.io/opendatahub/odh-notebook-controller:latest
+          image: $(odh-notebook-controller-image)
           imagePullPolicy: Always
           command:
             - /manager

--- a/components/odh-notebook-controller/config/manager/params.yaml
+++ b/components/odh-notebook-controller/config/manager/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/template/spec/containers/image
+  kind: Deployment


### PR DESCRIPTION
cherry-pick 301bfcec76361dddde55cc14b490a8503865c0a5 
Related to: https://github.com/opendatahub-io/kubeflow/pull/364 

## Description
Sync manifests among upstream v1.7-branch and downstream master branches

Note: For reference, the parametrization of the manifests incorporated downstream via this PR is as follows:: https://github.com/red-hat-data-services/kubeflow/pull/29

## How has been tested
Evaluate notebook-controller deployment by running the following:
$ cd components/notebook-controller
$ kustomize build config/overlays/openshift

Check on the image on the notebook-controller-deployment deployment that matched with the
image: quay.io/opendatahub/kubeflow-notebook-controller:1.7-35b81f5

Evaluate odh-notebook-controller deployment by running the following:
$ cd components/odh-notebook-controller
$ kustomize build config/base

Check on the image on the deployment of odh-notebook-controller-manager that matched with the
image: quay.io/opendatahub/kubeflow-notebook-controller:1.7-35b81f5

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
