### PR TITLE
RHOAIENG-15743: fix(odh-nbc): trim ca-bundle certData to avoid logging scary messages

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -283,6 +283,9 @@ func (r *OpenshiftNotebookReconciler) CreateNotebookCertConfigMap(notebook *nbv1
 		for _, certFile := range configMapFileNames[configMapName] {
 
 			certData, ok := configMap.Data[certFile]
+			// RHOAIENG-15743: opendatahub-operator#1339 started adding '\n' unconditionally, which
+			// is breaking our `== ""` checks below. Trim the certData again.
+			certData = strings.TrimSpace(certData)
 			// If ca-bundle.crt is not found in the ConfigMap odh-trusted-ca-bundle
 			// no need to create the workbench-trusted-ca-bundle, as it is created
 			// by annotation inject-ca-bundle: "true"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15743

## Description

After opendatahub-io/opendatahub-operator#1339, operator is adding '\n' unconditionally to the odh cert bundle, and that is breaking our `== ""` checks. Trim the certData and restore balance in the universe.

See the equivalent fix in pipelines
* https://github.com/opendatahub-io/data-science-pipelines-operator/pull/742

## How Has This Been Tested?

* quay.io/opendatahub/odh-notebook-controller:pr-455

Put image into odh-notebook-controller deployment and see how

```
{"level":"info","ts":"2024-11-15T19:10:16Z","logger":"controllers.Notebook","msg":"Invalid certificate format","notebook":"elyra","namespace":"jdanek2","configMap":"odh-trusted-ca-bundle","certFile":"odh-ca-bundle.crt"}
```

disappears when the`customCABundle ` in DSCi is `''`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
