### PR TITLE
RHOAIENG-15772: tests(odh-nbc) significantly reduce the amount of sleeping in tests

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -271,7 +271,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("By creating a new Notebook")
 			notebook := createNotebook(Name, Namespace)
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that trusted-ca bundle is mounted")
 			// Assert that the volume mount and volume are added correctly
@@ -306,6 +305,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			// Check the content in workbench-trusted-ca-bundle matches what we expect:
 			//   - have 2 certificates there in ca-bundle.crt
 			//   - both certificates are valid
+			// TODO(RHOAIENG-15907): adding sleep to reduce flakiness
+			time.Sleep(2 * time.Second)
 			configMapName := "workbench-trusted-ca-bundle"
 			checkCertConfigMap(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 2)
 		})
@@ -376,7 +377,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			updatedImage := "registry.redhat.io/ubi8/ubi:updated"
 			notebook.Spec.Template.Spec.Containers[0].Image = updatedImage
 			Expect(cli.Update(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that trusted-ca bundle is mounted")
 			// Assert that the volume mount and volume are added correctly
@@ -409,6 +409,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			// Check the content in workbench-trusted-ca-bundle matches what we expect:
 			//   - have 2 certificates there in ca-bundle.crt
 			//   - both certificates are valid
+			// TODO(RHOAIENG-15907): adding sleep to reduce flakiness
+			time.Sleep(2 * time.Second)
 			configMapName := "workbench-trusted-ca-bundle"
 			checkCertConfigMap(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 2)
 		})

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 	// Define utility constants for testing timeouts/durations and intervals.
 	const (
 		duration = 10 * time.Second
-		interval = 2 * time.Second
+		interval = 200 * time.Millisecond
 	)
 
 	When("Creating a Notebook", func() {

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -1120,7 +1120,7 @@ func createOAuthConfigmap(name, namespace string, label map[string]string, confi
 }
 
 // checkCertConfigMap checks the content of a config map defined by the name and namespace
-// It triest to parse the given certFileName and checks that all certificates can be parsed there and that the number of the certificates matches what we expect.
+// It tries to parse the given certFileName and checks that all certificates can be parsed there and that the number of the certificates matches what we expect.
 func checkCertConfigMap(ctx context.Context, namespace string, configMapName string, certFileName string, expNumberCerts int) {
 	configMap := &corev1.ConfigMap{}
 	key := types.NamespacedName{Namespace: namespace, Name: configMapName}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -92,7 +92,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has created the Route")
 			Eventually(func() error {
@@ -106,7 +105,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("By simulating a manual Route modification")
 			patch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"to":{"name":"foo"}}}`))
 			Expect(cli.Patch(ctx, route, patch)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has restored the Route spec")
 			Eventually(func() (string, error) {
@@ -123,7 +121,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should recreate the Route when deleted", func() {
 			By("By deleting the notebook route")
 			Expect(cli.Delete(ctx, route)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has recreated the Route")
 			Eventually(func() error {
@@ -152,7 +149,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("By deleting the recently created Notebook")
 			Expect(cli.Delete(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the Notebook is deleted")
 			Eventually(func() error {
@@ -330,7 +326,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By updating the Notebook's image")
 			key := types.NamespacedName{Name: Name, Namespace: Namespace}
@@ -339,7 +334,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			updatedImage := "registry.redhat.io/ubi8/ubi:updated"
 			notebook.Spec.Template.Spec.Containers[0].Image = updatedImage
 			Expect(cli.Update(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the Notebook's image is updated")
 			Eventually(func() string {
@@ -482,7 +476,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has created Network policy to allow only controller traffic")
 			Eventually(func() error {
@@ -503,7 +496,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("By simulating a manual NetworkPolicy modification")
 			patch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"policyTypes":["Egress"]}}`))
 			Expect(cli.Patch(ctx, notebookNetworkPolicy, patch)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has restored the network policy spec")
 			Eventually(func() (string, error) {
@@ -520,7 +512,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should recreate the Network Policy when deleted", func() {
 			By("By deleting the notebook OAuth Network Policy")
 			Expect(cli.Delete(ctx, notebookOAuthNetworkPolicy)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has recreated the OAuth Network policy")
 			Eventually(func() error {
@@ -657,7 +648,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the webhook has injected the sidecar container")
 			Expect(*notebook).To(BeMatchingK8sResource(expectedNotebook, CompareNotebooks))
@@ -679,7 +669,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			notebook.Spec.Template.Spec.Containers[1].Image = "bar"
 			notebook.Spec.Template.Spec.Volumes[1].VolumeSource = corev1.VolumeSource{}
 			Expect(cli.Update(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the webhook has restored the Notebook spec")
 			Eventually(func() error {
@@ -704,7 +693,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should recreate the Service Account when deleted", func() {
 			By("By deleting the notebook Service Account")
 			Expect(cli.Delete(ctx, serviceAccount)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has recreated the Service Account")
 			Eventually(func() error {
@@ -748,7 +736,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should recreate the Service when deleted", func() {
 			By("By deleting the notebook Service")
 			Expect(cli.Delete(ctx, service)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has recreated the Service")
 			Eventually(func() error {
@@ -774,7 +761,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should recreate the Secret when deleted", func() {
 			By("By deleting the notebook Secret")
 			Expect(cli.Delete(ctx, secret)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has recreated the Secret")
 			Eventually(func() error {
@@ -824,7 +810,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should recreate the Route when deleted", func() {
 			By("By deleting the notebook Route")
 			Expect(cli.Delete(ctx, route)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has recreated the Route")
 			Eventually(func() error {
@@ -838,7 +823,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("By simulating a manual Route modification")
 			patch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"to":{"name":"foo"}}}`))
 			Expect(cli.Patch(ctx, route, patch)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the controller has restored the Route spec")
 			Eventually(func() (string, error) {
@@ -880,7 +864,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("By deleting the recently created Notebook")
 			Expect(cli.Delete(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
 
 			By("By checking that the Notebook is deleted")
 			Eventually(func() error {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15772

Relates to
* https://github.com/opendatahub-io/kubeflow/issues/380

## Description

* remove `time.sleep()`s and rely on `Eventually`
* shorten the `interval` constant so that we check more frequently
* leaving one sleep that seems necessary for the tests (!)
* and two more sleeps that are a workaround for flakyness

This PR depends on
* https://github.com/opendatahub-io/kubeflow/pull/461

because with the caching client, a check for resource passes (resource is in cache) but server-side patching fails (resource is not yet on server). For example this one

https://github.com/opendatahub-io/kubeflow/blob/25558137ad3e1e49e1ead4b57fe811a3a5cd1d76/components/odh-notebook-controller/controllers/notebook_controller_test.go#L840-L841

and also the create-get does not work well

https://github.com/opendatahub-io/kubeflow/blob/25558137ad3e1e49e1ead4b57fe811a3a5cd1d76/components/odh-notebook-controller/controllers/notebook_controller_test.go#L331-L336

## How Has This Been Tested?

```
make test
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
