### PR TITLE
RHOAIENG-11142: chore(test): Integrate Codecov coverage reporting for notebook-controller

### DIFF
--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -28,3 +28,10 @@ jobs:
       run: |
         cd components/notebook-controller
         make test
+
+    - name: Upload results to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./components/notebook-controller/cover.out
+        disable_search: true


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-11142

## Description

This commit integrates Codecov into our testing process by publishing our coverage report generated during `make test` to Codecov via the official `codecov/codecov-action` GHA.

The `CODECOV_TOKEN` was previously uploaded to our GH repository as a secret (and copied to the Dependabot Secrets as well) by a repo admin:
- https://redhat-internal.slack.com/archives/C060A5FJEAD/p1733334721701649

Please be aware of functionality **NOT** included in this initial PR (that may be added in the future):
- unit test results are not being shipped to `Codecov` (even though that capability is supported)
- a `.codecov.yml` file is presently not included.  this could come as a fast-follow after the team gets a "feel" for `Codecov` - but I think its a bit premature to take my personal opinions to create such a file.  Example `odh-dashboard` config can be seen here:
    - https://github.com/opendatahub-io/odh-dashboard/blob/main/.codecov.yml

The `Codecov` integration was added to the `notebook_controller_unit_test.yaml` GHA - which is already configured to execute on `pull_request` and `push` triggers.  As such, no additional modification was necessary.

:warning: It should be noted that the `make test` target as configured in upstream is presently incorrect.  The 2 different `go test` executions are redundant - and the 2nd invocation (targetting only the `./controller/...` scope, actually overwrites the `cover.out` file initially generated by the 1st invocation.  However, the fix for this should come from upstream.. I will open up a PR against upstream at which point it will flow through to `odh` whenever its merged and we sync.

Related-to: https://issues.redhat.com/browse/RHOAIENG-11142


## How Has This Been Tested?

Testing of the `codecov/codecov-action` GHA was performed against a repo in my personal organization:
- https://github.com/andyatmiami/dependabot-demo/blob/main/.github/workflows/codecov.yml

Observations and outcomes were reported in Slack:
- https://redhat-internal.slack.com/archives/C060A5FJEAD/p1733432564689729?thread_ts=1733334721.701649&cid=C060A5FJEAD

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
