### PR TITLE
RHOAIENG-12107: chore(components/odh-notebook-controller): delete err parameter from the ensureOAuthNetworkPolicyExists to fix linter check

### DIFF
--- a/components/odh-notebook-controller/e2e/notebook_creation_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_creation_test.go
@@ -133,13 +133,13 @@ func (tc *testContext) testNetworkPolicyCreation(nbMeta *metav1.ObjectMeta) erro
 	}
 
 	if deploymentMode == OAuthProxy {
-		return tc.ensureOAuthNetworkPolicyExists(nbMeta, err)
+		return tc.ensureOAuthNetworkPolicyExists(nbMeta)
 	}
 
 	return nil
 }
 
-func (tc *testContext) ensureOAuthNetworkPolicyExists(nbMeta *metav1.ObjectMeta, err error) error {
+func (tc *testContext) ensureOAuthNetworkPolicyExists(nbMeta *metav1.ObjectMeta) error {
 	// Test Notebook Network policy that allows all requests on Notebook OAuth port
 	notebookOAuthNetworkPolicy, err := tc.getNotebookNetworkPolicy(nbMeta, nbMeta.Name+"-oauth-np")
 	if err != nil {


### PR DESCRIPTION
delete `err` parameter from the `ensureOAuthNetworkPolicyExists` to fix linter check

the code being changed was originally introduced in

* https://github.com/opendatahub-io/kubeflow/pull/96

## Description
<!--- Describe your changes in detail -->
Fixes the following golangci-lint (https://golangci-lint.run/) errors in odh-notebook-controller

```
components/odc-notebook-controller/e2e/notebook_creation_test.go:142:82: SA4009: argument err is overwritten before first use (staticcheck)
func (tc *testContext) ensureOAuthNetworkPolicyExists(nbMeta *metav1.ObjectMeta, err error) error {
                                                                                 ^
components/odc-notebook-controller/e2e/notebook_creation_test.go:144:2: SA4009(related information): assignment to err (staticcheck)
        notebookOAuthNetworkPolicy, err := tc.getNotebookNetworkPolicy(nbMeta, nbMeta.Name+"-oauth-np")
        ^
```

* https://issues.redhat.com/browse/RHOAIENG-12107


## How Has This Been Tested?
* https://github.com/RomanFilip/kubeflow-fork/actions/runs/13677089834
* https://github.com/RomanFilip/kubeflow-fork/actions/runs/13677061313

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
