### PR TITLE
RHOAIENG-7327: Set certs on both creation and update of notebooks

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -159,31 +159,35 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			}, duration, interval).Should(HaveOccurred())
 		})
 
-		It("Should mount a trusted-ca if exists on the given namespace", func() {
+	})
+
+	// New test case for notebook creation
+	When("Creating a Notebook, test certificate is mounted", func() {
+		const (
+			Name      = "test-notebook"
+			Namespace = "default"
+		)
+
+		It("Should mount a trusted-ca when it exists on the given namespace", func() {
 			ctx := context.Background()
 			logger := logr.Discard()
 
 			By("By simulating the existence of odh-trusted-ca-bundle ConfigMap")
 			// Create a ConfigMap similar to odh-trusted-ca-bundle for simulation
 			workbenchTrustedCACertBundle := "workbench-trusted-ca-bundle"
-			trustedCACertBundle := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "odh-trusted-ca-bundle",
-					Namespace: "default",
-					Labels: map[string]string{
-						"config.openshift.io/inject-trusted-cabundle": "true",
-					},
+			trustedCACertBundle := createOAuthConfigmap(
+				"odh-trusted-ca-bundle",
+				"default",
+				map[string]string{
+					"config.openshift.io/inject-trusted-cabundle": "true",
 				},
-				Data: map[string]string{
-					"ca-bundle.crt":     "-----BEGIN CERTIFICATE-----\n<base64-encoded-cert-data>\n-----END CERTIFICATE-----",
-					"odh-ca-bundle.crt": "-----BEGIN CERTIFICATE-----\n<base64-encoded-cert-data>\n-----END CERTIFICATE-----",
-				},
-			}
+				map[string]string{
+					"ca-bundle.crt":     "-----BEGIN CERTIFICATE-----\nMIIB8jCCAXigAwIBAgITBmyf18G7EEwpQ+Vxe3ssyBrBDjAKBggqhkjOPQQDAzA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6b24gUm9vdCBDQSA0MB4XDTE1MDUyNjAwMDAwMFoXDTQwMDUyNjAwMDAwMFowOTELMAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJvb3QgQ0EgNDB2MBAGByqGSM49AgEGBSuBBAAiA2IABNKrijdPo1MN/sGKe0uoe0ZLY7Bi9i0b2whxIdIA6GO9mif78DluXeo9pcmBqqNbIJhFXRbb/egQbeOc4OO9X4Ri83BkM6DLJC9wuoihKqB1+IGuYgbEgds5bimwHvouXKNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwHQYDVR0OBBYEFNPsxzplbszh2naaVvuc84ZtV+WBMAoGCCqGSM49BAMDA2gAMGUCMDqLIfG9fhGt0O9Yli/W651+kI0rz2ZVwyzjKKlwCkcO8DdZEv8tmZQoTipPNU0zWgIxAOp1AE47xDqUEpHJWEadIRNyp4iciuRMStuW1KyLa2tJElMzrdfkviT8tQp21KW8EA==\n-----END CERTIFICATE-----",
+					"odh-ca-bundle.crt": "-----BEGIN CERTIFICATE-----\nMIIB8jCCAXigAwIBAgITBmyf18G7EEwpQ+Vxe3ssyBrBDjAKBggqhkjOPQQDAzA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6b24gUm9vdCBDQSA0MB4XDTE1MDUyNjAwMDAwMFoXDTQwMDUyNjAwMDAwMFowOTELMAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJvb3QgQ0EgNDB2MBAGByqGSM49AgEGBSuBBAAiA2IABNKrijdPo1MN/sGKe0uoe0ZLY7Bi9i0b2whxIdIA6GO9mif78DluXeo9pcmBqqNbIJhFXRbb/egQbeOc4OO9X4Ri83BkM6DLJC9wuoihKqB1+IGuYgbEgds5bimwHvouXKNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwHQYDVR0OBBYEFNPsxzplbszh2naaVvuc84ZtV+WBMAoGCCqGSM49BAMDA2gAMGUCMDqLIfG9fhGt0O9Yli/W651+kI0rz2ZVwyzjKKlwCkcO8DdZEv8tmZQoTipPNU0zWgIxAOp1AE47xDqUEpHJWEadIRNyp4iciuRMStuW1KyLa2tJElMzrdfkviT8tQp21KW8EA==\n-----END CERTIFICATE-----",
+				})
+
 			// Create the ConfigMap
-			if err := cli.Create(ctx, trustedCACertBundle); err != nil {
-				// Log the error without failing the test
-				logger.Info("Error occurred during creation of ConfigMap: %v", err)
-			}
+			Expect(cli.Create(ctx, trustedCACertBundle)).Should(Succeed())
 			defer func() {
 				// Clean up the ConfigMap after the test
 				if err := cli.Delete(ctx, trustedCACertBundle); err != nil {
@@ -192,14 +196,12 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				}
 			}()
 
-			By("By checking and mounting the trusted-ca bundle")
-			// Invoke the function to mount the CA certificate bundle
-			err := CheckAndMountCACertBundle(ctx, cli, notebook, logger)
-			if err != nil {
-				// Log the error without failing the test
-				logger.Info("Error occurred during mounting CA certificate bundle: %v", err)
-			}
+			By("By creating a new Notebook")
+			notebook := createNotebook(Name, Namespace)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+			time.Sleep(interval)
 
+			By("By checking that trusted-ca bundle is mounted")
 			// Assert that the volume mount and volume are added correctly
 			volumeMountPath := "/etc/pki/tls/custom-certs/ca-bundle.crt"
 			expectedVolumeMount := corev1.VolumeMount{
@@ -208,13 +210,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				SubPath:   "ca-bundle.crt",
 				ReadOnly:  true,
 			}
-			if len(notebook.Spec.Template.Spec.Containers[0].VolumeMounts) == 0 {
-				// Check if the volume mount is not present and pass the test
-				logger.Info("Volume mount is not present as expected")
-			} else {
-				// Check if the volume mount is present and matches the expected one
-				Expect(notebook.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(expectedVolumeMount))
-			}
+			// Check if the volume mount is present and matches the expected one
+			Expect(notebook.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(expectedVolumeMount))
 
 			expectedVolume := corev1.Volume{
 				Name: "trusted-ca",
@@ -231,13 +228,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					},
 				},
 			}
-			if len(notebook.Spec.Template.Spec.Volumes) == 0 {
-				// Check if the volume is not present and pass the test
-				logger.Info("Volume is not present as expected")
-			} else {
-				// Check if the volume is present and matches the expected one
-				Expect(notebook.Spec.Template.Spec.Volumes).To(ContainElement(expectedVolume))
-			}
+			// Check if the volume is present and matches the expected one
+			Expect(notebook.Spec.Template.Spec.Volumes).To(ContainElement(expectedVolume))
 		})
 
 	})
