### PR TITLE
RHOAIENG-15335: feat(odh-nbc/webhook): don't initiate updates that would restart a running pod

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -683,23 +683,21 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			}, duration, interval).Should(BeTrue())
 		})
 
-		// RHOAIENG-14552: We *do not* reconcile OAuth in the notebook when it's modified
+		It("Should reconcile the Notebook when modified", func() {
+			By("By simulating a manual Notebook modification")
+			notebook.Spec.Template.Spec.ServiceAccountName = "foo"
+			notebook.Spec.Template.Spec.Containers[1].Image = "bar"
+			notebook.Spec.Template.Spec.Volumes[1].VolumeSource = corev1.VolumeSource{}
+			Expect(cli.Update(ctx, notebook)).Should(Succeed())
+			time.Sleep(interval)
 
-		//It("Should reconcile the Notebook when modified", func() {
-		//	By("By simulating a manual Notebook modification")
-		//	notebook.Spec.Template.Spec.ServiceAccountName = "foo"
-		//	notebook.Spec.Template.Spec.Containers[1].Image = "bar"
-		//	notebook.Spec.Template.Spec.Volumes[1].VolumeSource = corev1.VolumeSource{}
-		//	Expect(cli.Update(ctx, notebook)).Should(Succeed())
-		//	time.Sleep(interval)
-		//
-		//	By("By checking that the webhook has restored the Notebook spec")
-		//	Eventually(func() error {
-		//		key := types.NamespacedName{Name: Name, Namespace: Namespace}
-		//		return cli.Get(ctx, key, notebook)
-		//	}, duration, interval).Should(Succeed())
-		//	Expect(CompareNotebooks(*notebook, expectedNotebook)).Should(BeTrue())
-		//})
+			By("By checking that the webhook has restored the Notebook spec")
+			Eventually(func() error {
+				key := types.NamespacedName{Name: Name, Namespace: Namespace}
+				return cli.Get(ctx, key, notebook)
+			}, duration, interval).Should(Succeed())
+			Expect(CompareNotebooks(*notebook, expectedNotebook)).Should(BeTrue())
+		})
 
 		serviceAccount := &corev1.ServiceAccount{}
 		expectedServiceAccount := createOAuthServiceAccount(Name, Namespace)

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -265,17 +265,13 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	// Inject the OAuth proxy if the annotation is present but only if Service Mesh is disabled
-	if OAuthInjectionIsEnabled(notebook.ObjectMeta) && ServiceMeshIsEnabled(notebook.ObjectMeta) {
-		return admission.Denied(fmt.Sprintf("Cannot have both %s and %s set to true. Pick one.", AnnotationServiceMesh, AnnotationInjectOAuth))
-	}
-	// RHOAIENG-14552: Updating oauth-proxy in a running notebook may lead to notebook restart. Updating only
-	// on Create is safe as it cannot cause a restart in already running notebook when oauth-proxy image changes.
-	if req.Operation == admissionv1.Create {
-		if OAuthInjectionIsEnabled(notebook.ObjectMeta) {
-			err = InjectOAuthProxy(notebook, w.OAuthConfig)
-			if err != nil {
-				return admission.Errored(http.StatusInternalServerError, err)
-			}
+	if OAuthInjectionIsEnabled(notebook.ObjectMeta) {
+		if ServiceMeshIsEnabled(notebook.ObjectMeta) {
+			return admission.Denied(fmt.Sprintf("Cannot have both %s and %s set to true. Pick one.", AnnotationServiceMesh, AnnotationInjectOAuth))
+		}
+		err = InjectOAuthProxy(notebook, w.OAuthConfig)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
 		}
 	}
 

--- a/components/odh-notebook-controller/controllers/notebook_webhook_utils.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_utils.go
@@ -1,0 +1,79 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/go-logr/logr"
+)
+
+// UpdatesPending is either NoPendingUpdates, or a new value providing a Reason for the update.
+type UpdatesPending struct {
+	Reason string
+}
+
+var (
+	NoPendingUpdates = &UpdatesPending{}
+)
+
+// FirstDifferenceReporter is a custom reporter that only records the first difference.
+type FirstDifferenceReporter struct {
+	path cmp.Path
+	diff string
+}
+
+func (r *FirstDifferenceReporter) PushStep(ps cmp.PathStep) {
+	r.path = append(r.path, ps)
+}
+
+func (r *FirstDifferenceReporter) Report(rs cmp.Result) {
+	if r.diff == "" && !rs.Equal() {
+		vx, vy := r.path.Last().Values()
+		r.diff = fmt.Sprintf("%#v: %+v != %+v", r.path, vx, vy)
+	}
+}
+
+func (r *FirstDifferenceReporter) PopStep() {
+	r.path = r.path[:len(r.path)-1]
+}
+
+func (r *FirstDifferenceReporter) String() string {
+	return r.diff
+}
+
+func getStructDiff(ctx context.Context, a any, b any) (result string) {
+	log := logr.FromContextOrDiscard(ctx)
+
+	// calling cmp.Equal may panic, get ready for it
+	result = "failed to compute the reason for why there is a pending restart"
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error(fmt.Errorf("failed to compute struct difference: %+v", r), "Cannot determine reason for restart")
+		}
+	}()
+
+	var comparator FirstDifferenceReporter
+	eq := cmp.Equal(a, b, cmp.Reporter(&comparator))
+	if eq {
+		log.Error(nil, "Unexpectedly attempted to diff structs that are actually equal")
+	}
+	result = comparator.String()
+
+	return
+}

