### PR TITLE
Populate Elyra runtime images configMap from runtime images imagestream manifests and mounts it on the Notebook CR

### DIFF
--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -313,3 +313,15 @@ jobs:
           kubectl describe pods
           kubectl logs minimal-notebook-0
           kubectl describe routes
+
+      - name: Print logs (again, at the end)
+        if: "!cancelled()"
+        run: |
+          kubectl describe pods -n kubeflow -l app=notebook-controller
+          kubectl logs -n kubeflow -l app=notebook-controller
+
+      - name: Print ODH logs (again, at the end)
+        if: "!cancelled()"
+        run: |
+          kubectl describe pods -n opendatahub -l app=odh-notebook-controller
+          kubectl logs -n opendatahub -l app=odh-notebook-controller

--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -125,8 +125,31 @@ jobs:
                     x-kubernetes-preserve-unknown-fields: true
                 served: true
                 storage: true
+          ---
+          apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            annotations:
+              crd/fake: "true"
+            name: imagestreams.image.openshift.io
+          spec:
+            group: image.openshift.io
+            names:
+              kind: ImageStream
+              listKind: ImageStreamList
+              singular: imagestream
+              plural: imagestreams
+            scope: Namespaced
+            versions:
+              - name: v1
+                schema:
+                  openAPIV3Schema:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                served: true
+                storage: true
           EOF
-
+          
       - name: Build & Apply manifests
         run: |
           set -x

--- a/components/odh-notebook-controller/config/crd/external/imagestream.openshift.io_imagestreams.yaml
+++ b/components/odh-notebook-controller/config/crd/external/imagestream.openshift.io_imagestreams.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    crd/fake: "true"
+  name: imagestreams.image.openshift.io
+spec:
+  group: image.openshift.io
+  names:
+    kind: ImageStream
+    listKind: ImageStreamList
+    singular: imagestream
+    plural: imagestreams
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,6 +61,7 @@ type OpenshiftNotebookReconciler struct {
 	Namespace string
 	Scheme    *runtime.Scheme
 	Log       logr.Logger
+	Config    *rest.Config
 }
 
 // ClusterRole permissions
