### PR TITLE
RHOAIENG-15772: tests(odh-nbc): fix unintended shadowing of `cfg` variable

### DIFF
--- a/components/notebook-controller/controllers/suite_test.go
+++ b/components/notebook-controller/controllers/suite_test.go
@@ -58,7 +58,8 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -98,7 +98,8 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := envTest.Start()
+	var err error
+	cfg, err = envTest.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 


### PR DESCRIPTION
[RHOAIENG-15772](https://issues.redhat.com/browse/RHOAIENG-15772)

## Description

`cfg` is first declared here

https://github.com/opendatahub-io/kubeflow/blob/e7980b146e0d62779e019de95a6faabc45c439cf/components/odh-notebook-controller/controllers/suite_test.go#L57-L64

and then the `:=` operator shadows it, and the `cfg` we are setting is a different `cfg`. The top `cfg` remains `nil`.

https://github.com/opendatahub-io/kubeflow/blob/e7980b146e0d62779e019de95a6faabc45c439cf/components/odh-notebook-controller/controllers/suite_test.go#L101

This is a nasty Go gotcha, and we aren't the first to have trouble with it. C.f. https://temporal.io/blog/go-shadowing-bad-choices#the-bug for one.

## How Has This Been Tested?

```
make test
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
