### PR TITLE
RHOAIENG-23751: Add finalizer to clean up OAuthClients on notebook deletion

### DIFF
--- a/components/odh-notebook-controller/config/crd/external/oauthclients.oauth.openshift.io.yaml
+++ b/components/odh-notebook-controller/config/crd/external/oauthclients.oauth.openshift.io.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    crd/fake: "true"
+  name: oauthclients.oauth.openshift.io
+spec:
+  group: oauth.openshift.io
+  names:
+    kind: OAuthClient
+    listKind: OAuthClientList
+    plural: oauthclients
+    singular: oauthclient
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: OAuthClient represents an OAuth client
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.'
+            type: string
+          metadata:
+            type: object
+          grantMethod:
+            description: 'Method used to authorize client users (auto, prompt, or deny)'
+            type: string
+          secret:
+            description: 'Client secret'
+            type: string
+          redirectURIs:
+            description: 'List of valid redirect URIs for the client'
+            type: array
+            items:
+              type: string
+          respondWithChallenges:
+            description: 'If true, respond to 401 errors with a WWW-Authenticate challenge'
+            type: boolean
+          accessTokenMaxAgeSeconds:
+            description: 'Maximum token lifetime in seconds'
+            type: integer
+            format: int32
+          accessTokenInactivityTimeoutSeconds:
+            description: 'Timeout for inactive tokens in seconds'
+            type: integer
+            format: int32
+          additionalSecrets:
+            description: 'Additional client secrets'
+            type: array
+            items:
+              type: string
+          scopeRestrictions:
+            description: 'Restrictions on scopes the client can request'
+            type: array
+            items:
+              type: object
+    served: true
+    storage: true

--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -58,6 +58,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
 - apiGroups:
   - kubeflow.org
@@ -88,6 +89,7 @@ rules:
   - oauthclients
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -67,14 +67,14 @@ type OpenshiftNotebookReconciler struct {
 
 // ClusterRole permissions
 
-// +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks/status,verbs=get
 // +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks/finalizers,verbs=update
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthclients,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthclients,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=list;get;watch

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -1061,7 +1061,10 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("Ensuring finalizer exists first")
 			Eventually(func() []string {
 				var updated nbv1.Notebook
-				cli.Get(ctx, notebookKey, &updated)
+				err := cli.Get(ctx, notebookKey, &updated)
+				if err != nil {
+					return nil
+				}
 				return updated.Finalizers
 			}, duration, interval).Should(ContainElement(Finalizer))
 
@@ -1083,7 +1086,10 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("Ensuring prerequisite resources exist")
 			Eventually(func() []string {
 				var updated nbv1.Notebook
-				cli.Get(ctx, notebookKey, &updated)
+				err := cli.Get(ctx, notebookKey, &updated)
+				if err != nil {
+					return nil
+				}
 				return updated.Finalizers
 			}, duration, interval).Should(ContainElement(Finalizer))
 
@@ -1100,8 +1106,10 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("Verifying notebook is marked for deletion but persists due to finalizer")
 			Eventually(func() bool {
 				var updated nbv1.Notebook
-				err := cli.Get(ctx, notebookKey, &updated)
-				return err == nil && updated.DeletionTimestamp != nil
+				if err := cli.Get(ctx, notebookKey, &updated); err != nil {
+					return false
+				}
+				return updated.DeletionTimestamp != nil
 			}, duration, interval).Should(BeTrue(),
 				"Notebook should be marked for deletion but persist due to finalizer")
 
@@ -1120,7 +1128,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			Eventually(func() error {
 				var oauth oauthv1.OAuthClient
 				return cli.Get(ctx, oauthClientKey, &oauth)
-			}, time.Second*30).Should(MatchError(ContainSubstring("not found")))
+			}, duration, interval).Should(MatchError(ContainSubstring("not found")))
 
 			By("Verifying finalizer is removed and notebook is deleted")
 			Eventually(func() error {

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -38,6 +38,7 @@ import (
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
 	imagev1 "github.com/openshift/api/image/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -158,6 +159,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(netv1.AddToScheme(scheme))
 	utilruntime.Must(imagev1.AddToScheme(scheme))
 	utilruntime.Must(dspav1.AddToScheme(scheme))
+	utilruntime.Must(oauthv1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 


### PR DESCRIPTION
This PR fixes [RHOAIENG-23751](https://issues.redhat.com/browse/RHOAIENG-23751)

## Description
In the PR #449 , a change was done in such way that we would use an OAuthClient object to bypass the OAuth permission form (authentication is confirmed, only the permission is not required anymore), but since OAuthClient objects are cluster-level objects, they cannot be garbage-collected using the SetControllerReference method, and to fix it, a Finalizer needs to be created.

The main fix on this PR is to add the finalizer to the Notebook CRD, in such way that it will try to identify if a Notebook has been marked for deletion or not. If so, will wait to delete the OAuthClient properly, so no orphaned OAuthClient objects will remain in the server.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for managing OAuth clients as custom resources, including automatic cleanup of associated OAuth clients when a Notebook is deleted.
- **Bug Fixes**
  - Improved handling of resource deletion to ensure proper cleanup of OAuth clients.
- **Tests**
  - Added new tests to verify the creation and deletion flow of Notebooks with associated OAuth clients.
- **Chores**
  - Updated permissions and test environment setup to support OAuth client management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->