### PR TITLE
[RHOAIENG-15141] Fix failing E2E tests

### DIFF
--- a/components/odh-notebook-controller/e2e/notebook_update_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_update_test.go
@@ -65,7 +65,8 @@ func (tc *testContext) testNotebookUpdate(nbContext notebookContext) error {
 	}
 
 	// Example update: Change the Notebook image
-	updatedNotebook.Spec.Template.Spec.Containers[0].Image = "new-image:latest"
+	newImage := "quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.11-20241119-3ceb400"
+	updatedNotebook.Spec.Template.Spec.Containers[0].Image = newImage
 
 	err = tc.customClient.Update(tc.ctx, updatedNotebook)
 	if err != nil {
@@ -79,7 +80,7 @@ func (tc *testContext) testNotebookUpdate(nbContext notebookContext) error {
 		if err != nil {
 			return false, err
 		}
-		if note.Spec.Template.Spec.Containers[0].Image == "new-image:latest" {
+		if note.Spec.Template.Spec.Containers[0].Image == newImage {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
There were two E2E tests in failure:
            --- FAIL: TestE2ENotebookController/update/thoth-minimal-oauth-notebook/Notebook_Statefulset_Validation_After_Update (60.28s)
            --- FAIL: TestE2ENotebookController/update/thoth-minimal-oauth-notebook/Verify_Notebook_Traffic_After_Update (10.75s)

The reason was that after the culling test, the culling configuration is reverted, but the Notebook CR isn't updated and the annotation that was added by the notebook controller: `kubeflow-resource-stopped` stays in that CR and as such, the workbench instance isn't started back. This change deletes this annotation at the end of the culler test and the workbench is up and running and ready for the followup tests.

Another issue there was that the update test updated the workbench to a non-existent image link, which resulted in a ImagePullBackOff Error in the end. This change updates this link to some existing image.

---

https://issues.redhat.com/browse/RHOAIENG-15141

## How Has This Been Tested?
You can try to run locally e.g. by this:
```
~/workspace/rhosai/odh/kubeflow/components/odh-notebook-controller on  fixE2eTests! ⌚ 14:59:21
$ make -e ODH_NOTEBOOK_CONTROLLER_IMAGE=quay.io/opendatahub/odh-notebook-controller:main-f1be2a4 -e KF_NOTEBOOK_CONTROLLER=quay.io/opendatahub/kubeflow-notebook-controller:main-f1be2a4 run-ci-e2e-tests
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
