### PR TITLE
RHOAIENG-15335: feat(odh-nbc/webhook): only update oauth-proxy image in CREATE events

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -608,21 +608,23 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			}, duration, interval).Should(BeTrue())
 		})
 
-		It("Should reconcile the Notebook when modified", func() {
-			By("By simulating a manual Notebook modification")
-			notebook.Spec.Template.Spec.ServiceAccountName = "foo"
-			notebook.Spec.Template.Spec.Containers[1].Image = "bar"
-			notebook.Spec.Template.Spec.Volumes[1].VolumeSource = corev1.VolumeSource{}
-			Expect(cli.Update(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
+		// RHOAIENG-14552: We *do not* reconcile OAuth in the notebook when it's modified
 
-			By("By checking that the webhook has restored the Notebook spec")
-			Eventually(func() error {
-				key := types.NamespacedName{Name: Name, Namespace: Namespace}
-				return cli.Get(ctx, key, notebook)
-			}, duration, interval).Should(Succeed())
-			Expect(CompareNotebooks(*notebook, expectedNotebook)).Should(BeTrue())
-		})
+		//It("Should reconcile the Notebook when modified", func() {
+		//	By("By simulating a manual Notebook modification")
+		//	notebook.Spec.Template.Spec.ServiceAccountName = "foo"
+		//	notebook.Spec.Template.Spec.Containers[1].Image = "bar"
+		//	notebook.Spec.Template.Spec.Volumes[1].VolumeSource = corev1.VolumeSource{}
+		//	Expect(cli.Update(ctx, notebook)).Should(Succeed())
+		//	time.Sleep(interval)
+		//
+		//	By("By checking that the webhook has restored the Notebook spec")
+		//	Eventually(func() error {
+		//		key := types.NamespacedName{Name: Name, Namespace: Namespace}
+		//		return cli.Get(ctx, key, notebook)
+		//	}, duration, interval).Should(Succeed())
+		//	Expect(CompareNotebooks(*notebook, expectedNotebook)).Should(BeTrue())
+		//})
 
 		serviceAccount := &corev1.ServiceAccount{}
 		expectedServiceAccount := createOAuthServiceAccount(Name, Namespace)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15335

This is an alternate solution, see also

* https://github.com/opendatahub-io/kubeflow/pull/436

## Description

Don't touch OAuth Proxy parts when the Notebook is Updated, only set it once on Create.

## How Has This Been Tested?
Not yet, so far only thinking about possible approaches to solve the problem above. This PR is one such possible approach, there may be better ones.

I don't like this solution myself much, but it's for sure simpler than the other one.

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
