### PR TITLE
[Fix] update bash scripts for E2E tests run to propagate failures

### DIFF
--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -134,16 +134,13 @@ endif
 setup-kf: kustomize ## Replace Kustomize manifests with your environment configuration.
 	sed -i'' -e 's,namespace: .*,namespace: '"${K8S_NAMESPACE}"',' \
 		../notebook-controller/config/overlays/openshift/kustomization.yaml
-	sed -i'' -e 's,newName: .*,newName: '"${KF_IMG}"',' \
-		../notebook-controller/config/overlays/openshift/kustomization.yaml
-	sed -i'' -e 's,newTag: .*,newTag: '"${KF_TAG}"',' \
- 	../notebook-controller/config/overlays/openshift/kustomization.yaml
+	sed -i'' -e "s,odh-kf-notebook-controller-image=.*,odh-kf-notebook-controller-image=${KF_IMG}:${KF_TAG}," \
+		../notebook-controller/config/overlays/openshift/params.env
 
 .PHONY: setup
 setup: manifests kustomize ## Replace Kustomize manifests with your environment configuration.
 	sed -i'' -e 's,namespace: .*,namespace: '"${K8S_NAMESPACE}"',' ./config/default/kustomization.yaml
-	sed -i'' -e 's,newName: .*,newName: '"${IMG}"',' ./config/base/kustomization.yaml
-	sed -i'' -e 's,newTag: .*,newTag: '"${TAG}"',' ./config/base/kustomization.yaml
+	sed -i'' -e "s,odh-notebook-controller-image=.*,odh-notebook-controller-image=${IMG}:${TAG}," ./config/base/params.env
 
 .PHONY: setup-service-mesh
 setup-service-mesh: kustomize ## Replace Kustomize manifests with your environment configuration.
@@ -153,10 +150,8 @@ setup-service-mesh: kustomize ## Replace Kustomize manifests with your environme
 		../notebook-controller/config/overlays/standalone-service-mesh/kustomization.yaml
 	sed -i'' -e 's,ISTIO_GATEWAY=.*,ISTIO_GATEWAY='"${K8S_NAMESPACE}/odh-gateway"',' \
     		../notebook-controller/config/overlays/standalone-service-mesh/kustomization.yaml
-	sed -i'' -e 's,newName: .*,newName: '"${KF_IMG}"',' \
-		../notebook-controller/config/overlays/standalone-service-mesh/kustomization.yaml
-	sed -i'' -e 's,newTag: .*,newTag: '"${KF_TAG}"',' \
-	../notebook-controller/config/overlays/standalone-service-mesh/kustomization.yaml
+	sed -i'' -e "s,odh-kf-notebook-controller-image=.*,odh-kf-notebook-controller-image=${KF_IMG}:${KF_TAG}," \
+		../notebook-controller/config/overlays/openshift/params.env
 	sed -i'' -e 's,host: .*,host: opendatahub.'"$(shell kubectl get ingress.config.openshift.io cluster -o 'jsonpath={.spec.domain}')"',' \
     	../notebook-controller/config/overlays/standalone-service-mesh/gateway-route.yaml
 

--- a/components/odh-notebook-controller/run-e2e-test-service-mesh.sh
+++ b/components/odh-notebook-controller/run-e2e-test-service-mesh.sh
@@ -1,23 +1,44 @@
 #!/usr/bin/env bash
 
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -Eeuxo pipefail
+
+echo "Running the ${0} setup"
+
 TEST_NAMESPACE="odh-notebook-controller-system"
 
+# Following variables are optional - if not set, the default values in relevant params.env
+# will be used for both images. As such, if you want to run tests against your custom changes,
+# be sure to perform a docker build and set these variables accordingly!
+ODH_NOTEBOOK_CONTROLLER_IMAGE="${ODH_NOTEBOOK_CONTROLLER_IMAGE:-}"
+KF_NOTEBOOK_CONTROLLER="${KF_NOTEBOOK_CONTROLLER:-}"
+
+
+if test -n "${ODH_NOTEBOOK_CONTROLLER_IMAGE}"; then
+    IFS=':' read -r -a CTRL_IMG <<< "${ODH_NOTEBOOK_CONTROLLER_IMAGE}"
+    export IMG="${CTRL_IMG[0]}"
+    export TAG="${CTRL_IMG[1]}"
+fi
+
+if test -n "${KF_NOTEBOOK_CONTROLLER}"; then
+    IFS=':' read -r -a KF_NBC_IMG <<< "${KF_NOTEBOOK_CONTROLLER}"
+    export KF_IMG="${KF_NBC_IMG[0]}"
+    export KF_TAG="${KF_NBC_IMG[1]}"
+fi
+
+export K8S_NAMESPACE="${TEST_NAMESPACE}"
+
+# From now on we want to be sure that undeploy and testing project deletion are called
+
+function cleanup() {
+    echo "Performing deployment cleanup of the ${0}"
+    make undeploy-with-mesh undeploy-service-mesh && oc delete project "${TEST_NAMESPACE}"
+}
+trap cleanup EXIT
+
 # setup and deploy the controller
