### PR TITLE
RHOAIENG-23765: Add span event when ImageStream isn't found.

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -732,6 +732,7 @@ func SetContainerImageFromRegistry(ctx context.Context, cli client.Client, noteb
 						err = cli.Get(ctx, types.NamespacedName{Name: imagestreamName, Namespace: notebook.Namespace}, imgSelection)
 						if err != nil {
 							log.Error(err, "Error getting ImageStream", "imagestream", imagestreamName, "controllerNamespace", controllerNamespace)
+							span.AddEvent(IMAGE_STREAM_NOT_FOUND_EVENT)
 						} else {
 							// ImageStream found in the notebook namespace
 							imagestreamFound = true


### PR DESCRIPTION
This event should be raised when we don't find the required ImageStream neither in the controller namespace nor in the notebook namespace. Also, this event is used as a check point for the relevant test so we should have it.

It was removed in #593.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
