### PR TITLE
NO-JIRA: chore(.tekton/): since ubi8 (and ubi9) minimal images fail in Konflux when subscribed with entitlement certificate, hide the certificate from our build so that it does not fail

### DIFF
--- a/.tekton/kf-notebook-controller-pull-request.yaml
+++ b/.tekton/kf-notebook-controller-pull-request.yaml
@@ -214,6 +214,9 @@ spec:
         value: $(params.dockerfile)
       - name: CONTEXT
         value: $(params.path-context)
+      # KFLUXSPRT-2401: rename the secret so it's not found, otherwise it breaks ubi8:minimal builds
+      - name: ENTITLEMENT_SECRET
+        value: no-such-thing-for-ya
       - name: HERMETIC
         value: $(params.hermetic)
       - name: PREFETCH_INPUT

--- a/.tekton/kf-notebook-controller-push.yaml
+++ b/.tekton/kf-notebook-controller-push.yaml
@@ -213,6 +213,9 @@ spec:
         value: $(params.dockerfile)
       - name: CONTEXT
         value: $(params.path-context)
+      # KFLUXSPRT-2401: rename the secret so it's not found, otherwise it breaks ubi8:minimal builds
+      - name: ENTITLEMENT_SECRET
+        value: no-such-thing-for-ya
       - name: HERMETIC
         value: $(params.hermetic)
       - name: PREFETCH_INPUT

--- a/.tekton/odh-notebook-controller-pull-request.yaml
+++ b/.tekton/odh-notebook-controller-pull-request.yaml
@@ -214,6 +214,9 @@ spec:
         value: $(params.dockerfile)
       - name: CONTEXT
         value: $(params.path-context)
+      # KFLUXSPRT-2401: rename the secret so it's not found, otherwise it breaks ubi8:minimal builds
+      - name: ENTITLEMENT_SECRET
+        value: no-such-thing-for-ya
       - name: HERMETIC
         value: $(params.hermetic)
       - name: PREFETCH_INPUT

--- a/.tekton/odh-notebook-controller-push.yaml
+++ b/.tekton/odh-notebook-controller-push.yaml
@@ -213,6 +213,9 @@ spec:
         value: $(params.dockerfile)
       - name: CONTEXT
         value: $(params.path-context)
+      # KFLUXSPRT-2401: rename the secret so it's not found, otherwise it breaks ubi8:minimal builds
+      - name: ENTITLEMENT_SECRET
+        value: no-such-thing-for-ya
       - name: HERMETIC
         value: $(params.hermetic)
       - name: PREFETCH_INPUT


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-18400

## Description

* https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1742825365320619?thread_ts=1742819729.272789&cid=C04PZ7H0VA8

## How Has This Been Tested?

CI

## Merge criteria:

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
