### PR TITLE
Remove JUPYTER_IMAGE env variable from Notebook CR 

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -611,13 +611,6 @@ func SetContainerImageFromRegistry(ctx context.Context, config *rest.Config, not
 											imageHash := items[0].(map[string]interface{})["dockerImageReference"].(string)
 											// Update the Containers[i].Image value
 											notebook.Spec.Template.Spec.Containers[i].Image = imageHash
-											// Update the JUPYTER_IMAGE environment variable with the image selection for example "jupyter-datascience-notebook:2023.2"
-											for i, envVar := range container.Env {
-												if envVar.Name == "JUPYTER_IMAGE" {
-													container.Env[i].Value = imageSelection
-													break
-												}
-											}
 											imagestreamFound = true
 											break
 										}


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-7551
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As the JUPYTER_IMAGE env variable is not used, we can clean up our code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Should be tested in conjunction with dashboard PR changes:

1. Modify rhoai-operator DSC .yaml with devFlags that correspond to workbench changes
```
    workbenches:
      devFlags:
        manifests:
          - contextDir: components/odh-notebook-controller/config
            uri: 'https://github.com/atheo89/kubeflow/tarball/RHOAIENG-7551'
      managementState: Managed
````

2. Modify rhods-dashboard deployment to use  `quay.io/opendatahub/odh-dashboard:pr-3407` image

3. Deploy a workbench on RHOAI. Run the following command `env | grep JUPYTER_IMAGE` on workbench's terminal to ensure that the JUPYTER_IMAGE environment variable is not present. As well as should check on the Notebook CR that there is no `env.JUPYTER_IMAGE`. 
 
4. Drop the internal registry and re-run step 3.
`oc edit configs.imageregistry.operator.openshift.io -n openshift-image-registry`  change `spec.ManagmentState` to `Removed`

5. Inspect the `odh-notebook-controller` deployment logs for suspicious entries related to `JUPYTER_IMAGE`. Check the logs of the odh-notebook-controller deployment. Ensure that there are no logs/errors mentioning JUPYTER_IMAGE.


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