@@ -272,6 +264,71 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				Expect(cli.Get(ctx, key, notebook)).Should(Succeed())
 				return notebook.Spec.Template.Spec.Containers[0].Image
 			}, duration, interval).Should(Equal(updatedImage))
+		})
+
+		It("When notebook CR is updated, should mount a trusted-ca if it exists on the given namespace", func() {
+			ctx := context.Background()
+			logger := logr.Discard()
+
+			By("By simulating the existence of odh-trusted-ca-bundle ConfigMap")
+			// Create a ConfigMap similar to odh-trusted-ca-bundle for simulation
+			workbenchTrustedCACertBundle := "workbench-trusted-ca-bundle"
+			trustedCACertBundle := createOAuthConfigmap(
+				"odh-trusted-ca-bundle",
+				"default",
+				map[string]string{
+					"config.openshift.io/inject-trusted-cabundle": "true",
+				},
+				map[string]string{
+					"ca-bundle.crt":     "-----BEGIN CERTIFICATE-----\nMIIB8jCCAXigAwIBAgITBmyf18G7EEwpQ+Vxe3ssyBrBDjAKBggqhkjOPQQDAzA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6b24gUm9vdCBDQSA0MB4XDTE1MDUyNjAwMDAwMFoXDTQwMDUyNjAwMDAwMFowOTELMAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJvb3QgQ0EgNDB2MBAGByqGSM49AgEGBSuBBAAiA2IABNKrijdPo1MN/sGKe0uoe0ZLY7Bi9i0b2whxIdIA6GO9mif78DluXeo9pcmBqqNbIJhFXRbb/egQbeOc4OO9X4Ri83BkM6DLJC9wuoihKqB1+IGuYgbEgds5bimwHvouXKNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwHQYDVR0OBBYEFNPsxzplbszh2naaVvuc84ZtV+WBMAoGCCqGSM49BAMDA2gAMGUCMDqLIfG9fhGt0O9Yli/W651+kI0rz2ZVwyzjKKlwCkcO8DdZEv8tmZQoTipPNU0zWgIxAOp1AE47xDqUEpHJWEadIRNyp4iciuRMStuW1KyLa2tJElMzrdfkviT8tQp21KW8EA==\n-----END CERTIFICATE-----",
+					"odh-ca-bundle.crt": "-----BEGIN CERTIFICATE-----\nMIIB8jCCAXigAwIBAgITBmyf18G7EEwpQ+Vxe3ssyBrBDjAKBggqhkjOPQQDAzA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6b24gUm9vdCBDQSA0MB4XDTE1MDUyNjAwMDAwMFoXDTQwMDUyNjAwMDAwMFowOTELMAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJvb3QgQ0EgNDB2MBAGByqGSM49AgEGBSuBBAAiA2IABNKrijdPo1MN/sGKe0uoe0ZLY7Bi9i0b2whxIdIA6GO9mif78DluXeo9pcmBqqNbIJhFXRbb/egQbeOc4OO9X4Ri83BkM6DLJC9wuoihKqB1+IGuYgbEgds5bimwHvouXKNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAYYwHQYDVR0OBBYEFNPsxzplbszh2naaVvuc84ZtV+WBMAoGCCqGSM49BAMDA2gAMGUCMDqLIfG9fhGt0O9Yli/W651+kI0rz2ZVwyzjKKlwCkcO8DdZEv8tmZQoTipPNU0zWgIxAOp1AE47xDqUEpHJWEadIRNyp4iciuRMStuW1KyLa2tJElMzrdfkviT8tQp21KW8EA==\n-----END CERTIFICATE-----",
+				})
+			// Create the ConfigMap
+			Expect(cli.Create(ctx, trustedCACertBundle)).Should(Succeed())
+			defer func() {
+				// Clean up the ConfigMap after the test
+				if err := cli.Delete(ctx, trustedCACertBundle); err != nil {
+					// Log the error without failing the test
+					logger.Info("Error occurred during deletion of ConfigMap: %v", err)
+				}
+			}()
+
+			By("By updating the Notebook's image")
+			key := types.NamespacedName{Name: Name, Namespace: Namespace}
+			Expect(cli.Get(ctx, key, notebook)).Should(Succeed())
+
+			updatedImage := "registry.redhat.io/ubi8/ubi:updated"
+			notebook.Spec.Template.Spec.Containers[0].Image = updatedImage
+			Expect(cli.Update(ctx, notebook)).Should(Succeed())
+			time.Sleep(interval)
+
+			By("By checking that trusted-ca bundle is mounted")
+			// Assert that the volume mount and volume are added correctly
+			volumeMountPath := "/etc/pki/tls/custom-certs/ca-bundle.crt"
+			expectedVolumeMount := corev1.VolumeMount{
+				Name:      "trusted-ca",
+				MountPath: volumeMountPath,
+				SubPath:   "ca-bundle.crt",
+				ReadOnly:  true,
+			}
+			Expect(notebook.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(expectedVolumeMount))
+
+			expectedVolume := corev1.Volume{
+				Name: "trusted-ca",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: workbenchTrustedCACertBundle},
+						Optional:             pointer.Bool(true),
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "ca-bundle.crt",
+								Path: "ca-bundle.crt",
+							},
+						},
+					},
+				},
+			}
+			Expect(notebook.Spec.Template.Spec.Volumes).To(ContainElement(expectedVolume))
 		})
 	})
 
