### PR TITLE
[RHOAIENG-11895] fix(odh-nbc): put a newline between certs in case input is missing a newline

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -304,7 +304,7 @@ func (r *OpenshiftNotebookReconciler) CreateNotebookCertConfigMap(notebook *nbv1
 				Labels:    map[string]string{"opendatahub.io/managed-by": "workbenches"},
 			},
 			Data: map[string]string{
-				"ca-bundle.crt": string(bytes.Join(rootCertPool, []byte{})),
+				"ca-bundle.crt": string(bytes.Join(rootCertPool, []byte("\n"))),
 			},
 		}
 


### PR DESCRIPTION
In case that the source of the certificates doesn't contain newline,
this will assure that at least one new line is between the concatenated
certificates. In case that the new line in the source is present
already, then there will be two new lines now, but it shouldn't be a
problem as it shouldn't break anything for us. This fixes [1].

* [1] https://issues.redhat.com/browse/RHOAIENG-11895

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Not yet - will perform manual test on a custom build image and will try to implement/amend tests in this repo.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
