### PR TITLE
RHOAIENG-12107: chore(components/odh-notebook-controller): replace deprecated `pointer.` usages with `ptr.To` to fix linter checks

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -35,7 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
@@ -69,7 +69,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				To: routev1.RouteTargetReference{
 					Kind:   "Service",
 					Name:   Name,
-					Weight: pointer.Int32Ptr(100),
+					Weight: ptr.To[int32](100),
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString("http-" + Name),
@@ -143,8 +143,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				Kind:               "Notebook",
 				Name:               Name,
 				UID:                notebook.GetObjectMeta().GetUID(),
-				Controller:         pointer.BoolPtr(true),
-				BlockOwnerDeletion: pointer.BoolPtr(true),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}
 
 			By("By checking that the Notebook owns the Route object")
@@ -294,7 +294,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{Name: workbenchTrustedCACertBundle},
-						Optional:             pointer.Bool(true),
+						Optional:             ptr.To(true),
 						Items: []corev1.KeyToPath{
 							{
 								Key:  "ca-bundle.crt",
@@ -400,7 +400,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{Name: workbenchTrustedCACertBundle},
-						Optional:             pointer.Bool(true),
+						Optional:             ptr.To(true),
 						Items: []corev1.KeyToPath{
 							{
 								Key:  "ca-bundle.crt",
@@ -536,8 +536,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				Kind:               "Notebook",
 				Name:               Name,
 				UID:                notebook.GetObjectMeta().GetUID(),
-				Controller:         pointer.BoolPtr(true),
-				BlockOwnerDeletion: pointer.BoolPtr(true),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}
 
 			By("By checking that the Notebook owns the Notebook Network Policy object")
@@ -633,7 +633,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  Name + "-oauth-config",
-										DefaultMode: pointer.Int32Ptr(420),
+										DefaultMode: ptr.To[int32](420),
 									},
 								},
 							},
@@ -642,7 +642,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName:  Name + "-tls",
-										DefaultMode: pointer.Int32Ptr(420),
+										DefaultMode: ptr.To[int32](420),
 									},
 								},
 							},
@@ -796,7 +796,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				To: routev1.RouteTargetReference{
 					Kind:   "Service",
 					Name:   Name + "-tls",
-					Weight: pointer.Int32Ptr(100),
+					Weight: ptr.To[int32](100),
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString(OAuthServicePortName),
@@ -862,8 +862,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				Kind:               "Notebook",
 				Name:               Name,
 				UID:                notebook.GetObjectMeta().GetUID(),
-				Controller:         pointer.BoolPtr(true),
-				BlockOwnerDeletion: pointer.BoolPtr(true),
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
 			}
 
 			By("By checking that the Notebook owns the Service Account object")

--- a/components/odh-notebook-controller/controllers/notebook_route.go
+++ b/components/odh-notebook-controller/controllers/notebook_route.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -44,7 +44,7 @@ func NewNotebookRoute(notebook *nbv1.Notebook) *routev1.Route {
 			To: routev1.RouteTargetReference{
 				Kind:   "Service",
 				Name:   notebook.Name,
-				Weight: pointer.Int32Ptr(100),
+				Weight: ptr.To[int32](100),
 			},
 			Port: &routev1.RoutePort{
 				TargetPort: intstr.FromString("http-" + notebook.Name),

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -190,7 +190,7 @@ func InjectOAuthProxy(notebook *nbv1.Notebook, oauth OAuthConfig) error {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  notebook.Name + "-oauth-config",
-				DefaultMode: pointer.Int32Ptr(420),
+				DefaultMode: ptr.To[int32](420),
 			},
 		},
 	}
@@ -213,7 +213,7 @@ func InjectOAuthProxy(notebook *nbv1.Notebook, oauth OAuthConfig) error {
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  notebook.Name + "-tls",
-				DefaultMode: pointer.Int32Ptr(420),
+				DefaultMode: ptr.To[int32](420),
 			},
 		},
 	}
@@ -531,7 +531,7 @@ func InjectCertConfig(notebook *nbv1.Notebook, configMapName string) error {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: configMapName,
 				},
-				Optional: pointer.Bool(true),
+				Optional: ptr.To(true),
 				Items: []corev1.KeyToPath{{
 					Key:  configMapMountKey,
 					Path: configMapMountValue,


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-12107

## Description

Fixes the following golangci-lint (https://golangci-lint.run/) class of errors in odh-notebook-controller

```
  Error: components/odh-notebook-controller/controllers/notebook_route.go:47:13: SA1019: pointer.Int32Ptr is deprecated: Use ptr.To instead. (staticcheck)
  				Weight: pointer.Int32Ptr(100),
  				        ^
```

https://github.com/opendatahub-io/kubeflow/actions/runs/13613605894/job/38053824761#step:4:112

## How Has This Been Tested?

* https://github.com/RomanFilip/kubeflow-fork/actions/runs/13676767088
* https://github.com/RomanFilip/kubeflow-fork/actions/runs/13676767075
* https://github.com/RomanFilip/kubeflow-fork/actions/runs/13676767082

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
