### PR TITLE
NO-JIRA: default to building `--platform=linux/amd64` images in Docker builds

### DIFF
--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -92,7 +92,7 @@ run-culling: generate fmt vet manifests
 ##@ Build
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	cd .. && ${CONTAINER_ENGINE} build . -t ${IMG}:${TAG} -f ./notebook-controller/Dockerfile
+	cd .. && ${CONTAINER_ENGINE} build . --platform="${ARCH}" -t ${IMG}:${TAG} -f ./notebook-controller/Dockerfile
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -4,6 +4,7 @@ include makefile-vars.mk
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/opendatahub/odh-notebook-controller
 TAG ?= $(shell git describe --tags --always)
+ARCH ?= linux/amd64
 
 KF_IMG ?= quay.io/opendatahub/kubeflow-notebook-controller
 KF_TAG ?= $(KF_TAG)
@@ -115,7 +116,7 @@ run: manifests generate fmt vet certificates ktunnel ## Run a controller from yo
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	cd ../ && ${CONTAINER_ENGINE} build . -t ${IMG}:${TAG} -f odh-notebook-controller/Dockerfile
+	cd ../ && ${CONTAINER_ENGINE} build . --platform="${ARCH}" -t ${IMG}:${TAG} -f odh-notebook-controller/Dockerfile
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
## Description

This update sets the `--platform` flag in Docker build commands, allowing builds for specific architectures by using the `ARCH` variable. The default architecture is set to `linux/amd64`, ensuring compatibility and flexibility for multi-platform environments.

## How Has This Been Tested?

```
❯ cd components/notebook-controller; gmake docker-build
❯ cd components/odh-notebook-controller; gmake docker-build
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
