### PR TITLE
RHOAIENG-13916: fix(odh-notebook-controller): handle errored imagestreams in webhook

### DIFF
--- a/components/odh-notebook-controller/config/crd/external/image.openshift.io_imagestream.yaml
+++ b/components/odh-notebook-controller/config/crd/external/image.openshift.io_imagestream.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    crd/fake: "true"
+  name: imagestreams.image.openshift.io
+spec:
+  group: image.openshift.io
+  names:
+    kind: ImageStream
+    listKind: ImageStreamList
+    singular: imagestream
+    plural: imagestreams
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -717,7 +717,8 @@ func SetContainerImageFromRegistry(ctx context.Context, config *rest.Config, not
 						}
 					}
 					if !imagestreamFound {
-						log.Error(nil, "Imagestream not found in main controller namespace", "imageSelected", imageSelected[0], "tag", imageSelected[1], "namespace", namespace)
+						log.Error(nil, "ImageStream not found in main controller namespace, or the ImageStream is present but does not contain a dockerImageReference for the specified tag",
+							"imageSelected", imageSelected[0], "tag", imageSelected[1], "namespace", namespace)
 					}
 				}
 			}

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -642,8 +642,8 @@ func SetContainerImageFromRegistry(ctx context.Context, config *rest.Config, not
 				if container.Name == notebook.Name {
 					containerFound = true
 
-					// Check if the container.Image value has an internal registry, if so  will pickup this without extra checks.
-					// This value constructed on the initialization of the Notebook CR.
+					// Check if the container.Image value has an internal registry, if so, will pick up this without extra checks.
+					// This value is constructed on the initialization of the Notebook CR (usually by odh-dashboard).
 					if strings.Contains(container.Image, "image-registry.openshift-image-registry.svc:5000") {
 						log.Info("Internal registry found. Will pick up the default value from image field.")
 						return nil
@@ -691,8 +691,7 @@ func SetContainerImageFromRegistry(ctx context.Context, config *rest.Config, not
 									tagMap := t.(map[string]interface{})
 									tagName := tagMap["tag"].(string)
 									if tagName == imageSelected[1] {
-										items := tagMap["items"].([]interface{})
-										if len(items) > 0 {
+										if items, ok := tagMap["items"].([]interface{}); ok && items != nil && len(items) > 0 {
 											// Sort items by creationTimestamp to get the most recent one
 											sort.Slice(items, func(i, j int) bool {
 												iTime := items[i].(map[string]interface{})["created"].(string)

--- a/components/odh-notebook-controller/controllers/notebook_webhook_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_test.go
@@ -1,0 +1,181 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("The Openshift Notebook webhook", func() {
+	ctx := context.Background()
+
+	When("Creating a Notebook with internal registry disabled", func() {
+		const (
+			Name      = "test-notebook-with-last-image-selection"
+			Namespace = "default"
+		)
+
+		BeforeEach(func() {
+			// namespaces in envtest cannot be deleted https://github.com/kubernetes-sigs/controller-runtime/issues/880
+			err := cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: odhNotebookControllerTestNamespace}}, &client.CreateOptions{})
+			if err != nil && !apierrs.IsAlreadyExists(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		testCases := []struct {
+			name        string
+			imageStream *unstructured.Unstructured
+			notebook    *nbv1.Notebook
+			// currently we expect that Notebook CR is always created,
+			// and when unable to resolve imagestream, image: is left alone
+			expectedImage string
+			// todo(jdanek): also consider Observing for the log message, https://www.youtube.com/watch?v=prLRI3VEVq4
+		}{
+			{
+				name: "ImageStream with all that is needful",
+				imageStream: &unstructured.Unstructured{
+					Object: map[string]any{
+						"kind":       "ImageStream",
+						"apiVersion": "image.openshift.io/v1",
+						"metadata": map[string]any{
+							"name":      "some-image",
+							"namespace": "redhat-ods-applications",
+						},
+						"spec": map[string]any{
+							"lookupPolicy": map[string]any{
+								"local": true,
+							},
+						},
+						"status": map[string]any{
+							"tags": []any{
+								map[string]any{
+									"tag": "some-tag",
+									"items": []map[string]any{
+										{
+											"created":              "2024-10-03T08:10:22Z",
+											"dockerImageReference": "quay.io/modh/odh-generic-data-science-notebook@sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1",
+											"image":                "sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1",
+											"generation":           1,
+										},
+									},
+									"conditions": []any{
+										map[string]any{
+											"type":               "ImportSuccess",
+											"status":             "False",
+											"lastTransitionTime": "2025-03-11T08:50:51Z",
+											"reason":             "NotFound",
+										}}}},
+						},
+					},
+				},
+				notebook: &nbv1.Notebook{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      Name,
+						Namespace: Namespace,
+						Annotations: map[string]string{
+							"notebooks.opendatahub.io/last-image-selection": "some-image:some-tag",
+						},
+					},
+					Spec: nbv1.NotebookSpec{
+						Template: nbv1.NotebookTemplateSpec{
+							Spec: corev1.PodSpec{Containers: []corev1.Container{{
+								Name:  Name,
+								Image: ":some-tag",
+							}}}},
+					},
+				},
+				expectedImage: "quay.io/modh/odh-generic-data-science-notebook@sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1",
+			},
+			{
+				name: "ImageStream with a tag without items (RHOAIENG-13916)",
+				imageStream: &unstructured.Unstructured{
+					Object: map[string]any{
+						"kind":       "ImageStream",
+						"apiVersion": "image.openshift.io/v1",
+						"metadata": map[string]any{
+							"name":      "some-image",
+							"namespace": "redhat-ods-applications",
+						},
+						"spec": map[string]any{
+							"lookupPolicy": map[string]any{
+								"local": true,
+							},
+						},
+						"status": map[string]any{
+							"tags": []any{
+								map[string]any{
+									"tag":   "some-tag",
+									"items": nil,
+									"conditions": []any{
+										map[string]any{
+											"type":               "ImportSuccess",
+											"status":             "False",
+											"lastTransitionTime": "2025-03-11T08:50:51Z",
+											"reason":             "NotFound",
+										}}}},
+						},
+					},
+				},
+				notebook: &nbv1.Notebook{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      Name,
+						Namespace: Namespace,
+						Annotations: map[string]string{
+							"notebooks.opendatahub.io/last-image-selection": "some-image:some-tag",
+						},
+					},
+					Spec: nbv1.NotebookSpec{
+						Template: nbv1.NotebookTemplateSpec{
+							Spec: corev1.PodSpec{Containers: []corev1.Container{{
+								Name:  Name,
+								Image: ":some-tag",
+							}}}},
+					},
+				},
+				// there is no update to the Notebook
+				expectedImage: ":some-tag",
+			},
+		}
+
+		for _, testCase := range testCases {
+			testCase := testCase // create a copy to get correct capture in the `It` closure, https://go.dev/blog/loopvar-preview
+			It(fmt.Sprintf("Should create a Notebook resource successfully: %s", testCase.name), func() {
+				By("Creating a Notebook resource successfully")
+				Expect(cli.Create(ctx, testCase.imageStream, &client.CreateOptions{})).To(Succeed())
+				// if our webhook panics, then cli.Create will err
+				Expect(cli.Create(ctx, testCase.notebook, &client.CreateOptions{})).To(Succeed())
+
+				By("Checking that the webhook modified the notebook CR with the expected image")
+				Expect(testCase.notebook.Spec.Template.Spec.Containers[0].Image).To(Equal(testCase.expectedImage))
+
+				By("Deleting the created resources")
+				Expect(cli.Delete(ctx, testCase.notebook, &client.DeleteOptions{})).To(Succeed())
+				Expect(cli.Delete(ctx, testCase.imageStream, &client.DeleteOptions{})).To(Succeed())
+			})
+		}
+	})
+})


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-13916

## Description

Follow-up to

* https://github.com/opendatahub-io/kubeflow/pull/541

Handles the other line that can panic on incomplete ImageStream status.

## How Has This Been Tested?

Adds a test.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
