### PR TITLE
RHOAIENG-11142: chore(test): Integrate Codecov coverage reporting for odh-notebook-controller

### DIFF
--- a/.github/workflows/odh_notebook_controller_unit_test.yaml
+++ b/.github/workflows/odh_notebook_controller_unit_test.yaml
@@ -27,3 +27,10 @@ jobs:
       run: |
         cd components/odh-notebook-controller
         make test
+
+    - name: Upload results to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./components/odh-notebook-controller/cover-rbac-false.out,./components/odh-notebook-controller/cover-rbac-true.out
+        disable_search: true

--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -94,12 +94,12 @@ test-with-rbac-false: manifests generate fmt vet envtest ## Run tests.
 	export SET_PIPELINE_RBAC=false && \
 	ACK_GINKGO_DEPRECATIONS=1.16.5 \
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
-		go test ./controllers/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover.out
+		go test ./controllers/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover-rbac-false.out
 test-with-rbac-true: manifests generate fmt vet envtest ## Run tests.
 	export SET_PIPELINE_RBAC=true && \
 	ACK_GINKGO_DEPRECATIONS=1.16.5 \
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
-		go test ./controllers/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover.out
+		go test ./controllers/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover-rbac-true.out
 
 ##@ Build
 


### PR DESCRIPTION
## Description

This commit integrates Codecov into our testing process by publishing our coverage report generated during `make test` to Codecov via the official `codecov/codecov-action` GHA.

The `CODECOV_TOKEN` was previously uploaded to our GH repository as a secret (and copied to the Dependabot Secrets as well) by a repo admin:
- https://redhat-internal.slack.com/archives/C060A5FJEAD/p1733334721701649

Please be aware of functionality **NOT** included in this initial PR (that may be added in the future):
- unit test results are not being shipped to `Codecov` (even though that capability is supported)
- a `.codecov.yml` file is presently not included.  this could come as a fast-follow after the team gets a "feel" for `Codecov` - but I think its a bit premature to take my personal opinions to create such a file.  Example `odh-dashboard` config can be seen here:
    - https://github.com/opendatahub-io/odh-dashboard/blob/main/.codecov.yml

The `Codecov` integration was added to the `odh_notebook_controller_unit_test.yaml` GHA - which is already configured to execute on `pull_request` and `push` triggers.  As such, no additional modification was necessary.

:warning: It should be noted that the `make test` target was modifed to ensure the coverage files for the 2 respective invocations of `go test` wrote to unique output files to prevent information loss.  `*.out` files are already ignored via `.gitignore`, so no problems there.  Also, Codecov claims to support report merging automatically - so this should cause no issues:
- https://docs.codecov.com/docs/merging-reports

Related-to: https://issues.redhat.com/browse/RHOAIENG-11142

## How Has This Been Tested?

Testing of the `codecov/codecov-action` GHA was performed against a repo in my personal organization:
- https://github.com/andyatmiami/dependabot-demo/blob/main/.github/workflows/codecov.yml

Observations and outcomes were reported in Slack:
- https://redhat-internal.slack.com/archives/C060A5FJEAD/p1733432564689729?thread_ts=1733334721.701649&cid=C060A5FJEAD

`make test` was ran locally to ensure renaming output files didn't introduce any regressions

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
