### PR TITLE
RHOAIENG-9935: feat(nbcs): get ose-oauth-proxy image with PullIfNeeded policy and use digest to specify the image

### DIFF
--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: Always
           command:
             - /manager
-          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy:v4.10"]
+          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46"]
           securityContext:
             allowPrivilegeEscalation: false
           ports:

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -35,7 +35,10 @@ import (
 const (
 	OAuthServicePort     = 443
 	OAuthServicePortName = "oauth-proxy"
-	OAuthProxyImage      = "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
+	// OAuthProxyImage uses sha256 manifest list digest value of v4.8 image for AMD64 as default to be compatible with imagePullPolicy: IfNotPresent, overridable
+	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64?image=6306f12280cc9b3291272668&architecture=amd64&container-tabs=overview
+	// and kept in sync with the manifests here and in ClusterServiceVersion metadata of opendatahub operator
+	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46"
 )
 
 type OAuthConfig struct {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-9935

Revival of @shalberd's PR, now targetted against v1.7-branch.

* https://github.com/opendatahub-io/kubeflow/pull/119

I used https://github.com/opendatahub-io/kubeflow/pull/119.patch to get a patch that I applied against v1.7-branch, to avoid having to rebase the original PR branch.

* [x] TODO: create new ticket to update the proxy image we are using, it is truly ancient, https://issues.redhat.com/browse/RHOAIENG-10827

I also incorporated change to the manifests

* https://github.com/opendatahub-io/odh-manifests/pull/868

to be in sync with https://github.com/red-hat-data-services/kubeflow/blob/master/components/odh-notebook-controller/config/manager/manager.yaml#L28

and with operator annotations at https://github.com/red-hat-data-services/RHOAI-Build-Config/blob/main/catalog/v4.13/rhods-operator/catalog.yaml#L340

* [ ] TODO: create a followup issue to change pull policy for the controller image itself; this looks safe, because we always reference it with either digest or with a tag that includes commit hash in itself. also change github workflow (the sed) when making this change

## Motivation

Currently, the ose-oauth-proxy sidecar container of a running notebook, handled by odh notebook controller, always pulls the image from an external location. Current ose-oauth-proxy image is v4.10.
This always image pulling is problematic from a stability perspective, as, should connectivity to an external repo ever cease, no image pulling on notebook pod start is possible.

Also, providing the image in tag format is not compatible with disconnected cluster installs that use mirroring and soft-linking from source to target. Those on-prem installs need image references to be in sha256 digest format.

Another reason for changing to sha256 digest format: Tag ose-oauth-proxy:v4.10 changes. If imagePullPolicy is set to IfNotPresent, what matters is that an image with that tag is already cached on one of the cluster nodes. So, to keep a unique image version and build status for ose-oauth-proxy, we need to go with sha256 digest format as well.

## Description

changed from tag format to digest format in odh notebook controller webhook that adds an ose-oauth-proxy sidecar to a Notebook CR

Manifest link digest of v4.10 from July 6 2023:

ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33

https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64?architecture=amd64&tag=v4.10.0-202306170106.p0.g799d414.assembly.stream&push_date=1688610772000&container-tabs=gti

Put in comments with respect to actual tag used and location to look at for details. Changed imagepullPolicy from Always to IfNotPresent.

Related PR in odh-manifests:

https://github.com/opendatahub-io/odh-manifests/pull/868

## How Has This Been Tested?

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
