### PR TITLE
NO-JIRA: chore(nbcs): update tooling in controller's Makefiles - kubernetes and kustomize

### DIFF
--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -148,7 +148,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/v3/cmd/kustomize@v5.0.2)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5@v5.0.2)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 ENVTEST_VERSION?=v0.0.0-20240923090159-236e448db12c

--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -9,7 +9,7 @@ KF_TAG ?= main-3f931d2
 CONTAINER_ENGINE ?= podman
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.26
 
 # Kubernetes configuration
 K8S_NAMESPACE ?= odh-notebook-controller-system

--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -241,7 +241,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(LOCALBIN)/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/v3/cmd/kustomize@v5.0.2
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@v5.0.2
 
 ENVTEST = $(LOCALBIN)/setup-envtest
 .PHONY: envtest

--- a/components/profile-controller/Makefile
+++ b/components/profile-controller/Makefile
@@ -4,7 +4,7 @@ TAG ?= $(shell git describe --tags --always --dirty)
 ARCH ?= linux/amd64
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.26
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
Some tooling updates and fix. I bumped into this during my work on https://issues.redhat.com/browse/RHOAIENG-14687.

This fix is part of https://issues.redhat.com/browse/RHOAIENG-15141.

## Description
The update of the kubernetes version isn't mandatory and I can remove it from here if you want to. But I think it's reasonable.
The fix for the kustomize package is necessary to make our e2e tests pass (at least partially) again. This change is a followup of the #391.

## How Has This Been Tested?
Try to run in `components/odh-notebook-controller`:
* `make test` - all should pass.
* `make run-ci-e2e-tests` - 15 pass, 2 fail - you need to be logged into some cluster to make this work


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
