### PR TITLE
wip dump info when waiting

### DIFF
--- a/components/odh-notebook-controller/e2e/helper_test.go
+++ b/components/odh-notebook-controller/e2e/helper_test.go
@@ -68,7 +68,7 @@ func (tc *testContext) waitForControllerDeployment(name string, replicas int32) 
 						log.Printf("Pod %s is not running. Current phase: %s", pod.Name, pod.Status.Phase)
 						for _, containerStatus := range pod.Status.ContainerStatuses {
 							if !containerStatus.Ready {
-								log.Printf("Container %s in pod %s is not ready", containerStatus.Name, pod.Name)
+								log.Printf("Container %s in pod %s is not ready: %+v", containerStatus.Name, pod.Name, containerStatus.State)
 								if containerStatus.State.Waiting != nil {
 									log.Printf("Container %s is waiting. Reason: %s, Message: %s",
 										containerStatus.Name, containerStatus.State.Waiting.Reason, containerStatus.State.Waiting.Message)

--- a/components/odh-notebook-controller/e2e/helper_test.go
+++ b/components/odh-notebook-controller/e2e/helper_test.go
@@ -38,6 +38,7 @@ func (tc *testContext) waitForControllerDeployment(name string, replicas int32) 
 		for _, condition := range controllerDeployment.Status.Conditions {
 			if condition.Type == appsv1.DeploymentAvailable {
 				if condition.Status == v1.ConditionTrue && controllerDeployment.Status.ReadyReplicas == replicas {
+					log.Printf("Da deployment is done")
 					return true, nil
 				}
 			}

--- a/components/odh-notebook-controller/e2e/notebook_controller_setup_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_controller_setup_test.go
@@ -117,7 +117,7 @@ func NewTestContext() (*testContext, error) {
 		kubeClient:              kc,
 		customClient:            custClient,
 		testNamespace:           notebookTestNamespace,
-		resourceCreationTimeout: time.Minute * 1,
+		resourceCreationTimeout: time.Minute * 3, // 1*time.Minute is not enough to start seeing errors
 		resourceRetryInterval:   time.Second * 10,
 		ctx:                     context.TODO(),
 		testNotebooks:           testNotebooksContextList,


### PR DESCRIPTION
The e2e OCP-CI test was failing on the 1minute timeout. Thought to investigate by printing verbose status. Turned out that OCP-CI just was slow, the test needed 3 min to start everything. The slowness resolved itself over time.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
