### PR TITLE
RHOAIENG-15772: tests(odh-nbc): write envtest kubeconfig to disk upon request

### DIFF
--- a/components/odh-notebook-controller/README.md
+++ b/components/odh-notebook-controller/README.md
@@ -78,6 +78,14 @@ Run the following command to execute them:
 make test
 ```
 
+Useful options for running tests (that are already included in the above `make` command) are
+
+| Option                     | Description                                                                                   |
+|----------------------------|-----------------------------------------------------------------------------------------------|
+| KUBEBUILDER_ASSETS=        | Environment variable that specifies path to where Kubebuilder has downloaded envtest binaries |
+| -ginkgo.v -ginkgo.progress | Enables verbose output from Ginkgo                                                            |
+| -test.v                    | Enables verbose output from Go tests (*testing.T)                                             |
+
 The following environment variables are used to enable additional debug options for the tests
 
 | Environment variable   | Description                                                                                                                                  |

--- a/components/odh-notebook-controller/README.md
+++ b/components/odh-notebook-controller/README.md
@@ -78,6 +78,13 @@ Run the following command to execute them:
 make test
 ```
 
+The following environment variables are used to enable additional debug options for the tests
+
+| Environment variable   | Description                                                                                                                                  |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| DEBUG_WRITE_KUBECONFIG | Writes a Kubeconfig file to disk. It can be used with `kubectl` or `k9s` to examine the envtest cluster when test is paused on a breakpoint. |
+|                        |                                                                                                                                              |
+
 ### Run locally
 
 Install the `notebooks.kubeflow.org` CRD from the [Kubeflow notebook

--- a/components/odh-notebook-controller/README.md
+++ b/components/odh-notebook-controller/README.md
@@ -82,7 +82,7 @@ Useful options for running tests (that are already included in the above `make` 
 
 | Option                     | Description                                                                                   |
 |----------------------------|-----------------------------------------------------------------------------------------------|
-| KUBEBUILDER_ASSETS=        | Environment variable that specifies path to where Kubebuilder has downloaded envtest binaries |
+| KUBEBUILDER_ASSETS        | Environment variable that specifies path to where Kubebuilder has downloaded envtest binaries |
 | -ginkgo.v -ginkgo.progress | Enables verbose output from Ginkgo                                                            |
 | -test.v                    | Enables verbose output from Go tests (*testing.T)                                             |
 

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -138,6 +138,9 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = os.WriteFile(kubeconfigPath, config, 0600)
 		Expect(err).NotTo(HaveOccurred())
+		GinkgoT().Logf("DEBUG_WRITE_KUBECONFIG is set, writing system:masters' Kubeconfig to %s", kubeconfigPath)
+	} else {
+		GinkgoT().Logf("DEBUG_WRITE_KUBECONFIG environment variable was not provided")
 	}
 
 	// Setup notebook controller

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -128,6 +129,16 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+
+	if kubeconfigPath, found := os.LookupEnv("DEBUG_WRITE_KUBECONFIG"); found {
+		user := envtest.User{Name: "MasterOfTheSystems", Groups: []string{"system:masters"}}
+		authedUser, err := envTest.ControlPlane.AddUser(user, nil)
+		Expect(err).NotTo(HaveOccurred())
+		config, err := authedUser.KubeConfig()
+		Expect(err).NotTo(HaveOccurred())
+		err = os.WriteFile(kubeconfigPath, config, 0600)
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	// Setup notebook controller
 	err = (&OpenshiftNotebookReconciler{


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15772

## Description

This helps with debugging because it's then possible to do e.g.

```
KUBECONFIG=/tmp/envtest.kubeconfig k9s
```

and investigate the cluster while the test is paused on a breakpoint.

## How Has This Been Tested?

Works on my macOS laptop.

## Merge criteria:

* [x] Any internal docs about the env variable needed?

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
