### PR TITLE
[NO-JIRA] Allow approvers from OWNERS file to run sync gha

### DIFF
--- a/.github/workflows/sync-branches-through-pr.yaml
+++ b/.github/workflows/sync-branches-through-pr.yaml
@@ -12,7 +12,40 @@ on:  # yamllint disable-line rule:truthy
         required: true
 
 jobs:
+  check-approver:
+    runs-on: ubuntu-latest
+    outputs:
+      is-approver: ${{ steps.check-approver.outputs.is-approver }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Parse OWNERS file and check approver
+        id: check-approver
+        run: |
+
+          mapfile -t approvers < <(awk '/approvers:/ {found=1; next} /reviewers:/ {found=0} found {gsub(/^[ \t]*-?[ \t]*/, ""); print}' OWNERS)
+          is_approver=false
+          # Check if $GITHUB_ACTOR is in the list of approvers
+          for approver in "${approvers[@]}"; do
+            if [[ "$GITHUB_ACTOR" == "$approver" ]]; then
+              echo "User $GITHUB_ACTOR is allowed to run the workflow."
+              is_approver=true
+              break
+            fi
+          done
+
+          # Set output based on the approver status
+          if [[ "$is_approver" == true ]]; then
+            echo "is-approver=true" >> ${GITHUB_OUTPUT}
+          else
+            echo "User $GITHUB_ACTOR is not allowed to run the workflow."
+            echo "is-approver=false" >> ${GITHUB_OUTPUT}
+          fi
+
   sync:
+    needs: check-approver
+    if: needs.check-approver.outputs.is-approver == 'true'
     permissions:
       contents: write
       pull-requests: write
@@ -45,3 +78,13 @@ jobs:
             It merges all commits from `${{ github.event.inputs.source }}` branch into `${{ github.event.inputs.target }}` branch.
 
             :warning: **IMPORTANT NOTE**: Remember to delete the `${{ steps.prepare.outputs.branch }}` branch after merging the changes.
+
+  fail-unauthorized:
+    needs: check-approver
+    if: needs.check-approver.outputs.is-approver == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail job for unauthorized user
+        run: |
+          echo "You are not authorized to run this workflow. Only approvers listed in OWNERS can run it."
+          exit 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This upgrade allow approvers from OWNERS file to run sync gha

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
https://github.com/atheo89/test-auth-users/actions/runs/11382115618/job/31664947802#step:3:23 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
