### PR TITLE
RHOAIENG-12107: chore(components/odh-notebook-controller): rewrite Poll function to PollUntilContextTimeout to fix linter error

### DIFF
--- a/components/odh-notebook-controller/e2e/helper_test.go
+++ b/components/odh-notebook-controller/e2e/helper_test.go
@@ -25,7 +25,7 @@ import (
 func (tc *testContext) waitForControllerDeployment(name string, replicas int32) error {
 	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 
-		controllerDeployment, err := tc.kubeClient.AppsV1().Deployments(tc.testNamespace).Get(tc.ctx, name, metav1.GetOptions{})
+		controllerDeployment, err := tc.kubeClient.AppsV1().Deployments(tc.testNamespace).Get(ctx, name, metav1.GetOptions{})
 
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -60,7 +60,7 @@ func (tc *testContext) getNotebookRoute(nbMeta *metav1.ObjectMeta) (*routev1.Rou
 		opts = append(opts, client.MatchingLabels{"notebook-name": nbMeta.Name})
 	}
 	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
-		routeErr := tc.customClient.List(tc.ctx, &nbRouteList, opts...)
+		routeErr := tc.customClient.List(ctx, &nbRouteList, opts...)
 		if routeErr != nil {
 			log.Printf("error retrieving Notebook route %v", err)
 			return false, nil
@@ -79,7 +79,7 @@ func (tc *testContext) getNotebookRoute(nbMeta *metav1.ObjectMeta) (*routev1.Rou
 func (tc *testContext) getNotebookNetworkPolicy(nbMeta *metav1.ObjectMeta, name string) (*netv1.NetworkPolicy, error) {
 	nbNetworkPolicy := &netv1.NetworkPolicy{}
 	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
-		np, npErr := tc.kubeClient.NetworkingV1().NetworkPolicies(nbMeta.Namespace).Get(tc.ctx, name, metav1.GetOptions{})
+		np, npErr := tc.kubeClient.NetworkingV1().NetworkPolicies(nbMeta.Namespace).Get(ctx, name, metav1.GetOptions{})
 		if npErr != nil {
 			log.Printf("error retrieving Notebook Network policy %v: %v", name, err)
 			return false, nil
@@ -135,7 +135,7 @@ func (tc *testContext) rolloutDeployment(depMeta metav1.ObjectMeta) error {
 func (tc *testContext) waitForStatefulSet(nbMeta *metav1.ObjectMeta, availableReplicas int32, readyReplicas int32) error {
 	// Verify StatefulSet is running expected number of replicas
 	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
-		notebookStatefulSet, err1 := tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(tc.ctx,
+		notebookStatefulSet, err1 := tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(ctx,
 			nbMeta.Name, metav1.GetOptions{})
 
 		if err1 != nil {

--- a/components/odh-notebook-controller/e2e/helper_test.go
+++ b/components/odh-notebook-controller/e2e/helper_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"log"
@@ -22,7 +23,7 @@ import (
 )
 
 func (tc *testContext) waitForControllerDeployment(name string, replicas int32) error {
-	err := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 
 		controllerDeployment, err := tc.kubeClient.AppsV1().Deployments(tc.testNamespace).Get(tc.ctx, name, metav1.GetOptions{})
 
@@ -58,7 +59,7 @@ func (tc *testContext) getNotebookRoute(nbMeta *metav1.ObjectMeta) (*routev1.Rou
 	} else {
 		opts = append(opts, client.MatchingLabels{"notebook-name": nbMeta.Name})
 	}
-	err := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		routeErr := tc.customClient.List(tc.ctx, &nbRouteList, opts...)
 		if routeErr != nil {
 			log.Printf("error retrieving Notebook route %v", err)
@@ -77,7 +78,7 @@ func (tc *testContext) getNotebookRoute(nbMeta *metav1.ObjectMeta) (*routev1.Rou
 
 func (tc *testContext) getNotebookNetworkPolicy(nbMeta *metav1.ObjectMeta, name string) (*netv1.NetworkPolicy, error) {
 	nbNetworkPolicy := &netv1.NetworkPolicy{}
-	err := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		np, npErr := tc.kubeClient.NetworkingV1().NetworkPolicies(nbMeta.Namespace).Get(tc.ctx, name, metav1.GetOptions{})
 		if npErr != nil {
 			log.Printf("error retrieving Notebook Network policy %v: %v", name, err)
@@ -133,7 +134,7 @@ func (tc *testContext) rolloutDeployment(depMeta metav1.ObjectMeta) error {
 
 func (tc *testContext) waitForStatefulSet(nbMeta *metav1.ObjectMeta, availableReplicas int32, readyReplicas int32) error {
 	// Verify StatefulSet is running expected number of replicas
-	err := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		notebookStatefulSet, err1 := tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(tc.ctx,
 			nbMeta.Name, metav1.GetOptions{})
 

--- a/components/odh-notebook-controller/e2e/notebook_creation_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_creation_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -85,7 +86,7 @@ func (tc *testContext) testNotebookCreation(nbContext notebookContext) error {
 	err := tc.customClient.Get(tc.ctx, notebookLookupKey, &createdNotebook)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			nberr := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+			nberr := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 				creationErr := tc.customClient.Create(tc.ctx, testNotebook)
 				if creationErr != nil {
 					log.Printf("Error creating Notebook resource %v: %v, trying again",

--- a/components/odh-notebook-controller/e2e/notebook_creation_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_creation_test.go
@@ -87,7 +87,7 @@ func (tc *testContext) testNotebookCreation(nbContext notebookContext) error {
 	if err != nil {
 		if errors.IsNotFound(err) {
 			nberr := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
-				creationErr := tc.customClient.Create(tc.ctx, testNotebook)
+				creationErr := tc.customClient.Create(ctx, testNotebook)
 				if creationErr != nil {
 					log.Printf("Error creating Notebook resource %v: %v, trying again",
 						testNotebook.Name, creationErr)

--- a/components/odh-notebook-controller/e2e/notebook_deletion_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_deletion_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -59,7 +60,7 @@ func (tc *testContext) testNotebookDeletion(nbMeta *metav1.ObjectMeta) error {
 
 func (tc *testContext) testNotebookResourcesDeletion(nbMeta *metav1.ObjectMeta) error {
 	// Verify Notebook StatefulSet resource is deleted
-	err := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		_, err = tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(tc.ctx, nbMeta.Name, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -78,7 +79,7 @@ func (tc *testContext) testNotebookResourcesDeletion(nbMeta *metav1.ObjectMeta) 
 	// Verify Notebook Network Policies are deleted
 	nbNetworkPolicyList := netv1.NetworkPolicyList{}
 	opts := filterServiceMeshManagedPolicies(nbMeta)
-	err = wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		nperr := tc.customClient.List(tc.ctx, &nbNetworkPolicyList, opts...)
 		if nperr != nil {
 			if errors.IsNotFound(nperr) {
@@ -101,7 +102,7 @@ func (tc *testContext) testNotebookResourcesDeletion(nbMeta *metav1.ObjectMeta) 
 		// Verify Notebook Route is deleted
 		nbRouteLookupKey := types.NamespacedName{Name: nbMeta.Name, Namespace: tc.testNamespace}
 		nbRoute := &routev1.Route{}
-		err = wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+		err = wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 			err = tc.customClient.Get(tc.ctx, nbRouteLookupKey, nbRoute)
 			if err != nil {
 				if errors.IsNotFound(err) {

--- a/components/odh-notebook-controller/e2e/notebook_deletion_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_deletion_test.go
@@ -61,7 +61,7 @@ func (tc *testContext) testNotebookDeletion(nbMeta *metav1.ObjectMeta) error {
 func (tc *testContext) testNotebookResourcesDeletion(nbMeta *metav1.ObjectMeta) error {
 	// Verify Notebook StatefulSet resource is deleted
 	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
-		_, err = tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(tc.ctx, nbMeta.Name, metav1.GetOptions{})
+		_, err = tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(ctx, nbMeta.Name, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
@@ -80,7 +80,7 @@ func (tc *testContext) testNotebookResourcesDeletion(nbMeta *metav1.ObjectMeta) 
 	nbNetworkPolicyList := netv1.NetworkPolicyList{}
 	opts := filterServiceMeshManagedPolicies(nbMeta)
 	err = wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
-		nperr := tc.customClient.List(tc.ctx, &nbNetworkPolicyList, opts...)
+		nperr := tc.customClient.List(ctx, &nbNetworkPolicyList, opts...)
 		if nperr != nil {
 			if errors.IsNotFound(nperr) {
 				return true, nil
@@ -103,7 +103,7 @@ func (tc *testContext) testNotebookResourcesDeletion(nbMeta *metav1.ObjectMeta) 
 		nbRouteLookupKey := types.NamespacedName{Name: nbMeta.Name, Namespace: tc.testNamespace}
 		nbRoute := &routev1.Route{}
 		err = wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
-			err = tc.customClient.Get(tc.ctx, nbRouteLookupKey, nbRoute)
+			err = tc.customClient.Get(ctx, nbRouteLookupKey, nbRoute)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					return true, nil

--- a/components/odh-notebook-controller/e2e/notebook_update_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_update_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -74,7 +75,7 @@ func (tc *testContext) testNotebookUpdate(nbContext notebookContext) error {
 	}
 
 	// Wait for the update to be applied
-	err = wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		note := &nbv1.Notebook{}
 		err = tc.customClient.Get(tc.ctx, notebookLookupKey, note)
 		if err != nil {

--- a/components/odh-notebook-controller/e2e/notebook_update_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_update_test.go
@@ -77,7 +77,7 @@ func (tc *testContext) testNotebookUpdate(nbContext notebookContext) error {
 	// Wait for the update to be applied
 	err = wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
 		note := &nbv1.Notebook{}
-		err = tc.customClient.Get(tc.ctx, notebookLookupKey, note)
+		err = tc.customClient.Get(ctx, notebookLookupKey, note)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
rewrite Poll function to PollUntilContextTimeout to fix linter error

## Description
<!--- Describe your changes in detail -->
Fixes the following golangci-lint (https://golangci-lint.run/) errors in odh-notebook-controller

```
components/odc-notebook-controller/e2e/helper_test.go:25:9: SA1019: wait.Poll is deprecated: This method does not return errors from context, use PollUntilContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release. (staticcheck)
        err := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
               ^
components/odc-notebook-controller/e2e/helper_test.go:61:9: SA1019: wait.Poll is deprecated: This method does not return errors from context, use PollUntilContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release. (staticcheck)
        err := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
               ^
components/odc-notebook-controller/e2e/helper_test.go:80:9: SA1019: wait.Poll is deprecated: This method does not return errors from context, use PollUntilContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release. (staticcheck)
        err := wait.Poll(tc.resourceRetryInterval, tc.resourceCreationTimeout, func() (done bool, err error) {
```

* https://issues.redhat.com/browse/RHOAIENG-12107

## Additional resources

Both functions are defined in `k8s.io/apimachinery@v0.29.0/pkg/util/wait/poll.go`

```go
// PollUntilContextTimeout will terminate polling after timeout duration by setting a context
// timeout. This is provided as a convenience function for callers not currently executing under
// a deadline and is equivalent to:
//
//	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
//	err := PollUntilContextCancel(deadlineCtx, interval, immediate, condition)
//
// The deadline context will be cancelled if the Poll succeeds before the timeout, simplifying
// inline usage. All other behavior is identical to PollUntilContextCancel.
func PollUntilContextTimeout(ctx context.Context, interval, timeout time.Duration, immediate bool, condition ConditionWithContextFunc) error {
	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
	defer deadlineCancel()
	return loopConditionUntilContext(deadlineCtx, Backoff{Duration: interval}.Timer(), immediate, false, condition)
}

// Poll tries a condition func until it returns true, an error, or the timeout
// is reached.
//
// Poll always waits the interval before the run of 'condition'.
// 'condition' will always be invoked at least once.
//
// Some intervals may be missed if the condition takes too long or the time
// window is too short.
//
// If you want to Poll something forever, see PollInfinite.
//
// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
// Note that the new method will no longer return ErrWaitTimeout and instead return errors
// defined by the context package. Will be removed in a future release.
func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
	return PollWithContext(context.Background(), interval, timeout, condition.WithContext())
}
```

## How Has This Been Tested?
* https://github.com/RomanFilip/kubeflow-fork/actions/runs/13698689216
* https://github.com/RomanFilip/kubeflow-fork/actions/runs/13698689199

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
