### PR TITLE
chore(owners): add `andyatmiami` as reviewer and approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+  - andyatmiami
   - atheo89
   - caponetto
   - harshad16
@@ -7,6 +8,7 @@ approvers:
   - paulovmr
 
 reviewers:
+  - andyatmiami
   - atheo89
   - caponetto
   - dibryant


### PR DESCRIPTION
## Description
Adding my own GH handle (`andyatmiami`) to the `approvers` and `reviewers` section of `OWNERS` so I can be more self-sufficient in working issues alongside the team.

## How Has This Been Tested?
no testing required

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
