### PR TITLE
Increase timeouts as they were too short.

### DIFF
--- a/.github/workflows/kubeflow-release.yaml
+++ b/.github/workflows/kubeflow-release.yaml
@@ -45,8 +45,13 @@ jobs:
             "quay.io/opendatahub/kubeflow-notebook-controller:1.9-${GIT_HASH}"
             "quay.io/opendatahub/odh-notebook-controller:1.9-${GIT_HASH}"
           )
-          # Poll for image readiness total timeout=15m
-          MAX_ATTEMPTS=10
+
+          # Sleep for 5 minutes before starting polling
+          echo "Sleeping for 5 minutes before starting polling..."
+          sleep 300
+
+          # Poll for image readiness total timeout=20m
+          MAX_ATTEMPTS=13
           SLEEP_DURATION=90
           for image in "${IMAGES[@]}"; do
             for (( i=1; i<=MAX_ATTEMPTS; i++ )); do
@@ -105,9 +110,9 @@ jobs:
             exit 1
           fi
 
-          # Polling loop to wait for the PR to be merged total timeout=1h
-          MAX_ATTEMPTS=10
-          SLEEP_DURATION=360
+          # Polling loop to wait for the PR to be merged total timeout=5h
+          MAX_ATTEMPTS=30
+          SLEEP_DURATION=600
 
           for (( i=1; i<=MAX_ATTEMPTS; i++ )); do
             echo "Checking if PR #$PR_NUMBER is merged (Attempt $i/$MAX_ATTEMPTS)..."


### PR DESCRIPTION
Increase timeouts as they were too short.

Follow up for: https://github.com/opendatahub-io/kubeflow/pull/469

It cause this: https://github.com/opendatahub-io/kubeflow/actions/runs/12072896670/job/33667879991 

## Description
<!--- Describe your changes in detail -->
![image](https://github.com/user-attachments/assets/31de390b-f028-41f9-bb8a-9502646c14d3)

The initial timeout was 15 mins timeout and at the end the builds wanted 17 mins to be ready :rofl:   so now it has been increased 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
