### PR TITLE
RHOAIENG-23765: Adjust the image selection to consider notebook namespace

### DIFF
--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -33,6 +33,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - kubeflow.org
   resources:

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -76,7 +76,7 @@ type OpenshiftNotebookReconciler struct {
 // +kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthclients,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=list;get
+// +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=list;get;watch
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.
 func CompareNotebooks(nb1 nbv1.Notebook, nb2 nbv1.Notebook) bool {
@@ -137,7 +137,7 @@ func (r *OpenshiftNotebookReconciler) RemoveReconciliationLock(notebook *nbv1.No
 				return err
 			}
 			if len(serviceAccount.ImagePullSecrets) == 0 {
-				return errors.New("Pull secret not mounted")
+				return errors.New("pull secret not mounted")
 			}
 			return nil
 		},
@@ -358,7 +358,7 @@ func (r *OpenshiftNotebookReconciler) CreateNotebookCertConfigMap(notebook *nbv1
 					r.Log.Info("Created workbench-trusted-ca-bundle ConfigMap", "namespace", notebook.Namespace, "notebook", notebook.Name)
 				}
 			}
-		} else if err == nil && !reflect.DeepEqual(foundTrustedCAConfigMap.Data, desiredTrustedCAConfigMap.Data) {
+		} else if !reflect.DeepEqual(foundTrustedCAConfigMap.Data, desiredTrustedCAConfigMap.Data) {
 			// some data has changed, update the ConfigMap
 			r.Log.Info("Updating workbench-trusted-ca-bundle ConfigMap", "namespace", notebook.Namespace, "notebook", notebook.Name)
 			foundTrustedCAConfigMap.Data = desiredTrustedCAConfigMap.Data

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -939,7 +939,12 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		})
 
 		It("Should not create OAuth secret", func() {
-			secrets := &corev1.SecretList{}
+			secrets := &corev1.SecretList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "SecretList",
+					APIVersion: "v1",
+				},
+			}
 			Eventually(func() error {
 				return cli.List(context.Background(), secrets, client.InNamespace(namespace))
 			}, duration, interval).Should(Succeed())

--- a/components/odh-notebook-controller/controllers/notebook_webhook_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_test.go
@@ -215,7 +215,7 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 							}}}},
 					},
 				},
