### PR TITLE
RHOAIENG-8390: feat(odh-nbc): search for imagestreams only in the namespace the controller runs in

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -57,8 +57,9 @@ const (
 // OpenshiftNotebookReconciler holds the controller configuration.
 type OpenshiftNotebookReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Log    logr.Logger
+	Namespace string
+	Scheme    *runtime.Scheme
+	Log       logr.Logger
 }
 
 // ClusterRole permissions

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -455,9 +455,9 @@ var _ = Describe("The Openshift Notebook controller", func() {
 						},
 						From: []netv1.NetworkPolicyPeer{
 							{
-								// Since for unit tests we do not have context,
-								// namespace will fallback to test pod namespace
-								// if run in CI or `redhat-ods-applications` if run locally
+								// Since for unit tests the controller does not run in a cluster pod,
+								// it cannot detect its own pod's namespace. Therefore, we define it
+								// to be `redhat-ods-applications` (in suite_test.go)
 								NamespaceSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										"kubernetes.io/metadata.name": testPodNamespace,

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -20,9 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -432,12 +430,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		notebook := createNotebook(Name, Namespace)
 
 		npProtocol := corev1.ProtocolTCP
-		testPodNamespace := "redhat-ods-applications"
-		if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-			if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
-				testPodNamespace = ns
-			}
-		}
+		testPodNamespace := odhNotebookControllerTestNamespace
 
 		expectedNotebookNetworkPolicy := netv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -69,8 +69,9 @@ var (
 )
 
 const (
-	timeout  = time.Second * 10
-	interval = time.Second * 2
+	timeout                            = time.Second * 10
+	interval                           = time.Second * 2
+	odhNotebookControllerTestNamespace = "redhat-ods-applications"
 )
 
 func TestAPIs(t *testing.T) {
@@ -173,9 +174,10 @@ var _ = BeforeSuite(func() {
 
 	// Setup notebook controller
 	err = (&OpenshiftNotebookReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("notebook-controller"),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Log:       ctrl.Log.WithName("controllers").WithName("notebook-controller"),
+		Scheme:    mgr.GetScheme(),
+		Namespace: odhNotebookControllerTestNamespace,
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -183,9 +185,10 @@ var _ = BeforeSuite(func() {
 	hookServer := mgr.GetWebhookServer()
 	notebookWebhook := &webhook.Admission{
 		Handler: &NotebookWebhook{
-			Log:    ctrl.Log.WithName("controllers").WithName("notebook-controller"),
-			Client: mgr.GetClient(),
-			Config: mgr.GetConfig(),
+			Log:       ctrl.Log.WithName("controllers").WithName("notebook-controller"),
+			Client:    mgr.GetClient(),
+			Config:    mgr.GetConfig(),
+			Namespace: odhNotebookControllerTestNamespace,
 			OAuthConfig: OAuthConfig{
 				ProxyImage: OAuthProxyImage,
 			},


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-8390

We would like to think whether we can improve the way how we search for the ImageStreams in case the cluster doesn't have an internal image registry enabled. Not all cluster deployments run with the standard name `opendatahub` or `redhat-ods-applications`

## Description
Instead of hardcoding the central namespace to look for imagestreams, since all central components run in the main namespace where also by default the imagestreams are located:
- determine the namespace that the controller runs in
- use that namespace to continue with imagestream search

https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/#directly-accessing-the-rest-api

"the default namespace to be used for namespaced API operations is placed in a file at /var/run/secrets/kubernetes.io/serviceaccount/namespace in each container."

## How Has This Been Tested?
not tested yet. I propose testing with built PR image ...

* quay.io/opendatahub/kubeflow-notebook-controller:pr-375
  * no changes went into this one
* quay.io/opendatahub/odh-notebook-controller:pr-375

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
  - @jiridanek checked it works