### PR TITLE
RHOAIENG-15875: chore(gha): enable verbose govulncheck output

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -87,5 +87,5 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           go mod tidy
-          $(go env GOPATH)/bin/govulncheck ./...
+          $(go env GOPATH)/bin/govulncheck -show=verbose ./...
         working-directory: ${{ matrix.component }}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15875

## Description

Turns out that this "impacted but not vulnerable" prodsec thing is around to haunt us. This way we'll have full info from govulncheck so that we can better assess various reports.

## How Has This Been Tested?

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
