### PR TITLE
RHOAISTRAT-214: Issue #362: feat(nbcs): build containers to be fips-ready

### DIFF
--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -11,6 +11,8 @@ ARG GOLANG_VERSION=1.21
 
 # Use ubi8/go-toolset as base image
 FROM registry.access.redhat.com/ubi8/go-toolset:${GOLANG_VERSION} as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -30,14 +32,12 @@ WORKDIR /workspace/notebook-controller
 ## Build the kf-notebook-controller
 USER root
 
-RUN if [ -z ${CACHITO_ENV_FILE} ]; then \
-       go mod download all; \
-    else \
-       source ${CACHITO_ENV_FILE}; \
-    fi
-
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -mod=mod \
-        -o ./bin/manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN if [ -z ${CACHITO_ENV_FILE} ]; then go mod download; else source ${CACHITO_ENV_FILE}; fi && \
+  CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -a -o ./bin/manager main.go
 
 # Use ubi8/ubi-minimal as base image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -11,6 +11,8 @@ ARG GOLANG_VERSION=1.21
 
 # Use ubi8/go-toolset as base image
 FROM registry.access.redhat.com/ubi8/go-toolset:${GOLANG_VERSION} as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 ## Build args to be used at this step
 ARG SOURCE_CODE
@@ -28,14 +30,12 @@ WORKDIR /workspace/odh-notebook-controller
 ## Build the kf-notebook-controller
 USER root
 
-RUN if [ -z ${CACHITO_ENV_FILE} ]; then \
-       go mod download all; \
-    else \
-       source ${CACHITO_ENV_FILE}; \
-    fi
-
-RUN go build \
-        -o ./bin/manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN if [ -z ${CACHITO_ENV_FILE} ]; then go mod download; else source ${CACHITO_ENV_FILE}; fi && \
+  CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -a -o ./bin/manager main.go
 
 # Use ubi8/ubi-minimal as base image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
@@ -50,7 +50,7 @@ RUN useradd --uid 1001 --create-home --user-group --system rhods
 ## Set workdir directory to user home
 WORKDIR /home/rhods
 
-## Copy kf-notebook-controller-manager binary from builder stage
+## Copy odh-notebook-controller-manager binary from builder stage
 COPY --from=builder /workspace/odh-notebook-controller/bin/manager /manager
 COPY --from=builder /workspace/odh-notebook-controller/third_party/license.txt third_party/license.txt
 


### PR DESCRIPTION
* Fixes #362

We are already having these flags enabled in downstream build as part of the devops initiative to build with fips. It makes lots of sense to me to enable these flags in odh Dockerfile as well, for consistency.

This is not intended to fully resolve https://issues.redhat.com/browse/RHOAISTRAT-214, but it's just a sensible first step done as a code improvement initiative, by following public advice in https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant.

## Description

This PR was created by diffing the downstream and upstream dockerfile and then i made changes to upstream dockerfile to reflect the enhancements done downstream.

1. Dockerfiles are brought closer together, especially to the Red Hat build; previously, sourcing things in a stand-alone RUN command had no effect
2. The openssl fips-compatible library is linked into the manager binaries, to proactively address fips concerns

As a next step, cpaas Dockerfiles will need to be updated in turn with the new things here.

## How Has This Been Tested?
GHA
running controller on fips-enabled cluster with no problems

* quay.io/opendatahub/kubeflow-notebook-controller:pr-406
* quay.io/opendatahub/odh-notebook-controller:pr-406

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
