### PR TITLE
NO-JIRA: deps({odh-}notebook-controller): update to go1.23

### DIFF
--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -7,9 +7,11 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.22
+ARG GOLANG_VERSION=1.23
 
 # Use ubi8/go-toolset as base image
+# https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1
+# image sets GOTOOLCHAIN=local so it won't end up downloading if go.mod requests different version
 FROM registry.access.redhat.com/ubi8/go-toolset:${GOLANG_VERSION} as builder
 ARG TARGETOS
 ARG TARGETARCH

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -1,8 +1,8 @@
 module github.com/kubeflow/kubeflow/components/notebook-controller
 
-go 1.22
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -7,9 +7,11 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.22
+ARG GOLANG_VERSION=1.23
 
 # Use ubi8/go-toolset as base image
+# https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1
+# image sets GOTOOLCHAIN=local so it won't end up downloading if go.mod requests different version
 FROM registry.access.redhat.com/ubi8/go-toolset:${GOLANG_VERSION} as builder
 ARG TARGETOS
 ARG TARGETARCH

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -1,8 +1,8 @@
 module github.com/opendatahub-io/kubeflow/components/odh-notebook-controller
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
* https://github.com/opendatahub-io/kubeflow/pull/574

* Release notes https://tip.golang.org/doc/go1.23

## Description

This is a follow-up to

* https://github.com/opendatahub-io/kubeflow/pull/571

so that we can finally get

* https://github.com/opendatahub-io/kubeflow/pull/556

## How Has This Been Tested?

GHA / OCP-CI

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
