### PR TITLE
Enable GHAs for v1.9-branch

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -3,6 +3,9 @@ name: Code static analysis
 "on":
   push:
   pull_request:
+    branches:
+      - main
+      - v1.9-branch
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/notebook_controller_integration_test.yaml
+++ b/.github/workflows/notebook_controller_integration_test.yaml
@@ -2,6 +2,9 @@ name: Notebook Controller Integration Test
 on:
   push:
   pull_request:
+    branches:
+      - main
+      - v1.9-branch
     paths:
       - components/notebook-controller/**
   workflow_dispatch:

--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -2,6 +2,9 @@ name: Run Notebook Controller unit tests
 on:
   push:
   pull_request:
+    branches:
+      - main
+      - v1.9-branch
     paths:
       - components/notebook-controller/**
   workflow_dispatch:

--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -2,6 +2,9 @@ name: ODH Notebook Controller Integration Test
 on:
   push:
   pull_request:
+    branches:
+      - main
+      - v1.9-branch
     paths:
       - .github/workflows/odh_notebook_controller_integration_test.yaml
       - components/notebook-controller/**

--- a/.github/workflows/odh_notebook_controller_unit_test.yaml
+++ b/.github/workflows/odh_notebook_controller_unit_test.yaml
@@ -2,6 +2,9 @@ name: Run ODH Notebook Controller unit tests
 on:
   push:
   pull_request:
+    branches:
+      - main
+      - v1.9-branch
     paths:
       - components/odh-notebook-controller/**
   workflow_dispatch:


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-16396 (Missing GHAs)
## Description
<!--- Describe your changes in detail -->
With this PR we can enable the GHAs to run also on v1.9-branch. 

We need the these gha tests to run before sign off the release/sync. Currently, wasn't enabled https://github.com/opendatahub-io/kubeflow/pull/482 

## How Has This Been Tested?
Once this PR get merged, we need to close and reopen this PR https://github.com/opendatahub-io/kubeflow/pull/482 to check if it will take effect of the latest changes. 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