@@ -187,6 +189,12 @@ func (r *OpenshiftNotebookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Call the Network Policies reconciler
 	err = r.ReconcileAllNetworkPolicies(notebook, ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Create/Watch and Update the pipeline-runtime-image ConfigMap on Notebook's Namspace
+	err = r.EnsureNotebookConfigMap(notebook, ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -598,6 +598,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					"notebooks.opendatahub.io/inject-oauth":     "true",
 					"notebooks.opendatahub.io/foo":              "bar",
 					"notebooks.opendatahub.io/oauth-logout-url": "https://example.notebook-url/notebook/" + Namespace + "/" + Name,
+					"kubeflow-resource-stopped":                 "odh-notebook-controller-lock",
 				},
 			},
 			Spec: nbv1.NotebookSpec{

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -698,6 +698,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			// Only do changes that your webhook or controller DOES restore:
 			notebook.Spec.Template.Spec.ServiceAccountName = "foo"
 			notebook.Spec.Template.Spec.Containers[1].Image = "bar"
+			notebook.Spec.Template.Spec.Volumes[1].VolumeSource = corev1.VolumeSource{}
 
 			Expect(cli.Update(ctx, notebook)).Should(Succeed())
 

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -87,59 +87,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		route := &routev1.Route{}
 
-		It("Should create and mount the runtime images ConfigMap in the Notebook's pod", func() {
-			const (
-				Name          = "test-notebook-runtime"
-				Namespace     = "default"
-				configMapName = "pipeline-runtime-images"
-				mountPath     = "/opt/app-root/pipeline-runtimes/"
-				volumeName    = "runtime-images"
-			)
-
-			ctx := context.Background()
-
-			By("Creating a ConfigMap before the Notebook")
-			runtimeImagesCM := createRuntimeImagesConfigMap(configMapName, Namespace, map[string]string{
-				"runtime-1.yaml": "content-1",
-				"runtime-2.yaml": "content-2",
-			})
-
-			Expect(cli.Create(ctx, runtimeImagesCM)).Should(Succeed())
-			defer func() {
-				if err := cli.Delete(ctx, runtimeImagesCM); err != nil {
-					GinkgoT().Logf("Failed to delete ConfigMap: %v", err)
-				}
-			}()
-
-			By("Creating a new Notebook with the ConfigMap mounted")
-			notebook := createNotebook(Name, Namespace)
-
-			notebook.Spec.Template.Spec.Volumes = append(notebook.Spec.Template.Spec.Volumes, corev1.Volume{
-				Name: volumeName,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
-						Optional:             pointer.Bool(true),
-					},
-				},
-			})
-
-			notebook.Spec.Template.Spec.Containers[0].VolumeMounts = append(
-				notebook.Spec.Template.Spec.Containers[0].VolumeMounts,
-				corev1.VolumeMount{
-					Name:      volumeName,
-					MountPath: mountPath,
-					ReadOnly:  true,
-				},
-			)
-
-			Expect(cli.Create(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
-
-			By("Checking that the ConfigMap is correctly mounted in the Notebook's pod")
-			checkConfigMapMount(ctx, Namespace, Name, configMapName, mountPath)
-		})
-
 		It("Should create a Route to expose the traffic externally", func() {
 			ctx := context.Background()
 
@@ -1184,55 +1131,4 @@ func checkCertConfigMap(ctx context.Context, namespace string, configMapName str
 		}
 	}
 	Expect(certificatesFound).Should(Equal(expNumberCerts), "Number of parsed certificates don't match expected one:\n"+certData)
-}
-
-func createRuntimeImagesConfigMap(name, namespace string, data map[string]string) *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"opendatahub.io/managed-by": "workbenches",
-			},
-		},
-		Data: data,
-	}
-}
-
-func checkConfigMapMount(ctx context.Context, namespace, notebookName, configMapName, mountPath string) {
-	notebook := &nbv1.Notebook{}
-	key := types.NamespacedName{Name: notebookName, Namespace: namespace}
-	Expect(cli.Get(ctx, key, notebook)).Should(Succeed())
-
-	// Debug: Print all VolumeMounts in the Notebook Spec
-	for _, container := range notebook.Spec.Template.Spec.Containers {
-		GinkgoT().Logf("Container: %s, VolumeMounts: %+v", container.Name, container.VolumeMounts)
-	}
-
-	// Debug: Print all Volumes in the Notebook Spec
-	GinkgoT().Logf("Notebook Volumes: %+v", notebook.Spec.Template.Spec.Volumes)
-
-	expectedVolumeMount := corev1.VolumeMount{
-		Name:      "runtime-images",
-		MountPath: mountPath,
-		ReadOnly:  true,
-	}
-
-	expectedVolume := corev1.Volume{
-		Name: "runtime-images",
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
-				Optional:             pointer.Bool(true),
-			},
-		},
-	}
-
-	// Check for Volume Mounts
-	Expect(notebook.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(expectedVolumeMount),
-		"Expected volume mount not found!")
-
-	// Check for Volumes
-	Expect(notebook.Spec.Template.Spec.Volumes).To(ContainElement(expectedVolume),
-		"Expected volume not found!")
 }

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -677,8 +677,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		})
 
 		It("Should remove the reconciliation lock annotation", func() {
-			By("By waiting before checking the reconciliation lock annotation removal")
-			time.Sleep(2 * time.Second)
 
 			By("By checking that the annotation lock annotation is not present")
 			delete(expectedNotebook.Annotations, culler.STOP_ANNOTATION)

--- a/components/odh-notebook-controller/controllers/notebook_runtime.go
+++ b/components/odh-notebook-controller/controllers/notebook_runtime.go
@@ -1,0 +1,248 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/go-logr/logr"
+	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+const configMapName = "pipeline-runtime-images"
+const mountPath = "/opt/app-root/pipeline-runtimes/"
+const volumeName = "runtime-images"
+
+// checkConfigMapExists verifies if a ConfigMap exists in the namespace.
+func (r *OpenshiftNotebookReconciler) checkConfigMapExists(ctx context.Context, configMapName, namespace string) (bool, error) {
+	configMap := &corev1.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: namespace}, configMap)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return false, nil // ConfigMap not found
+		}
+		return false, err // Some other error occurred
+	}
+	//r.Log.Info("ConfigMap found", "ConfigMap.Name", configMapName, "Namespace", namespace)
+	return true, nil // ConfigMap exists
+}
+
+func (r *OpenshiftNotebookReconciler) syncRuntimeImagesConfigMap(ctx context.Context, notebookNamespace string) error {
+	log := r.Log.WithValues("namespace", notebookNamespace)
+
+	// Create a dynamic client
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Error(err, "Error creating cluster config")
+		return err
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		log.Error(err, "Error creating dynamic client")
+		return err
+	}
+
+	// Define GroupVersionResource for ImageStreams
+	ims := schema.GroupVersionResource{
+		Group:    "image.openshift.io",
+		Version:  "v1",
+		Resource: "imagestreams",
+	}
+
+	// Fetch ImageStreams from "redhat-ods-applications" namespace
+	imageStreamNamespace := "redhat-ods-applications"
+	imagestreams, err := dynamicClient.Resource(ims).Namespace(imageStreamNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Error(err, "Failed to list ImageStreams", "Namespace", imageStreamNamespace)
+		return err
+	}
+
+	// Prepare data for ConfigMap
+	data := make(map[string]string)
+	for _, item := range imagestreams.Items {
+		labels := item.GetLabels()
+		if labels["opendatahub.io/runtime-image"] == "true" {
+			tags, found, err := unstructured.NestedSlice(item.Object, "spec", "tags")
+			if err != nil || !found {
+				log.Error(err, "Failed to extract tags from ImageStream", "ImageStream", item.GetName())
+				continue
+			}
+
+			for _, tag := range tags {
+				tagMap, ok := tag.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				// Extract metadata annotation
+				annotations, found, err := unstructured.NestedMap(tagMap, "annotations")
+				if err != nil || !found {
+					annotations = map[string]interface{}{}
+				}
+
+				metadataRaw, ok := annotations["opendatahub.io/runtime-image-metadata"].(string)
+				if !ok || metadataRaw == "" {
+					metadataRaw = "[]"
+				}
+
+				// Parse metadata
+				metadataParsed := parseRuntimeImageMetadata(metadataRaw)
+				displayName := extractDisplayName(metadataParsed)
+
+				// Construct the key name
+				if displayName != "" {
+					formattedName := formatKeyName(displayName)
+					data[formattedName] = metadataParsed
+				}
+			}
+		}
+	}
+
+	// Create or update the ConfigMap in the Notebook's namespace
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: notebookNamespace,
+			Labels:    map[string]string{"opendatahub.io/managed-by": "workbenches"},
+		},
+		Data: data,
+	}
+
+	configMapExists, err := r.checkConfigMapExists(ctx, configMapName, notebookNamespace)
+	if err != nil {
+		log.Error(err, "Error checking if ConfigMap exists", "ConfigMap.Name", configMapName)
+		return err
+	}
+
+	if configMapExists {
+		existingConfigMap := &corev1.ConfigMap{}
+		if err := r.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: notebookNamespace}, existingConfigMap); err != nil {
+			log.Error(err, "Failed to get existing ConfigMap", "ConfigMap.Name", configMapName)
+			return err
+		}
+
+		if !jsonEqual(existingConfigMap.Data, data) {
+			existingConfigMap.Data = data
+			if err := r.Update(ctx, existingConfigMap); err != nil {
+				log.Error(err, "Failed to update ConfigMap", "ConfigMap.Name", configMapName)
+				return err
+			}
+			log.Info("Updated existing ConfigMap with new runtime images", "ConfigMap.Name", configMapName)
+		}
+	} else {
+		if err := r.Create(ctx, configMap); err != nil {
+			log.Error(err, "Failed to create ConfigMap", "ConfigMap.Name", configMapName)
+			return err
+		}
+		log.Info("Created new ConfigMap for runtime images", "ConfigMap.Name", configMapName)
+	}
+
+	return nil
+}
+
+// jsonEqual compares two JSON-like maps for equality.
+func jsonEqual(a, b map[string]string) bool {
+	aBytes, _ := json.Marshal(a)
+	bBytes, _ := json.Marshal(b)
+	return string(aBytes) == string(bBytes)
+}
+
+func extractDisplayName(metadata string) string {
+	var metadataMap map[string]interface{}
+	err := json.Unmarshal([]byte(metadata), &metadataMap)
+	if err != nil {
+		return ""
+	}
+	displayName, ok := metadataMap["display_name"].(string)
+	if !ok {
+		return ""
+	}
+	return displayName
+}
+
+func formatKeyName(displayName string) string {
+	replacer := strings.NewReplacer(" ", "-", "(", "", ")", "")
+	return strings.ToLower(replacer.Replace(displayName)) + ".json"
+}
+
+// parseRuntimeImageMetadata extracts the first object from the JSON array
+func parseRuntimeImageMetadata(rawJSON string) string {
+	var metadataArray []map[string]interface{}
+
+	err := json.Unmarshal([]byte(rawJSON), &metadataArray)
+	if err != nil || len(metadataArray) == 0 {
+		return "{}" // Return empty JSON object if parsing fails
+	}
+
+	// Convert first object back to JSON
+	metadataJSON, err := json.Marshal(metadataArray[0])
+	if err != nil {
+		return "{}"
+	}
+
+	return string(metadataJSON)
+}
+
+func (r *OpenshiftNotebookReconciler) EnsureNotebookConfigMap(notebook *nbv1.Notebook, ctx context.Context) error {
+	return r.syncRuntimeImagesConfigMap(ctx, notebook.Namespace)
+}
+
+func MountPipelineRuntimeImages(notebook *nbv1.Notebook, log logr.Logger) error {
+
+	// Define the volume
+	configVolume := corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: configMapName,
+				},
+			},
+		},
+	}
+
+	// Define the volume mount
+	volumeMount := corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: mountPath,
+	}
+
+	// Append the volume if it does not already exist
+	volumes := &notebook.Spec.Template.Spec.Volumes
+	volumeExists := false
+	for _, v := range *volumes {
+		if v.Name == volumeName {
+			volumeExists = true
+			break
+		}
+	}
+	if !volumeExists {
+		*volumes = append(*volumes, configVolume)
+	}
+
+	log.Info("Injecting runtime-images volume into notebook", "notebook", notebook.Name, "namespace", notebook.Namespace)
+
+	// Append the volume mount to all containers
+	for i, container := range notebook.Spec.Template.Spec.Containers {
+		mountExists := false
+		for _, vm := range container.VolumeMounts {
+			if vm.Name == volumeName {
+				mountExists = true
+				break
+			}
+		}
+		if !mountExists {
+			notebook.Spec.Template.Spec.Containers[i].VolumeMounts = append(container.VolumeMounts, volumeMount)
+		}
+	}
+
+	return nil
+}