-oc new-project $TEST_NAMESPACE -n $TEST_NAMESPACE --skip-config-write
+oc new-project "${TEST_NAMESPACE}" --skip-config-write
 
-IFS=':' read -r -a CTRL_IMG <<< "${ODH_NOTEBOOK_CONTROLLER_IMAGE}"
-export IMG="${CTRL_IMG[0]}"
-export TAG="${CTRL_IMG[1]}"
-IFS=':' read -r -a KF_NBC_IMG <<< "${KF_NOTEBOOK_CONTROLLER}"
-export KF_IMG="${KF_NBC_IMG[0]}"
-export KF_TAG="${KF_NBC_IMG[1]}"
-export K8S_NAMESPACE=$TEST_NAMESPACE
-
+# deploy and run e2e tests
 make deploy-service-mesh deploy-with-mesh
-
-# run e2e tests
 make e2e-test-service-mesh
-
-# cleanup deployment
-make undeploy-with-mesh undeploy-service-mesh
-oc delete project $TEST_NAMESPACE -n $TEST_NAMESPACE

--- a/components/odh-notebook-controller/run-e2e-test.sh
+++ b/components/odh-notebook-controller/run-e2e-test.sh
@@ -37,7 +37,7 @@ function cleanup() {
 trap cleanup EXIT
 
 # setup and deploy the controller
-oc new-project "${TEST_NAMESPACE}" --skip-config-write
+oc new-project "${TEST_NAMESPACE}"
 
 # deploy and run e2e tests
 make deploy

--- a/components/odh-notebook-controller/run-e2e-test.sh
+++ b/components/odh-notebook-controller/run-e2e-test.sh
@@ -1,23 +1,44 @@
 #!/usr/bin/env bash
 
+# https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -Eeuxo pipefail
+
+echo "Running the ${0} setup"
+
 TEST_NAMESPACE="odh-notebook-controller-system"
 
+# Following variables are optional - if not set, the default values in relevant params.env
+# will be used for both images. As such, if you want to run tests against your custom changes,
+# be sure to perform a docker build and set these variables accordingly!
+ODH_NOTEBOOK_CONTROLLER_IMAGE="${ODH_NOTEBOOK_CONTROLLER_IMAGE:-}"
+KF_NOTEBOOK_CONTROLLER="${KF_NOTEBOOK_CONTROLLER:-}"
+
+
+if test -n "${ODH_NOTEBOOK_CONTROLLER_IMAGE}"; then
+    IFS=':' read -r -a CTRL_IMG <<< "${ODH_NOTEBOOK_CONTROLLER_IMAGE}"
+    export IMG="${CTRL_IMG[0]}"
+    export TAG="${CTRL_IMG[1]}"
+fi
+
+if test -n "${KF_NOTEBOOK_CONTROLLER}"; then
+    IFS=':' read -r -a KF_NBC_IMG <<< "${KF_NOTEBOOK_CONTROLLER}"
+    export KF_IMG="${KF_NBC_IMG[0]}"
+    export KF_TAG="${KF_NBC_IMG[1]}"
+fi
+
+export K8S_NAMESPACE="${TEST_NAMESPACE}"
+
+# From now on we want to be sure that undeploy and testing project deletion are called
+
+function cleanup() {
+    echo "Performing deployment cleanup of the ${0}"
+    make undeploy && oc delete project "${TEST_NAMESPACE}"
+}
+trap cleanup EXIT
+
 # setup and deploy the controller
-oc new-project $TEST_NAMESPACE -n $TEST_NAMESPACE --skip-config-write
+oc new-project "${TEST_NAMESPACE}" --skip-config-write
 
-IFS=':' read -r -a CTRL_IMG <<< "${ODH_NOTEBOOK_CONTROLLER_IMAGE}"
-export IMG="${CTRL_IMG[0]}"
-export TAG="${CTRL_IMG[1]}"
-IFS=':' read -r -a KF_NBC_IMG <<< "${KF_NOTEBOOK_CONTROLLER}"
-export KF_IMG="${KF_NBC_IMG[0]}"
-export KF_TAG="${KF_NBC_IMG[1]}"
-export K8S_NAMESPACE=$TEST_NAMESPACE
-
+# deploy and run e2e tests
 make deploy
-
-# run e2e tests
 make e2e-test
-
-# cleanup deployment
-make undeploy
-oc delete project $TEST_NAMESPACE -n $TEST_NAMESPACE


### PR DESCRIPTION
We haven't been propagating the test failures in our E2E CI jobs because we weren't checking for the return codes of the commands run in the bash scripts.

Also, this fixes setup* targets in Makefile so that expected images are deployed to the testing cluster.

This depends on #432!

I bumped into this during my work on https://issues.redhat.com/browse/RHOAIENG-14687.

This fix is part of https://issues.redhat.com/browse/RHOAIENG-15141.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Try to run in `components/odh-notebook-controller`:
* `make run-ci-e2e-tests` - 15 pass, 2 fail - you need to be logged into some cluster to make this work
* since 2 tests are failing, see that now the execution itself fails with return code 2 - before this change the return code was just 0 as a success, which was wrong of course

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
