### PR TITLE
RHOAIENG-15772: tests(nbcs): use the direct (uncached) client to drive tests

### DIFF
--- a/components/notebook-controller/controllers/suite_test.go
+++ b/components/notebook-controller/controllers/suite_test.go
@@ -91,7 +91,6 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 
-	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
 
 }, 60)

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func() {
 	}
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseFlagOptions(&opts)))
 
-	// Initiliaze test environment:
+	// Initialize test environment:
 	// https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest#Environment.Start
 	By("Bootstrapping test environment")
 	envTest = &envtest.Environment{
@@ -110,7 +110,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(netv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 
-	// Initiliaze Kubernetes client
+	// Initialize Kubernetes client
 	cli, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cli).NotTo(BeNil())
@@ -172,7 +172,6 @@ var _ = BeforeSuite(func() {
 	}).Should(Succeed())
 
 	// Verify kubernetes client is working
-	cli = mgr.GetClient()
 	Expect(cli).ToNot(BeNil())
 
 	for _, namespace := range testNamespaces {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15772

## Description

This is in accordance with the recommendations in the Kubebuilder Book.

> Note that we set up both a "live" k8s client and a separate client from the manager.
> This is because when making assertions in tests, you generally want to assert against the live state of the API server.
> If you use the client from the manager (`k8sManager.GetClient`), you'd end up asserting against the contents of the cache instead, which is slower and can introduce flakiness into your tests.
> We could use the manager's `APIReader` to accomplish the same thing, but that would leave us with two clients in our test assertions and setup (one for reading, one for writing), and it'd be easy to make mistakes.
>
> Note that we keep the reconciler running against the manager's cache client, though – we want our controller to behave as it would in production, and we use features of the cache (like indices) in our controller which aren't available when talking directly to the API server.

(https://book.kubebuilder.io/cronjob-tutorial/writing-tests)

And also in this discusion
* https://github.com/kubernetes-sigs/controller-runtime/issues/343#issuecomment-469435686

## How Has This Been Tested?

GHA

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