--- a/components/odh-notebook-controller/controllers/notebook_webhook_utils.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_utils.go
@@ -32,7 +32,7 @@ var (
 	NoPendingUpdates = &UpdatesPending{}
 )
 
-// FirstDifferenceReporter is a custom reporter that only records the first difference.
+// FirstDifferenceReporter is a custom go-cmp reporter that only records the first difference.
 type FirstDifferenceReporter struct {
 	path cmp.Path
 	diff string
@@ -57,6 +57,7 @@ func (r *FirstDifferenceReporter) String() string {
 	return r.diff
 }
 
+// getStructDiff compares a and b, reporting the first difference it found in a human-readable single-line string.
 func getStructDiff(ctx context.Context, a any, b any) (result string) {
 	log := logr.FromContextOrDiscard(ctx)
 

--- a/components/odh-notebook-controller/controllers/notebook_webhook_utils_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_utils_test.go
@@ -1,0 +1,64 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFirstDifferenceReporter(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		a    any
+		b    any
+		diff string
+	}{
+		{"", 42, 42, ""},
+		{"", v1.Pod{Spec: v1.PodSpec{NodeName: "node1"}}, v1.Pod{Spec: v1.PodSpec{NodeName: "node2"}}, "{v1.Pod}.Spec.NodeName: node1 != node2"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var reporter FirstDifferenceReporter
+			eq := cmp.Equal(tt.a, tt.b, cmp.Reporter(&reporter))
+			assert.Equal(t, tt.diff == "", eq)
+			assert.Equal(t, tt.diff, reporter.String())
+		})
+	}
+}
+
+func TestGetStructDiff(t *testing.T) {
+	var tests = []struct {
+		name     string
+		a        any
+		b        any
+		expected string
+	}{
+		{"simple numbers", 42, 42, ""},
+		{"differing pods", v1.Pod{Spec: v1.PodSpec{NodeName: "node1"}}, v1.Pod{Spec: v1.PodSpec{NodeName: "node2"}}, "{v1.Pod}.Spec.NodeName: node1 != node2"},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(t *testing.T) {
+			diff := getStructDiff(context.Background(), v.a, v.b)
+			assert.Equal(t, diff, v.expected)
+		})
+	}
+}

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -6,6 +6,7 @@ toolchain go1.21.9
 
 require (
 	github.com/go-logr/logr v1.4.1
+	github.com/google/go-cmp v0.6.0
 	github.com/kubeflow/kubeflow/components/notebook-controller v0.0.0-20220728153354-fc09bd1eefb8
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.30.0
@@ -36,7 +37,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15335

This is an alternate solution, see also
* https://github.com/opendatahub-io/kubeflow/pull/437


The alternate solution in #437 does not work well, it caused regression https://issues.redhat.com/browse/RHOAIENG-15603 due to how Dashboard changes notebook image when user wants to use different notebook image. Therefore, this PR reverts that and resolves the problem in a different, hopefully more correct, way.

## Description

Check whether the Notebook is running, and if it is, then don't mutate the pod template in the webhook itself. If we don't do this, then we have problems when some of the values that the mutating webhook sets are changed between updates.

1. user enables culling
2. therefore notebook-controller periodically updates Notebook CR with metadata annotations about last detected activity
3. which triggers odh-notebook-controller webhook mutating webhook that acts on Notebook CR modifications
4. and it will change the defined oauth-proxy if rhoai has been recently updated
5. leading to pod restart, which is undesirable

We need to break the above chain of events somewhere, so that the Pod is not restarted just by Culler doing its job. OAuth Proxy image update in the pod may only be applied when the notebook is stopped, not when it is running.

## How Has This Been Tested?

Not yet, so far only thinking about possible approaches to solve the problem above. This PR is one such possible approach, there may be better ones.

Testing instructions from @atheo89 

* https://github.com/opendatahub-io/kubeflow/pull/437#issuecomment-2459448268

use PR build image

* quay.io/opendatahub/odh-notebook-controller:pr-436

and also update the `odh-notebook-controller-manager-role` otherwise controller will be crashlooping as new controller wants to manage rolebindings

* components/odh-notebook-controller/config/rbac/role.yaml

also tested the steps from https://issues.redhat.com/browse/RHOAIENG-15603 where @manosnoam reported the regression about changing image

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