@@ -967,5 +1024,18 @@ func createOAuthNetworkPolicy(name, namespace string, npProtocol corev1.Protocol
 				netv1.PolicyTypeIngress,
 			},
 		},
+	}
+}
+
+// createOAuthConfigmap creates a ConfigMap
+// this function can be used to create any kinda of ConfigMap
+func createOAuthConfigmap(name, namespace string, label map[string]string, configMapData map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    label,
+		},
+		Data: configMapData,
 	}
 }

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -247,17 +247,18 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
-		// Only Mount ca bundle on new notebook creation
-		err = CheckAndMountCACertBundle(ctx, w.Client, notebook, log)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
-		}
 	}
 
 	// Check Imagestream Info both on create and update operations
 	if req.Operation == admissionv1.Create || req.Operation == admissionv1.Update {
 		// Check Imagestream Info
 		err = SetContainerImageFromRegistry(ctx, w.Config, notebook, log)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+
+		// Mount ca bundle on notebook creation and update
+		err = CheckAndMountCACertBundle(ctx, w.Client, notebook, log)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Set certs on both creation and update of notebooks
Fixes: https://issues.redhat.com/browse/RHOAIENG-7327

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

For testing, the setup would use the RHOAI operator instance:

- Create a workbench instance in 2.9+ RHOAI version.
- Once the workbench is created check the details 
![Screenshot from 2024-08-12 01-56-52](https://github.com/user-attachments/assets/409db3cf-a81d-4739-a591-84ad607a1e4a)

- after that set the trustedCABundle setup inside the `DSCI instance`
```
spec:
  trustedCABundle:
      customCABundle: ''
      managementState: Managed
```
- Once the setup is set, update the DSC instance.

```
spec:
  components:
       workbenches:
          devFlags:
            manifests:
              - contextDir: components/odh-notebook-controller/config
                sourcePath: ''
                uri: 'https://github.com/opendatahub-io/kubeflow/tarball/pull/373/head'
              - contextDir: components/notebook-controller/config
                sourcePath: ''
                uri: 'https://github.com/opendatahub-io/kubeflow/tarball/pull/373/head'
              - contextDir: ''
                sourcePath: base
                uri: 'https://github.com/opendatahub-io/notebooks/tarball/v1.21.0'
          managementState: Managed
```
- After the setup, Toggle the workbench with changes, either with Notebook CR change or restart(toggle start/stop)
- Notice the change:
![Screenshot from 2024-08-12 01-56-52](https://github.com/user-attachments/assets/1370e003-c436-4029-a0e7-7475a1f0a97e)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
