### PR TITLE
NO-ISSUE: chore(gha): run tests in a gha when gha itself is modified in a pr

### DIFF
--- a/.github/workflows/notebook_controller_integration_test.yaml
+++ b/.github/workflows/notebook_controller_integration_test.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - v1.9-branch
     paths:
+      - .github/workflows/notebook_controller_integration_test.yaml
       - components/notebook-controller/**
   workflow_dispatch:
 

--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - v1.9-branch
     paths:
+      - .github/workflows/notebook_controller_unit_test.yaml
       - components/notebook-controller/**
   workflow_dispatch:
 

--- a/.github/workflows/odh_notebook_controller_unit_test.yaml
+++ b/.github/workflows/odh_notebook_controller_unit_test.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - v1.9-branch
     paths:
+      - .github/workflows/odh_notebook_controller_unit_test.yaml
       - components/odh-notebook-controller/**
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

This is a followup to a previous pr that added this to `.github/workflows/odh_notebook_controller_integration_test.yaml` odh-notebook-controller integration tests already

* https://github.com/opendatahub-io/kubeflow/pull/398

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
