### PR TITLE
NO-JIRA: fix(gha) improve robustness by checking for resource existence

### DIFF
--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -271,6 +271,8 @@ jobs:
                         port: notebook-port
           EOF
 
+          # wait for the statefulset to be created
+          timeout 100 bash -c -- 'until kubectl get statefulset minimal-notebook; do sleep 1; done'
           # wait for the good result
           kubectl rollout status --watch statefulset minimal-notebook
           kubectl wait statefulset minimal-notebook --for=jsonpath='{.spec.replicas}'=1 --timeout=100s


### PR DESCRIPTION
Depends on

* https://github.com/opendatahub-io/kubeflow/pull/417

## Description

Without this, the gha is flaky and may fail with

```
notebook.kubeflow.org/minimal-notebook created
Error from server (NotFound): statefulsets.apps "minimal-notebook" not found
```

## How Has This Been Tested?

GHA

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
