### PR TITLE
RHOAIENG-18401: chore(konflux): restrict triggering only for the opendatahub-io/kubeflow repository

### DIFF
--- a/.tekton/kf-notebook-controller-pull-request.yaml
+++ b/.tekton/kf-notebook-controller-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main" && ( "components/***".pathChanged() || ".tekton/kf-notebook-controller-pull-request.yaml".pathChanged()
-      || "components/notebook-controller/Dockerfile".pathChanged() )
+      || "components/notebook-controller/Dockerfile".pathChanged() ) && has(body.repository) && body.repository.full_name == "opendatahub-io/kubeflow"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kubeflow

--- a/.tekton/kf-notebook-controller-push.yaml
+++ b/.tekton/kf-notebook-controller-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && has(body.repository) && body.repository.full_name == "opendatahub-io/kubeflow"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kubeflow

--- a/.tekton/odh-notebook-controller-pull-request.yaml
+++ b/.tekton/odh-notebook-controller-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main" && ( "components/***".pathChanged() || ".tekton/odh-notebook-controller-pull-request.yaml".pathChanged()
-      || "components/odh-notebook-controller/Dockerfile".pathChanged() )
+      || "components/odh-notebook-controller/Dockerfile".pathChanged() ) && has(body.repository) && body.repository.full_name == "opendatahub-io/kubeflow"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kubeflow

--- a/.tekton/odh-notebook-controller-push.yaml
+++ b/.tekton/odh-notebook-controller-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && has(body.repository) && body.repository.full_name == "opendatahub-io/kubeflow"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: kubeflow


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-18401

## Description

Same change and reasoning as in

* https://github.com/opendatahub-io/notebooks/pull/941

## How Has This Been Tested?

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
