### PR TITLE
RHOAI-4148: Re-adjust the statefulset, route, service based on generateName

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -144,7 +144,7 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// controller-service-hash that shouldn't exceed 63 chars.
 	isGenerateName := false
 	if len(instance.Name) > MaxStatefulsetNameLength {
-		log.Info("Notebook name is too long, it should be less than 52 chars")
+		log.Info("Notebook name is too long, it can be {MaxStatefulsetNameLength} chars long at most")
 		isGenerateName = true
 	}
 

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -501,7 +501,7 @@ func generateService(instance *v1beta1.Notebook) *corev1.Service {
 			Ports: []corev1.ServicePort{
 				{
 					// Make port name follow Istio pattern so it can be managed by istio rbac
-					Name:       "http-" + instance.Name,
+					Name:       "http-notebook",
 					Port:       DefaultServingPort,
 					TargetPort: intstr.FromInt(port),
 					Protocol:   "TCP",

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -55,6 +55,9 @@ const WorkbenchLabel = "opendatahub.io/workbenches"
 
 const PrefixEnvVar = "NB_PREFIX"
 
+// Statefulset name should be less than 52https://github.com/kubernetes/kubernetes/issues/64023
+const MaxStatefulsetNameLength = 52
+
 // The default fsGroup of PodSecurityContext.
 // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podsecuritycontext-v1-core
 const DefaultFSGroup = int64(100)
@@ -140,7 +143,7 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// as controller-service include as hash (len 11) as label
 	// controller-service-hash that shouldn't exceed 63 chars.
 	isGenerateName := false
-	if len(instance.Name) > 52 {
+	if len(instance.Name) > MaxStatefulsetNameLength {
 		log.Info("Notebook name is too long, it should be less than 52 chars")
 		isGenerateName = true
 	}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -309,6 +310,131 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			time.Sleep(2 * time.Second)
 			configMapName := "workbench-trusted-ca-bundle"
 			checkCertConfigMap(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 2)
+		})
+
+	})
+
+	// New test case for notebook creation with long name
+	When("Creating a long named Notebook", func() {
+
+		// With the work done https://issues.redhat.com/browse/RHOAIENG-4148,
+		// 48 characters is the maximum length for a notebook name.
+		// This would the extent of the test.
+		// TODO: Update the test to use the maximum length when the work is done.
+		const (
+			Name      = "test-notebook-with-a-very-long-name-thats-48char"
+			Namespace = "default"
+		)
+
+		notebook := createNotebook(Name, Namespace)
+
+		expectedRoute := routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "nb-",
+				Namespace:    Namespace,
+				Labels: map[string]string{
+					"notebook-name": Name,
+				},
+			},
+			Spec: routev1.RouteSpec{
+				To: routev1.RouteTargetReference{
+					Kind:   "Service",
+					Name:   Name,
+					Weight: ptr.To[int32](100),
+				},
+				Port: &routev1.RoutePort{
+					TargetPort: intstr.FromString("http-" + Name),
+				},
+				TLS: &routev1.TLSConfig{
+					Termination:                   routev1.TLSTerminationEdge,
+					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+				},
+				WildcardPolicy: routev1.WildcardPolicyNone,
+			},
+			Status: routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{},
+			},
+		}
+
+		route := &routev1.Route{}
+
+		It("Should create a Route to expose the traffic externally", func() {
+			ctx := context.Background()
+
+			By("By creating a new Notebook")
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+			time.Sleep(interval)
+
+			By("By checking that the controller has created the Route")
+			Eventually(func() error {
+				route, err := getRouteFromList(route, notebook, Name, Namespace)
+				if route == nil {
+					return err
+				}
+				return nil
+			}, duration, interval).Should(Succeed())
+			Expect(*route).To(BeMatchingK8sResource(expectedRoute, CompareNotebookRoutes))
+		})
+
+		It("Should reconcile the Route when modified", func() {
+			By("By simulating a manual Route modification")
+			patch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"to":{"name":"foo"}}}`))
+			Expect(cli.Patch(ctx, route, patch)).Should(Succeed())
+			time.Sleep(interval)
+
+			By("By checking that the controller has restored the Route spec")
+			Eventually(func() (string, error) {
+				route, err := getRouteFromList(route, notebook, Name, Namespace)
+				if route == nil {
+					return "", err
+				}
+				return route.Spec.To.Name, nil
+			}, duration, interval).Should(Equal(Name))
+			Expect(*route).To(BeMatchingK8sResource(expectedRoute, CompareNotebookRoutes))
+		})
+
+		It("Should recreate the Route when deleted", func() {
+			By("By deleting the notebook route")
+			Expect(cli.Delete(ctx, route)).Should(Succeed())
+			time.Sleep(interval)
+
+			By("By checking that the controller has recreated the Route")
+			Eventually(func() error {
+				route, err := getRouteFromList(route, notebook, Name, Namespace)
+				if route == nil {
+					return err
+				}
+				return nil
+			}, duration, interval).Should(Succeed())
+			Expect(*route).To(BeMatchingK8sResource(expectedRoute, CompareNotebookRoutes))
+		})
+
+		It("Should delete the Openshift Route", func() {
+			// Testenv cluster does not implement Kubernetes GC:
+			// https://book.kubebuilder.io/reference/envtest.html#testing-considerations
+			// To test that the deletion lifecycle works, test the ownership
+			// instead of asserting on existence.
+			expectedOwnerReference := metav1.OwnerReference{
+				APIVersion:         "kubeflow.org/v1",
+				Kind:               "Notebook",
+				Name:               Name,
+				UID:                notebook.GetObjectMeta().GetUID(),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}
+
+			By("By checking that the Notebook owns the Route object")
+			Expect(route.GetObjectMeta().GetOwnerReferences()).To(ContainElement(expectedOwnerReference))
+
+			By("By deleting the recently created Notebook")
+			Expect(cli.Delete(ctx, notebook)).Should(Succeed())
+			time.Sleep(interval)
+
+			By("By checking that the Notebook is deleted")
+			Eventually(func() error {
+				key := types.NamespacedName{Name: Name, Namespace: Namespace}
+				return cli.Get(ctx, key, notebook)
+			}, duration, interval).Should(HaveOccurred())
 		})
 
 	})
@@ -965,6 +1091,28 @@ func createNotebook(name, namespace string) *nbv1.Notebook {
 				}}}},
 		},
 	}
+}
+
+func getRouteFromList(route *routev1.Route, notebook *nbv1.Notebook, name, namespace string) (*routev1.Route, error) {
+	routeList := &routev1.RouteList{}
+	opts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{"notebook-name": name},
+	}
+
+	err := cli.List(ctx, routeList, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the route from the list
+	for _, nRoute := range routeList.Items {
+		if metav1.IsControlledBy(&nRoute, notebook) {
+			*route = nRoute
+			return route, nil
+		}
+	}
+	return nil, errors.New("Route not found")
 }
 
 func createOAuthServiceAccount(name, namespace string) corev1.ServiceAccount {

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -335,8 +335,8 @@ func (r *OpenshiftNotebookReconciler) createSecret(notebook *nbv1.Notebook, ctx 
 }
 
 // NewNotebookOAuthRoute defines the desired OAuth route object
-func NewNotebookOAuthRoute(notebook *nbv1.Notebook) *routev1.Route {
-	route := NewNotebookRoute(notebook)
+func NewNotebookOAuthRoute(notebook *nbv1.Notebook, isGenerateName bool) *routev1.Route {
+	route := NewNotebookRoute(notebook, isGenerateName)
 	route.Spec.To.Name = notebook.Name + "-tls"
 	route.Spec.Port.TargetPort = intstr.FromString(OAuthServicePortName)
 	route.Spec.TLS.Termination = routev1.TLSTerminationReencrypt

--- a/components/odh-notebook-controller/controllers/notebook_route.go
+++ b/components/odh-notebook-controller/controllers/notebook_route.go
@@ -37,10 +37,8 @@ import (
 // we are using the generateName for the Route object. The const used for this
 // would be max 48 chars for route.name and 15 chars for route.namespace
 const (
-	// RouteNameMaxLen is the max length of the route name
-	RouteNameMaxLen = 48
-	// RouteNamespaceMaxLen is the max length of the route namespace
-	RouteNamespaceMaxLen = 15
+	// RouteSubDomainMaxLen is the max length of the route subdomain
+	RouteSubDomainMaxLen = 63
 )
 
 // NewNotebookRoute defines the desired route object
@@ -108,7 +106,7 @@ func (r *OpenshiftNotebookReconciler) reconcileRoute(notebook *nbv1.Notebook,
 	var isGenerateName bool = false
 	// If the route name + namespace is greater than 63 characters, the route name would be created by generateName
 	// ex: notebook-name 48 + namespace(rhods-notebooks) 15 = 63
-	if len(notebook.Name) > RouteNameMaxLen && len(notebook.Namespace) >= RouteNamespaceMaxLen {
+	if len(notebook.Name)+len(notebook.Namespace) > RouteSubDomainMaxLen {
 		log.Info("Route name is too long, using generateName")
 		isGenerateName = true
 		// Note: Also update service account redirect reference once route is created.

--- a/components/odh-notebook-controller/controllers/notebook_route.go
+++ b/components/odh-notebook-controller/controllers/notebook_route.go
@@ -103,7 +103,7 @@ func (r *OpenshiftNotebookReconciler) reconcileRoute(notebook *nbv1.Notebook,
 	// Initialize logger format
 	log := r.Log.WithValues("notebook", notebook.Name, "namespace", notebook.Namespace)
 
-	var isGenerateName bool = false
+	var isGenerateName = false
 	// If the route name + namespace is greater than 63 characters, the route name would be created by generateName
 	// ex: notebook-name 48 + namespace(rhods-notebooks) 15 = 63
 	if len(notebook.Name)+len(notebook.Namespace) > RouteSubDomainMaxLen {
@@ -233,7 +233,7 @@ func (r *OpenshiftNotebookReconciler) ReconcileRoute(
 
 // InsertSecondRedirectReference inserts the second redirect reference into the ServiceAccount
 func InsertSecondRedirectReference(sa *corev1.ServiceAccount, routeName string) *corev1.ServiceAccount {
-	sa.ObjectMeta.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.second"] = "" +
+	sa.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.second"] = "" +
 		`{"kind":"OAuthRedirectReference","apiVersion":"v1",` +
 		`"reference":{"kind":"Route","name":"` + routeName + `"}}`
 	return sa

--- a/components/odh-notebook-controller/controllers/notebook_route.go
+++ b/components/odh-notebook-controller/controllers/notebook_route.go
@@ -32,6 +32,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Route Url are defined with combination of Route.name and Route.namespace
+// The max sub-domain length is 63 characters, to keep the bound is place
+// we are using the generateName for the Route object. The const used for this
+// would be max 48 chars for route.name and 15 chars for route.namespace
+const (
+	// RouteNameMaxLen is the max length of the route name
+	RouteNameMaxLen = 48
+	// RouteNamespaceMaxLen is the max length of the route namespace
+	RouteNamespaceMaxLen = 15
+)
+
 // NewNotebookRoute defines the desired route object
 func NewNotebookRoute(notebook *nbv1.Notebook, isgenerateName bool) *routev1.Route {
 
@@ -97,7 +108,7 @@ func (r *OpenshiftNotebookReconciler) reconcileRoute(notebook *nbv1.Notebook,
 	var isGenerateName bool = false
 	// If the route name + namespace is greater than 63 characters, the route name would be created by generateName
 	// ex: notebook-name 48 + namespace(rhods-notebooks) 15 = 63
-	if len(notebook.Name) > 48 && len(notebook.Namespace) >= 15 {
+	if len(notebook.Name) > RouteNameMaxLen && len(notebook.Namespace) >= RouteNamespaceMaxLen {
 		log.Info("Route name is too long, using generateName")
 		isGenerateName = true
 		// Note: Also update service account redirect reference once route is created.

--- a/components/odh-notebook-controller/controllers/notebook_route.go
+++ b/components/odh-notebook-controller/controllers/notebook_route.go
@@ -21,6 +21,7 @@ import (
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,18 +29,33 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewNotebookRoute defines the desired route object
-func NewNotebookRoute(notebook *nbv1.Notebook) *routev1.Route {
-	return &routev1.Route{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      notebook.Name,
-			Namespace: notebook.Namespace,
+func NewNotebookRoute(notebook *nbv1.Notebook, isgenerateName bool) *routev1.Route {
+
+	routeMetadata := metav1.ObjectMeta{
+		Name:      notebook.Name,
+		Namespace: notebook.Namespace,
+		Labels: map[string]string{
+			"notebook-name": notebook.Name,
+		},
+	}
+
+	// If the route name + namespace is greater than 63 characters, the route name would be created by generateName
+	// ex: notebook-name 48 + namespace(rhods-notebooks) 15 = 63
+	if isgenerateName {
+		routeMetadata = metav1.ObjectMeta{
+			GenerateName: "nb-",
+			Namespace:    notebook.Namespace,
 			Labels: map[string]string{
 				"notebook-name": notebook.Name,
 			},
-		},
+		}
+	}
+	return &routev1.Route{
+		ObjectMeta: routeMetadata,
 		Spec: routev1.RouteSpec{
 			To: routev1.RouteTargetReference{
 				Kind:   "Service",
@@ -74,41 +90,62 @@ func CompareNotebookRoutes(r1 routev1.Route, r2 routev1.Route) bool {
 // Reconcile will manage the creation, update and deletion of the route returned
 // by the newRoute function
 func (r *OpenshiftNotebookReconciler) reconcileRoute(notebook *nbv1.Notebook,
-	ctx context.Context, newRoute func(*nbv1.Notebook) *routev1.Route) error {
+	ctx context.Context, newRoute func(*nbv1.Notebook, bool) *routev1.Route) error {
 	// Initialize logger format
 	log := r.Log.WithValues("notebook", notebook.Name, "namespace", notebook.Namespace)
 
+	var isGenerateName bool = false
+	// If the route name + namespace is greater than 63 characters, the route name would be created by generateName
+	// ex: notebook-name 48 + namespace(rhods-notebooks) 15 = 63
+	if len(notebook.Name) > 48 && len(notebook.Namespace) >= 15 {
+		log.Info("Route name is too long, using generateName")
+		isGenerateName = true
+		// Note: Also update service account redirect reference once route is created.
+	}
+
 	// Generate the desired route
-	desiredRoute := newRoute(notebook)
+	desiredRoute := newRoute(notebook, isGenerateName)
 
 	// Create the route if it does not already exist
 	foundRoute := &routev1.Route{}
+	routeList := &routev1.RouteList{}
 	justCreated := false
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      desiredRoute.Name,
-		Namespace: notebook.Namespace,
-	}, foundRoute)
+
+	// List the routes in the notebook namespace with the notebook name label
+	opts := []client.ListOption{
+		client.InNamespace(notebook.Namespace),
+		client.MatchingLabels{"notebook-name": notebook.Name},
+	}
+
+	err := r.List(ctx, routeList, opts...)
 	if err != nil {
-		if apierrs.IsNotFound(err) {
-			log.Info("Creating Route")
-			// Add .metatada.ownerReferences to the route to be deleted by the
-			// Kubernetes garbage collector if the notebook is deleted
-			err = ctrl.SetControllerReference(notebook, desiredRoute, r.Scheme)
-			if err != nil {
-				log.Error(err, "Unable to add OwnerReference to the Route")
-				return err
-			}
-			// Create the route in the Openshift cluster
-			err = r.Create(ctx, desiredRoute)
-			if err != nil && !apierrs.IsAlreadyExists(err) {
-				log.Error(err, "Unable to create the Route")
-				return err
-			}
-			justCreated = true
-		} else {
-			log.Error(err, "Unable to fetch the Route")
+		log.Error(err, "Unable to list the Route")
+	}
+
+	// Get the route from the list
+	for _, nRoute := range routeList.Items {
+		if metav1.IsControlledBy(&nRoute, notebook) {
+			foundRoute = &nRoute
+			break
+		}
+	}
+	// If the route is not found, create it
+	if foundRoute.Name == "" && foundRoute.Namespace == "" {
+		log.Info("Creating Route")
+		// Add .metatada.ownerReferences to the route to be deleted by the
+		// Kubernetes garbage collector if the notebook is deleted
+		err = ctrl.SetControllerReference(notebook, desiredRoute, r.Scheme)
+		if err != nil {
+			log.Error(err, "Unable to add OwnerReference to the Route")
 			return err
 		}
+		// Create the route in the Openshift cluster
+		err = r.Create(ctx, desiredRoute)
+		if err != nil && !apierrs.IsAlreadyExists(err) {
+			log.Error(err, "Unable to create the Route")
+			return err
+		}
+		justCreated = true
 	}
 
 	// Reconcile the route spec if it has been manually modified
@@ -119,7 +156,7 @@ func (r *OpenshiftNotebookReconciler) reconcileRoute(notebook *nbv1.Notebook,
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			// Get the last route revision
 			if err := r.Get(ctx, types.NamespacedName{
-				Name:      desiredRoute.Name,
+				Name:      foundRoute.Name,
 				Namespace: notebook.Namespace,
 			}, foundRoute); err != nil {
 				return err
@@ -135,6 +172,46 @@ func (r *OpenshiftNotebookReconciler) reconcileRoute(notebook *nbv1.Notebook,
 		}
 	}
 
+	// Update service account redirect reference if justCreated and isGenerateName
+	if justCreated && isGenerateName {
+		// get the generated route name
+		findRoute := &routev1.Route{}
+		routeList := &routev1.RouteList{}
+		opts := []client.ListOption{
+			client.InNamespace(notebook.Namespace),
+			client.MatchingLabels{"notebook-name": notebook.Name},
+		}
+
+		err := r.List(ctx, routeList, opts...)
+		if err != nil {
+			log.Error(err, "Unable to list the Route")
+		}
+
+		// Get the route from the list
+		for _, nRoute := range routeList.Items {
+			if metav1.IsControlledBy(&nRoute, notebook) {
+				findRoute = &nRoute
+				break
+			}
+		}
+		// Update the service account if already exist
+		foundSA := &corev1.ServiceAccount{}
+		err = r.Get(ctx, types.NamespacedName{
+			Name:      notebook.Name,
+			Namespace: notebook.Namespace,
+		}, foundSA)
+		if err == nil && foundSA.Name != "" {
+			log.Info("Updating Service Account")
+			foundSA = InsertSecondRedirectReference(foundSA, findRoute.Name)
+			err = r.Update(ctx, foundSA)
+			if err != nil {
+				log.Error(err, "Unable to update the Service Account")
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 
@@ -143,4 +220,12 @@ func (r *OpenshiftNotebookReconciler) reconcileRoute(notebook *nbv1.Notebook,
 func (r *OpenshiftNotebookReconciler) ReconcileRoute(
 	notebook *nbv1.Notebook, ctx context.Context) error {
 	return r.reconcileRoute(notebook, ctx, NewNotebookRoute)
+}
+
+// InsertSecondRedirectReference inserts the second redirect reference into the ServiceAccount
+func InsertSecondRedirectReference(sa *corev1.ServiceAccount, routeName string) *corev1.ServiceAccount {
+	sa.ObjectMeta.Annotations["serviceaccounts.openshift.io/oauth-redirectreference.second"] = "" +
+		`{"kind":"OAuthRedirectReference","apiVersion":"v1",` +
+		`"reference":{"kind":"Route","name":"` + routeName + `"}}`
+	return sa
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-4148

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Re-adjust the statefulset, route, service based on generateName

The setup on Opendatahub allows spin-up of workbenches, via 
- Data Science Project
- Jupyter Tile (application>enabled)

Way of naming in the above methods:
- Data Science Project: users choose to name it 
- Jupyter Tile: `jupyter-nb-<encoded-username>`

Length issue on Jupyter Tile:
- Depending on the username, the dashboard [encode special characters](https://github.com/opendatahub-io/odh-dashboard/blob/0a4fd273bed8af3cd0ccfb1a61a0a64c37d5abde/frontend/src/utilities/notebookControllerUtils.ts#L30) as not special chars are accepted in Kubernetes. 
  - This can cause the length of the username to change with few added chars.
 - Dashboard adds `jupyter-nb-` that is 11 len, [here](https://github.com/opendatahub-io/odh-dashboard/blob/0a4fd273bed8af3cd0ccfb1a61a0a64c37d5abde/backend/src/utils/notebookUtils.ts#L31).
 
Explanation:
- The route URL is created by sub-domain`(<route-name>-<namespace>)` : `<route-name>-<namespace>.<domain>`
- The len of sub-domain needs to be 63 chars. References:
   - https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#:~:text=Each%20route%20consists%20of%20a,and%20an%20optional%20security%20configuration.
   - https://access.redhat.com/solutions/3638581
- As jupyter-tiles are created in namespace (rhods-notebooks) this add: 16 chars to sub-domain.
- Following get the limit of len of username: 63-16 = 47 - (len of prefix jupyter-nb i.e 11) = 36.

In ODH username above 36 chars were failing , fixing the Route name to generated using Kubernets generateName method, we can fix the route sub-domain issue. 

Upon further exploring found that labels have length constraint of 63 chars.
- https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
- https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

The controllerRevision, adds a hash that is 8-10Chars, which adds 11 chars to a label of statefulset.
Given a workbench in jupyter-tile, that allows: 
username: 63- (len of prefix jupyter-nb i.e 11) - (len of hash i.e 11) = 41

In ODH username between 36-41 chars were failing in statefulset creation stage , fixing the Statefulset name to generated using Kubernets generateName method, we can fix the controller-revision-hash label.

With this, username can be up to 52 chars. 
as there are other labels, which would fail the 63 chars limit (app, notebook-name labels)

End Result:
Old username limit: max 36
New username limit: max 52

Related-to: 
https://github.com/opendatahub-io/kubeflow/issues/179
https://issues.redhat.com/browse/RHOAIENG-4148

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TBD

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
