### PR TITLE
RHOAIENG-15748: chore(release): set the main tag to `main`, so we need not update it with digest updater from now on

### DIFF
--- a/components/notebook-controller/config/overlays/openshift/params.env
+++ b/components/notebook-controller/config/overlays/openshift/params.env
@@ -1,1 +1,1 @@
-odh-kf-notebook-controller-image=quay.io/opendatahub/kubeflow-notebook-controller:main-363bcdb
+odh-kf-notebook-controller-image=quay.io/opendatahub/kubeflow-notebook-controller:main

--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,1 +1,1 @@
-odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:main-363bcdb
+odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:main

--- a/components/odh-notebook-controller/makefile-vars.mk
+++ b/components/odh-notebook-controller/makefile-vars.mk
@@ -1,1 +1,1 @@
-KF_TAG ?= main-363bcdb
+KF_TAG ?= main


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15748

Follow-up to

* https://github.com/red-hat-data-services/rhods-devops-infra/pull/131

## Description

![image](https://github.com/user-attachments/assets/5ce77222-a56b-4dc4-b139-76ca23429c67)

https://docs.google.com/document/d/1R1zPFKI4-HQY9SeJYa2erSnzr5YNdEU497CdOgni7AY/edit?tab=t.0#heading=h.p8a8iq2tou22

## How Has This Been Tested?

Images with `main` tag are present and can be used

```
podman pull --platform=linux/amd64 quay.io/opendatahub/kubeflow-notebook-controller:main
Trying to pull quay.io/opendatahub/kubeflow-notebook-controller:main...
Getting image source signatures
Copying blob sha256:bb4c96ca6d403d756b0d1fa420b6ade5ab46035a46451db44f1abff5b200b345
Copying blob sha256:e0348fdb2685077d22116d294a90a253709aba78815882a57fcc536b22dcae2f
Copying config sha256:dfab4f088ac5d5587543216d61a0969a63a0c0f148c8a9782b2be221eaf28f6b
Writing manifest to image destination
dfab4f088ac5d5587543216d61a0969a63a0c0f148c8a9782b2be221eaf28f6b
```

```
podman pull --platform=linux/amd64 quay.io/opendatahub/odh-notebook-controller:main
Trying to pull quay.io/opendatahub/odh-notebook-controller:main...
Getting image source signatures
Copying blob sha256:84f1c1f659dd19766fea787ec33bcf66ff5ad1b78be4f6f7eaf73276ee0466e3
Copying blob sha256:e0348fdb2685077d22116d294a90a253709aba78815882a57fcc536b22dcae2f
Copying config sha256:d7ca01df108e912016aa9ce24d9013fd01a1ab323e7674939d3c2451a6cea92a
Writing manifest to image destination
d7ca01df108e912016aa9ce24d9013fd01a1ab323e7674939d3c2451a6cea92a
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
