### PR TITLE
RHOAIENG-17634: ref(odh-nbc/tests): create Gomega custom matcher for comparing CRs in kubeflow notebooks tests

### DIFF
--- a/components/odh-notebook-controller/controllers/matchers_test.go
+++ b/components/odh-notebook-controller/controllers/matchers_test.go
@@ -1,0 +1,52 @@
+package controllers
+
+import (
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/onsi/gomega/types"
+)
+
+// See https://onsi.github.io/gomega/#adding-your-own-matchers
+
+// BeMatchingK8sResource is a custom Gomega matcher that compares using `comparator` function and reports differences using
+// [cmp.Diff]. It attempts to minimize the diff (TODO(jdanek): not yet implemented) to only include those entries that cause `comparator` to fail.
+//
+// Use this to replace assertions such as
+// > Expect(CompareNotebookRoutes(*route, expectedRoute)).Should(BeTrueBecause(cmp.Diff(*route, expectedRoute)))
+// with
+// > Expect(*route).To(BeMatchingK8sResource(expectedRoute, CompareNotebookRoutes))
+//
+// NOTE: The diff minimization functionality (TODO(jdanek): not yet implemented) is best-effort. It is designed to never under-approximate, but over-approximation is possible.
+// NOTE2: Using [gcustom.MakeMatcher] is not possible because it does not conveniently allow running [cmp.Diff] at the time of failure message generation.
+func BeMatchingK8sResource[T any](expected T, comparator func(T, T) bool) types.GomegaMatcher {
+	return &beMatchingK8sResource[T]{
+		expected:   expected,
+		comparator: comparator,
+	}
+}
+
+type beMatchingK8sResource[T any] struct {
+	expected   T
+	comparator func(r1 T, r2 T) bool
+}
+
+var _ types.GomegaMatcher = &beMatchingK8sResource[any]{}
+
+func (m *beMatchingK8sResource[T]) Match(actual interface{}) (success bool, err error) {
+	actualT, ok := actual.(T)
+	if !ok {
+		return false, fmt.Errorf("BeMatchingK8sResource matcher expects two objects of the same type")
+	}
+
+	return m.comparator(m.expected, actualT), nil
+}
+
+func (m *beMatchingK8sResource[T]) FailureMessage(actual interface{}) (message string) {
+	diff := cmp.Diff(actual, m.expected)
+	return fmt.Sprintf("Expected\n\t%#v\nto compare identical to\n\t%#v\nbut it differs in\n%s", actual, m.expected, diff)
+}
+
+func (m *beMatchingK8sResource[T]) NegatedFailureMessage(actual interface{}) (message string) {
+	diff := cmp.Diff(actual, m.expected)
+	return fmt.Sprintf("Expected\n\t%#v\nto not compare identical to\n\t%#v\nit differs in\n%s", actual, m.expected, diff)
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-17634

## Description

This is the initial refactor to use a new custom matcher. The matcher has no new features compared to the old way.

I will do the meaningful-diffs part as a next PR (under the same Jira number). Currently (same as before) the diff also includes irrelevant parts of the struct under comparison.

## How Has This Been Tested?

Here's how a failure is reported

https://github.com/opendatahub-io/kubeflow/blob/330d81632ce19d2baf4430b1b701c9a8a738c9ee/components/odh-notebook-controller/controllers/notebook_controller_test.go#L112-L121

```
    Should reconcile the Route when modified [It]
    /Users/jdanek/IdeaProjects/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:105

    Expected
        v1.Route{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"test-notebook", GenerateName:"", Namespace:"default", SelfLink:"", UID:"bd00712a-9bff-4c3f-819e-525f29891761", ResourceVersion:"211", Generation:3, CreationTimestamp:time.Date(2025, time.January, 10, 13, 40, 31, 0, time.Local), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"notebook-name":"test-notebook"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference{v1.OwnerReference{APIVersion:"kubeflow.org/v1", Kind:"Notebook", Name:"test-notebook", UID:"bec15653-6c39-4e01-b93e-5bdca8c332e8", Controller:(*bool)(0x1400037e8de), BlockOwnerDeletion:(*bool)(0x1400037e8dd)}}, Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"controllers.test", Operation:"Update", APIVersion:"route.openshift.io/v1", Time:time.Date(2025, time.January, 10, 13, 40, 37, 0, time.Local), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0x14000fec1c8), Subresource:""}}}, Spec:v1.RouteSpec{Host:"", Subdomain:"", Path:"", To:v1.RouteTargetReference{Kind:"Service", Name:"test-notebook", Weight:(*int32)(0x1400037e948)}, AlternateBackends:[]v1.RouteTargetReference(nil), Port:(*v1.RoutePort)(0x14000034d00), TLS:(*v1.TLSConfig)(0x140003aba40), WildcardPolicy:"None"}, Status:v1.RouteStatus{Ingress:[]v1.RouteIngress{}}}
    to compare identical to
        v1.Route{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"test-notebook", GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"notebook-name":"test-notebook"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1.RouteSpec{Host:"", Subdomain:"", Path:"", To:v1.RouteTargetReference{Kind:"No Such Service", Name:"test-notebook", Weight:(*int32)(0x1400000ee90)}, AlternateBackends:[]v1.RouteTargetReference(nil), Port:(*v1.RoutePort)(0x14000590340), TLS:(*v1.TLSConfig)(0x1400005c600), WildcardPolicy:"None"}, Status:v1.RouteStatus{Ingress:[]v1.RouteIngress{}}}
    but it differs in
      v1.Route{
        TypeMeta: {},
        ObjectMeta: v1.ObjectMeta{
                ... // 2 identical fields
                Namespace:                  "default",
                SelfLink:                   "",
    -           UID:                        "bd00712a-9bff-4c3f-819e-525f29891761",
    +           UID:                        "",
    -           ResourceVersion:            "211",
    +           ResourceVersion:            "",
    -           Generation:                 3,
    +           Generation:                 0,
    -           CreationTimestamp:          v1.Time{Time: s"2025-01-10 13:40:31 +0100 CET"},
    +           CreationTimestamp:          v1.Time{},
                DeletionTimestamp:          nil,
                DeletionGracePeriodSeconds: nil,
                Labels:                     {"notebook-name": "test-notebook"},
                Annotations:                nil,
    -           OwnerReferences: []v1.OwnerReference{
    -                   {
    -                           APIVersion:         "kubeflow.org/v1",
    -                           Kind:               "Notebook",
    -                           Name:               "test-notebook",
    -                           UID:                "bec15653-6c39-4e01-b93e-5bdca8c332e8",
    -                           Controller:         &true,
    -                           BlockOwnerDeletion: &true,
    -                   },
    -           },
    +           OwnerReferences: nil,
                Finalizers:      nil,
    -           ManagedFields: []v1.ManagedFieldsEntry{
    -                   {
    -                           Manager:    "controllers.test",
    -                           Operation:  "Update",
    -                           APIVersion: "route.openshift.io/v1",
    -                           Time:       s"2025-01-10 13:40:37 +0100 CET",
    -                           FieldsType: "FieldsV1",
    -                           FieldsV1:   s`{"f:metadata":{"f:labels":{".":{},"f:notebook-name":{}},"f:owner`...,
    -                   },
    -           },
    +           ManagedFields: nil,
        },
        Spec: v1.RouteSpec{
                Host:      "",
                Subdomain: "",
                Path:      "",
                To: v1.RouteTargetReference{
    -                   Kind:   "Service",
    +                   Kind:   "No Such Service",
                        Name:   "test-notebook",
                        Weight: &100,
                },
                AlternateBackends: nil,
                Port:              &{TargetPort: {Type: 1, StrVal: "http-test-notebook"}},
                ... // 2 identical fields
        },
        Status: {Ingress: {}},
      }
    

    /Users/jdanek/IdeaProjects/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:120
```

In the above example, the only really relevant part of the diff is

```
    -                   Kind:   "Service",
    +                   Kind:   "No Such Service",
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