-				// there is no update to the Notebook
+				// valid new image is picked from user namespace.
 				expectedImage: "quay.io/modh/odh-generic-data-science-notebook@sha256:5999547f847ca841fe067ff84e2972d2cbae598066c2418e236448e115c1728e",
 				unexpectedEvents: []string{
 					IMAGE_STREAM_NOT_FOUND_EVENT,

--- a/components/odh-notebook-controller/controllers/notebook_webhook_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_test.go
@@ -18,12 +18,13 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
@@ -49,7 +50,7 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 
 		testCases := []struct {
 			name        string
-			imageStream *unstructured.Unstructured
+			imageStream *imagev1.ImageStream
 			notebook    *nbv1.Notebook
 			// currently we expect that Notebook CR is always created,
 			// and when unable to resolve imagestream, image: is left alone
@@ -60,39 +61,36 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 		}{
 			{
 				name: "ImageStream with all that is needful",
-				imageStream: &unstructured.Unstructured{
-					Object: map[string]any{
-						"kind":       "ImageStream",
-						"apiVersion": "image.openshift.io/v1",
-						"metadata": map[string]any{
-							"name":      "some-image",
-							"namespace": "redhat-ods-applications",
+				imageStream: &imagev1.ImageStream{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ImageStream",
+						APIVersion: "image.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-image",
+						Namespace: "redhat-ods-applications",
+					},
+					Spec: imagev1.ImageStreamSpec{
+						LookupPolicy: imagev1.ImageLookupPolicy{
+							Local: true,
 						},
-						"spec": map[string]any{
-							"lookupPolicy": map[string]any{
-								"local": true,
-							},
-						},
-						"status": map[string]any{
-							"tags": []any{
-								map[string]any{
-									"tag": "some-tag",
-									"items": []map[string]any{
-										{
-											"created":              "2024-10-03T08:10:22Z",
-											"dockerImageReference": "quay.io/modh/odh-generic-data-science-notebook@sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1",
-											"image":                "sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1",
-											"generation":           1,
-										},
-									},
-									"conditions": []any{
-										map[string]any{
-											"type":               "ImportSuccess",
-											"status":             "False",
-											"lastTransitionTime": "2025-03-11T08:50:51Z",
-											"reason":             "NotFound",
-										}}}},
-						},
+					},
+					Status: imagev1.ImageStreamStatus{
+						Tags: []imagev1.NamedTagEventList{{
+							Tag: "some-tag",
+							Items: []imagev1.TagEvent{{
+								Created:              toMetav1Time("2024-10-03T08:10:22Z"),
+								DockerImageReference: "quay.io/modh/odh-generic-data-science-notebook@sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1",
+								Image:                "sha256:76e6af79c601a323f75a58e7005de0beac66b8cccc3d2b67efb6d11d85f0cfa1",
+								Generation:           2,
+							}},
+							Conditions: []imagev1.TagEventCondition{{
+								Type:               "ImportSuccess",
+								Status:             "False",
+								LastTransitionTime: toMetav1Time("2025-03-11T08:50:51Z"),
+								Reason:             "NotFound",
+							}},
+						}},
 					},
 				},
 				notebook: &nbv1.Notebook{
@@ -118,32 +116,31 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 			},
 			{
 				name: "ImageStream with a tag without items (RHOAIENG-13916)",
-				imageStream: &unstructured.Unstructured{
-					Object: map[string]any{
-						"kind":       "ImageStream",
-						"apiVersion": "image.openshift.io/v1",
-						"metadata": map[string]any{
-							"name":      "some-image",
-							"namespace": "redhat-ods-applications",
+				imageStream: &imagev1.ImageStream{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ImageStream",
+						APIVersion: "image.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-image",
+						Namespace: "redhat-ods-applications",
+					},
+					Spec: imagev1.ImageStreamSpec{
+						LookupPolicy: imagev1.ImageLookupPolicy{
+							Local: true,
 						},
-						"spec": map[string]any{
-							"lookupPolicy": map[string]any{
-								"local": true,
-							},
-						},
-						"status": map[string]any{
-							"tags": []any{
-								map[string]any{
-									"tag":   "some-tag",
-									"items": nil,
-									"conditions": []any{
-										map[string]any{
-											"type":               "ImportSuccess",
-											"status":             "False",
-											"lastTransitionTime": "2025-03-11T08:50:51Z",
-											"reason":             "NotFound",
-										}}}},
-						},
+					},
+					Status: imagev1.ImageStreamStatus{
+						Tags: []imagev1.NamedTagEventList{{
+							Tag:   "some-tag",
+							Items: nil,
+							Conditions: []imagev1.TagEventCondition{{
+								Type:               "ImportSuccess",
+								Status:             "False",
+								LastTransitionTime: toMetav1Time("2025-03-11T08:50:51Z"),
+								Reason:             "",
+							}},
+						}},
 					},
 				},
 				notebook: &nbv1.Notebook{
@@ -165,6 +162,62 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 				// there is no update to the Notebook
 				expectedImage: ":some-tag",
 				expectedEvents: []string{
+					IMAGE_STREAM_TAG_NOT_FOUND_EVENT,
+				},
+			},
+			{
+				name: "ImageStream in the same namespace as the Notebook",
+				imageStream: &imagev1.ImageStream{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ImageStream",
+						APIVersion: "image.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-image",
+						Namespace: Namespace,
+					},
+					Spec: imagev1.ImageStreamSpec{
+						LookupPolicy: imagev1.ImageLookupPolicy{
+							Local: true,
+						},
+					},
+					Status: imagev1.ImageStreamStatus{
+						Tags: []imagev1.NamedTagEventList{{
+							Tag: "some-tag",
+							Items: []imagev1.TagEvent{{
+								Created:              toMetav1Time("2025-05-14T02:36:21Z"),
+								DockerImageReference: "quay.io/modh/odh-generic-data-science-notebook@sha256:5999547f847ca841fe067ff84e2972d2cbae598066c2418e236448e115c1728e",
+								Image:                "sha256:5999547f847ca841fe067ff84e2972d2cbae598066c2418e236448e115c1728e",
+								Generation:           2,
+							}},
+							Conditions: []imagev1.TagEventCondition{{
+								Type:               "ImportSuccess",
+								Status:             "False",
+								LastTransitionTime: toMetav1Time("2025-05-14T02:36:21Z"),
+								Reason:             "NotFound",
+							}},
+						}},
+					},
+				},
+				notebook: &nbv1.Notebook{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      Name,
+						Namespace: Namespace,
+						Annotations: map[string]string{
+							"notebooks.opendatahub.io/last-image-selection": "some-image:some-tag",
+						},
+					},
+					Spec: nbv1.NotebookSpec{
+						Template: nbv1.NotebookTemplateSpec{
+							Spec: corev1.PodSpec{Containers: []corev1.Container{{
+								Name:  Name,
+								Image: ":some-tag",
+							}}}},
+					},
+				},
+				// there is no update to the Notebook
+				expectedImage: "quay.io/modh/odh-generic-data-science-notebook@sha256:5999547f847ca841fe067ff84e2972d2cbae598066c2418e236448e115c1728e",
+				unexpectedEvents: []string{
 					IMAGE_STREAM_NOT_FOUND_EVENT,
 				},
 			},
@@ -209,3 +262,11 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 		}
 	})
 })
+
+func toMetav1Time(timeString string) metav1.Time {
+	parsedTime, err := time.Parse(time.RFC3339, timeString)
+	if err != nil {
+		return metav1.Time{}
+	}
+	return metav1.NewTime(parsedTime)
+}

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -154,6 +155,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(nbv1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(netv1.AddToScheme(scheme))
+	utilruntime.Must(imagev1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 

--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -40,6 +40,7 @@ import (
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	configv1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -58,16 +59,20 @@ func init() {
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(configv1.AddToScheme(scheme))
 	utilruntime.Must(oauthv1.AddToScheme(scheme))
+	utilruntime.Must(imagev1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }
 
 func getControllerNamespace() (string, error) {
 	// Try to get the namespace from the service account secret
+	// or from the K8S_NAMESPACE environment variable in local
 	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := string(data); len(ns) > 0 {
 			return ns, nil
 		}
+	} else if ns := os.Getenv("K8S_NAMESPACE"); len(ns) > 0 {
+		return ns, nil
 	}
 
 	return "", fmt.Errorf("unable to determine the namespace")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

[RHOAIENG-23765](https://issues.redhat.com//browse/RHOAIENG-23765): Adjust the image selection to consider notebook namespace
With the initiative: https://issues.redhat.com/browse/RHOAISTRAT-340
User would be able to create and use imagestream in their own namespace.
With this feature, on a cluster where internal image registry is disabled 
should accommodate this inclusion.

- By default read from controller namespace for imagestream
- Look up imagestream in user namespace if not available on default.


Restructured the code to directly use : https://github.com/openshift/api/blob/master/image/v1/types.go

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* local
> make test
```
The Openshift Notebook webhook when Creating a Notebook with internal registry disabled The Notebook webhook test case: ImageStream in the same namespace as the Notebook 
  Should create a Notebook resource successfully
  /home/hnalla/odh/odh-kubeflow/components/odh-notebook-controller/controllers/notebook_webhook_test.go:233
[BeforeEach] when Creating a Notebook with internal registry disabled
  /home/hnalla/odh/odh-kubeflow/components/odh-notebook-controller/controllers/notebook_webhook_test.go:43
[BeforeEach] when Creating a Notebook with internal registry disabled
  /home/hnalla/odh/odh-kubeflow/components/odh-notebook-controller/controllers/notebook_webhook_test.go:226
[It] Should create a Notebook resource successfully
  /home/hnalla/odh/odh-kubeflow/components/odh-notebook-controller/controllers/notebook_webhook_test.go:233
STEP: Creating a Notebook resource successfully
2025-05-14T00:20:27-04:00	INFO	controllers.notebook-controller	No internal registry found, let's pick up image reference from relevant ImageStream 'status.tags[].tag.dockerImageReference'	{"notebook": "test-notebook-with-last-image-selection", "namespace": "default"}
2025-05-14T00:20:27-04:00	INFO	controllers.notebook-controller	Unable to find the ImageStream in controller namespace, try finding in notebook namespace	{"notebook": "test-notebook-with-last-image-selection", "namespace": "default", "imagestream": "some-image", "controllerNamespace": "redhat-ods-applications"}
2025-05-14T00:20:27-04:00	INFO	controllers.notebook-controller	ImageStream found in notebook namespace	{"notebook": "test-notebook-with-last-image-selection", "namespace": "default", "imagestream": "some-image", "namespace": "default"}
2025-05-14T00:20:27-04:00	INFO	controllers.notebook-controller	odh-trusted-ca-bundle ConfigMap is not present, not starting mounting process.	{"notebook": "test-notebook-with-last-image-selection", "namespace": "default"}
2025-05-14T00:20:27-04:00	INFO	controllers.notebook-controller	ConfigMap does not exist	{"notebook": "test-notebook-with-last-image-selection", "namespace": "default", "ConfigMap": "pipeline-runtime-images"}
2025-05-14T00:20:27-04:00	INFO	controllers.notebook-controller	Not blocking update, notebook is being newly created	{"notebook": "test-notebook-with-last-image-selection", "namespace": "default"}
STEP: Checking that the webhook modified the notebook CR with the expected image
STEP: Checking telemetry events
[AfterEach] The Notebook webhook test case: ImageStream in the same namespace as the Notebook
  /home/hnalla/odh/odh-kubeflow/components/odh-notebook-controller/controllers/notebook_webhook_test.go:256
STEP: Deleting the created resources
•
```

* on cluster
- Deploy the controller with image of this PR
```
    workbenches:
      devFlags:
        manifests:
          - contextDir: components/odh-notebook-controller/config
            sourcePath: ''
            uri: 'https://github.com/harshad16/odh-kubeflow/archive/test-image.tar.gz'
      managementState: Managed
```
- Disable the internal registry 
- Try using different scenarios
   - imagestream on user namespace
   - imagestream on default namespace
   
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
