### PR TITLE
RHOAIENG-13916: fix(odh-notebook-controller): handle errored imagestreams in webhook

### DIFF
--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -27,6 +27,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kubeflow.org
   resources:
   - notebooks

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -73,6 +73,7 @@ type OpenshiftNotebookReconciler struct {
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=list;get
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.
 func CompareNotebooks(nb1 nbv1.Notebook, nb2 nbv1.Notebook) bool {


### PR DESCRIPTION
Related issues

* https://issues.redhat.com/browse/RHOAIENG-13916

and

* https://issues.redhat.com/browse/RHOAIENG-8232
* https://issues.redhat.com/browse/RHOAIENG-8390

Work done

- add RBAC on clusterrole for list imagestream, not sure why it was not there before
- update code to ensure tag is not on a nil to cause panic when convert , see `status["tags"].([]interface{})`
- set explictily error on forbidding if due to miss permission, fast exit
- error out if no container everntually matches

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
encounter error like on rhoai 2.16.0, even the hardcoded 2 namespaces has been removed last Nov still permission and follow to panice need to be addressed:
```
2025-02-28T07:57:33.821531941Z {"level":"info","ts":"2025-02-28T07:57:33Z","logger":"controllers.Notebook","msg":"No internal registry found, let's pick up image reference from relevant ImageStream 'status.tags[].tag.dockerImageReference'","notebook":"XXXX","namespace":"notebook"}
2025-02-28T07:57:33.823147980Z {"level":"info","ts":"2025-02-28T07:57:33Z","logger":"controllers.Notebook","msg":"Cannot list imagestreams","notebook":"XXX","namespace":"notebook","error":"imagestreams.image.openshift.io is forbidden: User \"system:serviceaccount:redhat-ods-applications:odh-notebook-controller-manager\" cannot list resource \"imagestreams\" in API group \"image.openshift.io\" in the namespace \"opendatahub\""}
2025-02-28T07:57:33.842362382Z 2025/02/28 07:57:33 http: panic serving 5.131.0.2:48840: interface conversion: interface {} is nil, not []interface {}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