--- a/components/odh-notebook-controller/controllers/notebook_runtime.go
+++ b/components/odh-notebook-controller/controllers/notebook_runtime.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -195,6 +196,7 @@ func MountPipelineRuntimeImages(notebook *nbv1.Notebook, log logr.Logger) error 
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: configMapName,
 				},
+				Optional: ptr.To(true),
 			},
 		},
 	}

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -28,6 +28,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/go-logr/logr"
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	"github.com/kubeflow/kubeflow/components/notebook-controller/pkg/culler"

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -300,12 +300,6 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
-		// Mount ConfigMap pipeline-runtime-images as runtime-images
-		err = MountPipelineRuntimeImages(notebook, log)
-		if err != nil {
-			return admission.Errored(http.StatusInternalServerError, err)
-		}
-
 	}
 
 	// Check Imagestream Info both on create and update operations
@@ -318,6 +312,12 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 
 		// Mount ca bundle on notebook creation and update
 		err = CheckAndMountCACertBundle(ctx, w.Client, notebook, log)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+
+		// Mount ConfigMap pipeline-runtime-images as runtime-images
+		err = MountPipelineRuntimeImages(notebook, log, w.Client, ctx)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -298,6 +298,12 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
 
+		// Mount ConfigMap pipeline-runtime-images as runtime-images
+		err = MountPipelineRuntimeImages(notebook, log)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
+
 	}
 
 	// Check Imagestream Info both on create and update operations

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -187,6 +187,7 @@ var _ = BeforeSuite(func() {
 		Log:       ctrl.Log.WithName("controllers").WithName("notebook-controller"),
 		Scheme:    mgr.GetScheme(),
 		Namespace: odhNotebookControllerTestNamespace,
+		Config:    mgr.GetConfig(),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -128,6 +128,7 @@ func main() {
 		Log:       ctrl.Log.WithName("controllers").WithName("Notebook"),
 		Namespace: namespace,
 		Scheme:    mgr.GetScheme(),
+		Config:    mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Notebook")
 		os.Exit(1)


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/RHOAIENG-19051

Related PRs for this workload: 
New set of runtime ImageStreams: https://github.com/opendatahub-io/notebooks/pull/930
Unwire .json files from the Datascience Notebook: https://github.com/opendatahub-io/notebooks/pull/909 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR add a new notebook_runtime script where includes the logic to create/watch/update a new ConfigMap the `pipeline-runtime-images` from the runtime images imagesStreams (related [PR](https://github.com/opendatahub-io/notebooks/pull/888)) and mount it as volume with the name `/opt/app-root/pipeline-runtimes/` on the notebook CR when is getting created.

NOTE: We don't make a use of devFlag for this feature, as it doesn't seem to have any issue with Applications -> Embeded-> JupyterLab spinup notebook


## How Has This Been Tested?


1. Update the RHOAI DSC with the following:
```
    workbenches:
      devFlags:
        manifests:
          - contextDir: components/odh-notebook-controller/config
            sourcePath: ''
            uri: 'https://github.com/atheo89/kubeflow/archive/rhoaieng-19050-configmap-generator.tar.gz'
          - contextDir: manifests
            sourcePath: ''
            uri: 'https://github.com/opendatahub-io/notebooks/archive/main.tar.gz'
      managementState: Managed
      
```
2. Import the `quay.io/rh_ee_atheodor/workbench-images@sha256:f2bc105afab97575007a5743e39cc4c045fa276ba8612b6a8241758d48711913` notebook (Includes the changes from this [PR](https://github.com/opendatahub-io/notebooks/pull/909)) This is a notebook without the .json runtimes in it. 

3. Spin up this `Custom Datascience` notebook via UI
Click on the left side menu and click this icon. 
![image](https://github.com/user-attachments/assets/47e26125-8e9c-496e-b11e-d9a095a621bf)
 
You should see the runtimes mounted like below:
![image](https://github.com/user-attachments/assets/d753293f-147c-4685-81f5-a296c679d62f)

On the Back-end side: 
4. Inspect the logs on the odh-notebook-controller to find the related logs on the configMap creation and the mounting, like below. 

```
...
{"level":"info","ts":"2025-02-20T10:13:31Z","logger":"controllers.Notebook","msg":"Created new ConfigMap for runtime images","namespace":"atheo","ConfigMap.Name":"pipeline-runtime-images"}
...
{"level":"info","ts":"2025-02-20T10:13:31Z","logger":"controllers.Notebook","msg":"Injecting runtime-images volume into notebook","notebook":"t1","namespace":"atheo","notebook":"t1","namespace":"atheo"}
...

```

5. Check on the notebook pod statefullset for the config map, press on it to inspect also the data from this configMap
![image](https://github.com/user-attachments/assets/5f448eb2-ab89-4a94-86bb-4c7076e5fcb3)

6. Check as well on the notebook CR to evaluate the mounting, as is on the bellow image:
![image](https://github.com/user-attachments/assets/00817217-3956-44c7-a24e-e2cdb850805d)

![image](https://github.com/user-attachments/assets/dd63b8b1-7c66-4569-a07d-3db078075751)


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
