### PR TITLE
RHOAIENG-15772: tests(odh-nbc): write auditlogs from envtest tests to disk upon request

### DIFF
--- a/components/odh-notebook-controller/README.md
+++ b/components/odh-notebook-controller/README.md
@@ -91,7 +91,7 @@ The following environment variables are used to enable additional debug options 
 | Environment variable   | Description                                                                                                                                  |
 |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
 | DEBUG_WRITE_KUBECONFIG | Writes a Kubeconfig file to disk. It can be used with `kubectl` or `k9s` to examine the envtest cluster when test is paused on a breakpoint. |
-|                        |                                                                                                                                              |
+| DEBUG_WRITE_AUDITLOG   | Writes kube-apiserver auditlogs to disk. The config is in `envtest-audit-policy.yaml`, set the namespace of interest there.                  |
 
 ### Run locally
 

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -102,6 +102,16 @@ var _ = BeforeSuite(func() {
 			IgnoreErrorIfPathMissing: false,
 		},
 	}
+	if auditLogPath, found := os.LookupEnv("DEBUG_WRITE_AUDITLOG"); found {
+		envTest.ControlPlane.APIServer.Configure().
+			// https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#log-backend
+			Append("audit-log-maxage", "1").
+			Append("audit-log-maxbackup", "5").
+			Append("audit-log-maxsize", "100"). // in MiB
+			Append("audit-log-format", "json").
+			Append("audit-policy-file", filepath.Join("..", "envtest-audit-policy.yaml")).
+			Append("audit-log-path", auditLogPath)
+	}
 
 	var err error
 	cfg, err = envTest.Start()

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -102,16 +102,6 @@ var _ = BeforeSuite(func() {
 			IgnoreErrorIfPathMissing: false,
 		},
 	}
-	if auditLogPath, found := os.LookupEnv("DEBUG_WRITE_AUDITLOG"); found {
-		envTest.ControlPlane.APIServer.Configure().
-			// https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#log-backend
-			Append("audit-log-maxage", "1").
-			Append("audit-log-maxbackup", "5").
-			Append("audit-log-maxsize", "100"). // in MiB
-			Append("audit-log-format", "json").
-			Append("audit-policy-file", filepath.Join("..", "envtest-audit-policy.yaml")).
-			Append("audit-log-path", auditLogPath)
-	}
 
 	var err error
 	cfg, err = envTest.Start()
@@ -119,6 +109,7 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	if kubeconfigPath, found := os.LookupEnv("DEBUG_WRITE_KUBECONFIG"); found {
+		// https://github.com/rancher/fleet/blob/main/integrationtests/utils/kubeconfig.go
 		user := envtest.User{Name: "MasterOfTheSystems", Groups: []string{"system:masters"}}
 		authedUser, err := envTest.ControlPlane.AddUser(user, nil)
 		Expect(err).NotTo(HaveOccurred())
@@ -129,6 +120,20 @@ var _ = BeforeSuite(func() {
 		GinkgoT().Logf("DEBUG_WRITE_KUBECONFIG is set, writing system:masters' Kubeconfig to %s", kubeconfigPath)
 	} else {
 		GinkgoT().Logf("DEBUG_WRITE_KUBECONFIG environment variable was not provided")
+	}
+
+	if auditLogPath, found := os.LookupEnv("DEBUG_WRITE_AUDITLOG"); found {
+		envTest.ControlPlane.APIServer.Configure().
+			// https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#log-backend
+			Append("audit-log-maxage", "1").
+			Append("audit-log-maxbackup", "5").
+			Append("audit-log-maxsize", "100"). // in MiB
+			Append("audit-log-format", "json").
+			Append("audit-policy-file", filepath.Join("..", "envtest-audit-policy.yaml")).
+			Append("audit-log-path", auditLogPath)
+		GinkgoT().Logf("DEBUG_WRITE_AUDITLOG is set, writing `envtest-audit-policy.yaml` auditlog to %s", auditLogPath)
+	} else {
+		GinkgoT().Logf("DEBUG_WRITE_AUDITLOG environment variable was not provided")
 	}
 
 	// Register API objects

--- a/components/odh-notebook-controller/envtest-audit-policy.yaml
+++ b/components/odh-notebook-controller/envtest-audit-policy.yaml
@@ -7,3 +7,10 @@ rules:
   # Log all requests in `developer` namespace at the RequestResponse (maximum verbosity) level.
   - level: RequestResponse
     namespaces: ["developer"]
+
+# Use jq to analyze the log file this produces. For example:
+
+# jq 'select((.objectRef.apiGroup == "dscinitialization.opendatahub.io"
+#              or .objectRef.apiGroup == "datasciencecluster.opendatahub.io")
+#            and .user.username != "system:serviceaccount:redhat-ods-operator:redhat-ods-operator-controller-manager"
+#            and .verb != "get" and .verb != "watch" and .verb != "list")' < /tmp/kube-apiserver-audit.log

--- a/components/odh-notebook-controller/envtest-audit-policy.yaml
+++ b/components/odh-notebook-controller/envtest-audit-policy.yaml
@@ -1,0 +1,9 @@
+# https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy
+# This is extremely verbose k8s apiserver logging that may be enabled for debugging of envtest-based tests
+---
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  # Log all requests in developer namespace at the RequestResponse (maximum verbosity) level.
+  - level: RequestResponse
+    namespaces: ["developer"]

--- a/components/odh-notebook-controller/envtest-audit-policy.yaml
+++ b/components/odh-notebook-controller/envtest-audit-policy.yaml
@@ -1,9 +1,9 @@
 # https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy
-# This is extremely verbose k8s apiserver logging that may be enabled for debugging of envtest-based tests
+# This is extremely verbose kube-apiserver logging that may be enabled for debugging of envtest-based tests
 ---
 apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
-  # Log all requests in developer namespace at the RequestResponse (maximum verbosity) level.
+  # Log all requests in `developer` namespace at the RequestResponse (maximum verbosity) level.
   - level: RequestResponse
     namespaces: ["developer"]


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15772

## Description

This helps with debugging because it's then possible to do e.g.

```
cat /tmp/audit.log | jq | ...
```

and investigate what happened when a test was running.

## How Has This Been Tested?

Works on my machine.

## Merge criteria:

* [x] Do we need some readme about this?

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
