### PR TITLE
RHOAIENG-23204: feat: Introduce dspa secret controller to handle ds-pipeline-config lifecycle

### DIFF
--- a/components/odh-notebook-controller/config/crd/external/opendatahub.io_dashboard.yaml
+++ b/components/odh-notebook-controller/config/crd/external/opendatahub.io_dashboard.yaml
@@ -1,0 +1,156 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: dashboards.components.platform.opendatahub.io
+spec:
+  group: components.platform.opendatahub.io
+  names:
+    kind: Dashboard
+    listKind: DashboardList
+    plural: dashboards
+    singular: dashboard
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - description: URL
+      jsonPath: .status.url
+      name: URL
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Dashboard is the Schema for the dashboards API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DashboardSpec defines the desired state of Dashboard
+            properties:
+              devFlags:
+                description: Add developer fields
+                properties:
+                  manifests:
+                    description: List of custom manifests for the given component
+                    items:
+                      properties:
+                        contextDir:
+                          default: manifests
+                          description: contextDir is the relative path to the folder
+                            containing manifests in a repository, default value "manifests"
+                          type: string
+                        sourcePath:
+                          default: ""
+                          description: 'sourcePath is the subpath within contextDir
+                            where kustomize builds start. Examples include any sub-folder
+                            or path: `base`, `overlays/dev`, `default`, `odh` etc.'
+                          type: string
+                        uri:
+                          default: ""
+                          description: uri is the URI point to a git repo with tag/branch.
+                            e.g.  https://github.com/org/repo/tarball/<tag/branch>
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: DashboardStatus defines the observed state of Dashboard
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastHeartbeatTime:
+                      description: |-
+                        The last time we got an update on a given condition, this should not be set and is
+                        present only for backward compatibility reasons
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human-readable message indicating
+                        details about the transition.
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        The value should be a CamelCase string.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity with which to treat failures of this type of condition.
+                        When this is not specified, it defaults to Error.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              observedGeneration:
+                description: The generation observed by the resource controller.
+                format: int64
+                type: integer
+              phase:
+                type: string
+              url:
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: Dashboard name must be default-dashboard
+          rule: self.metadata.name == 'default-dashboard'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/components/odh-notebook-controller/config/crd/external/opendatahub.io_dspa.yaml
+++ b/components/odh-notebook-controller/config/crd/external/opendatahub.io_dspa.yaml
@@ -1,0 +1,1969 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: datasciencepipelinesapplications.datasciencepipelinesapplications.opendatahub.io
+spec:
+  group: datasciencepipelinesapplications.opendatahub.io
+  names:
+    kind: DataSciencePipelinesApplication
+    listKind: DataSciencePipelinesApplicationList
+    plural: datasciencepipelinesapplications
+    shortNames:
+    - dspa
+    singular: datasciencepipelinesapplication
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              apiServer:
+                default:
+                  deploy: true
+                description: DS Pipelines API Server configuration.
+                properties:
+                  argoDriverImage:
+                    description: Driver image used during pipeline execution.
+                    type: string
+                  argoLauncherImage:
+                    description: Launcher/Executor image used during pipeline execution.
+                    type: string
+                  artifactSignedURLExpirySeconds:
+                    default: 60
+                    description: |-
+                      The expiry time (seconds) for artifact download links when
+                      querying the dsp server via /apis/v2beta1/artifacts/{id}?share_url=true
+                      Default: 60
+                    type: integer
+                  cABundle:
+                    description: |-
+                      If the Object store/DB is behind a TLS secured connection that is
+                      unrecognized by the host OpenShift/K8s cluster, then you can
+                      provide a PEM formatted CA bundle to be injected into the DSP
+                      server pod to trust this connection. CA Bundle should be provided
+                      as values within configmaps, mapped to keys.
+                    properties:
+                      configMapKey:
+                        description: |-
+                          Key should map to a CA bundle. The key is also used to name
+                          the CA bundle file (e.g. ca-bundle.crt)
+                        type: string
+                      configMapName:
+                        type: string
+                    required:
+                    - configMapKey
+                    - configMapName
+                    type: object
+                  caBundleFileMountPath:
+                    description: |-
+                      This is the path where the ca bundle will be mounted in the
+                      pipeline server and user executor pods
+                    type: string
+                  caBundleFileName:
+                    description: |-
+                      This is the filename of the ca bundle that will be created in the
+                      pipeline server and user executor pods
+                    type: string
+                  customKfpLauncherConfigMap:
+                    description: |-
+                      When specified, the `data` contents of the `kfp-launcher` ConfigMap that DSPO writes
+                      will be fully replaced with the `data` contents of the ConfigMap specified here.
+                      This allows the user to fully replace the `data` contents of the kfp-launcher ConfigMap.
+                      The `kfp-launcher` component requires a ConfigMap to exist in the namespace
+                      where it runs (i.e. the namespace where pipelines run). This ConfigMap contains
+                      object storage configuration, as well as pipeline root (object store root path
+                      where artifacts will be uploaded) configuration. Currently this ConfigMap *must*
+                      be named "kfp-launcher". We currently deploy a default copy of the kfp-launcher
+                      ConfigMap via DSPO, but a user may want to provide their own ConfigMap configuration,
+                      so that they can specify multiple object storage sources and paths.
+                    type: string
+                  customServerConfigMap:
+                    description: |-
+                      CustomServerConfig is a custom config file that you can provide
+                      for the api server to use instead.
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  deploy:
+                    default: true
+                    description: 'Enable DS Pipelines Operator management of DSP API
+                      Server. Setting Deploy to false disables operator reconciliation.
+                      Default: true'
+                    type: boolean
+                  enableOauth:
+                    default: true
+                    description: 'Create an Openshift Route for this DSP API Server.
+                      Default: true'
+                    type: boolean
+                  enableSamplePipeline:
+                    default: false
+                    description: 'Include the Iris sample pipeline with the deployment
+                      of this DSP API Server. Default: true'
+                    type: boolean
+                  image:
+                    description: Specify a custom image for DSP API Server.
+                    type: string
+                  initResources:
+                    description: |-
+                      Specify init container resource requirements. The init container
+                      is used to build managed-pipelines and store them in a shared volume.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  managedPipelines:
+                    description: Enable various managed pipelines on this DSP API
+                      server.
+                    properties:
+                      instructLab:
+                        description: |-
+                          Configures whether to automatically import the technical preview of the InstructLab pipeline.
+                          You must enable the trainingoperator component to run the InstructLab pipeline.
+                        properties:
+                          state:
+                            default: Removed
+                            description: |-
+                              Set to one of the following values:
+
+                              - "Managed" : This pipeline is automatically imported.
+                              - "Removed" : This pipeline is not automatically imported. If previously set to "Managed", setting to "Removed" does not remove existing managed pipelines but does prevent future updates from being imported.
+                            enum:
+                            - Managed
+                            - Removed
+                            pattern: ^(Managed|Removed)$
+                            type: string
+                        type: object
+                    type: object
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  rhelAIImage:
+                    description: RhelAI image used for ilab tasks in managed pipelines.
+                    type: string
+                  runtimeGenericImage:
+                    description: |-
+                      Generic runtime image used for building managed pipelines during
+                      api server init, and for basic runtime operations.
+                    type: string
+                  toolboxImage:
+                    description: |-
+                      Toolbox image used for basic container spec runtime operations
+                      in managed pipelines.
+                    type: string
+                type: object
+              database:
+                default:
+                  mariaDB:
+                    deploy: true
+                description: Database specifies database configurations, used for
+                  DS Pipelines metadata tracking. Specify either the default MariaDB
+                  deployment, or configure your own External SQL DB.
+                properties:
+                  customExtraParams:
+                    description: |-
+                      CustomExtraParams allow users to further customize the sql dsn parameters used by the Pipeline Server
+                      when opening a connection with the Database.
+                      ref: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#dsn-data-source-name
+
+                      Value must be a JSON string. For example, to disable tls for Pipeline Server DB connection
+                      the user can provide a string: {"tls":"true"}
+
+                      If updating post DSPA deployment, then a manual restart of the pipeline server pod will be required
+                      so the new configmap may be consumed.
+                    type: string
+                  disableHealthCheck:
+                    default: false
+                    description: 'Default: false'
+                    type: boolean
+                  externalDB:
+                    properties:
+                      host:
+                        type: string
+                      passwordSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      pipelineDBName:
+                        type: string
+                      port:
+                        type: string
+                      username:
+                        type: string
+                    required:
+                    - host
+                    - passwordSecret
+                    - pipelineDBName
+                    - port
+                    - username
+                    type: object
+                  mariaDB:
+                    properties:
+                      deploy:
+                        default: true
+                        description: 'Enable DS Pipelines Operator management of MariaDB.
+                          Setting Deploy to false disables operator reconciliation.
+                          Default: true'
+                        type: boolean
+                      image:
+                        description: Specify a custom image for DSP MariaDB pod.
+                        type: string
+                      passwordSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      pipelineDBName:
+                        default: mlpipeline
+                        description: 'The database name that will be created. Should
+                          match `^[a-zA-Z0-9_]+`. // Default: mlpipeline'
+                        pattern: ^[a-zA-Z0-9_]+$
+                        type: string
+                      pvcSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 10Gi
+                        description: 'Customize the size of the PVC created for the
+                          default MariaDB instance. Default: 10Gi'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      resources:
+                        description: Specify custom Pod resource requirements for
+                          this component.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      storageClassName:
+                        description: Volume Mode Filesystem storageClass to use for
+                          PVC creation
+                        type: string
+                      username:
+                        default: mlpipeline
+                        description: 'The MariadB username that will be created. Should
+                          match `^[a-zA-Z0-9_]+`. Default: mlpipeline'
+                        pattern: ^[a-zA-Z0-9_]+$
+                        type: string
+                    type: object
+                type: object
+              dspVersion:
+                default: v2
+                type: string
+              mlmd:
+                properties:
+                  deploy:
+                    default: false
+                    description: 'Enable DS Pipelines Operator management of MLMD.
+                      Setting Deploy to false disables operator reconciliation. Default:
+                      true'
+                    type: boolean
+                  envoy:
+                    properties:
+                      deployRoute:
+                        default: true
+                        type: boolean
+                      image:
+                        type: string
+                      resources:
+                        description: |-
+                          ResourceRequirements structures compute resource requirements.
+                          Replaces ResourceRequirements from corev1 which also includes optional storage field.
+                          We handle storage field separately, and should not include it as a subfield for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    type: object
+                  grpc:
+                    properties:
+                      image:
+                        type: string
+                      port:
+                        type: string
+                      resources:
+                        description: |-
+                          ResourceRequirements structures compute resource requirements.
+                          Replaces ResourceRequirements from corev1 which also includes optional storage field.
+                          We handle storage field separately, and should not include it as a subfield for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              mlpipelineUI:
+                description: Deploy the KFP UI with DS Pipelines UI. This feature
+                  is unsupported, and primarily used for exploration, testing, and
+                  development purposes.
+                properties:
+                  configMap:
+                    type: string
+                  deploy:
+                    default: true
+                    description: 'Enable DS Pipelines Operator management of KFP UI.
+                      Setting Deploy to false disables operator reconciliation. Default:
+                      true'
+                    type: boolean
+                  image:
+                    description: Specify a custom image for KFP UI pod.
+                    type: string
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              objectStorage:
+                description: ObjectStorage specifies Object Store configurations,
+                  used for DS Pipelines artifact passing and storage. Specify either
+                  the your own External Storage (e.g. AWS S3), or use the default
+                  Minio deployment (unsupported, primarily for development, and testing)
+                  .
+                properties:
+                  disableHealthCheck:
+                    default: false
+                    description: 'Default: false'
+                    type: boolean
+                  enableExternalRoute:
+                    default: false
+                    description: 'Enable an external route so the object storage is
+                      reachable from outside the cluster. Default: false'
+                    type: boolean
+                  externalStorage:
+                    properties:
+                      basePath:
+                        description: Subpath where objects should be stored for this
+                          DSPA
+                        type: string
+                      bucket:
+                        type: string
+                      host:
+                        type: string
+                      port:
+                        type: string
+                      region:
+                        type: string
+                      s3CredentialsSecret:
+                        properties:
+                          accessKey:
+                            description: The "Keys" in the k8sSecret key/value pairs.
+                              Not to be confused with the values.
+                            type: string
+                          secretKey:
+                            type: string
+                          secretName:
+                            description: The name of the Secret where the AccessKey
+                              and SecretKey are defined.
+                            type: string
+                        required:
+                        - accessKey
+                        - secretKey
+                        - secretName
+                        type: object
+                      scheme:
+                        type: string
+                      secure:
+                        type: boolean
+                    required:
+                    - bucket
+                    - host
+                    - s3CredentialsSecret
+                    - scheme
+                    type: object
+                  minio:
+                    description: Enable DS Pipelines Operator management of Minio.
+                      Setting Deploy to false disables operator reconciliation.
+                    properties:
+                      bucket:
+                        default: mlpipeline
+                        description: 'Provide the Bucket name that will be used to
+                          store artifacts in S3. If provided bucket does not exist,
+                          DSP Apiserver will attempt to create it. As such the credentials
+                          provided should have sufficient permissions to do create
+                          buckets. Default: mlpipeline'
+                        type: string
+                      deploy:
+                        default: true
+                        description: 'Enable DS Pipelines Operator management of Minio.
+                          Setting Deploy to false disables operator reconciliation.
+                          Default: true'
+                        type: boolean
+                      image:
+                        description: Specify a custom image for Minio pod.
+                        type: string
+                      pvcSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 10Gi
+                        description: 'Customize the size of the PVC created for the
+                          Minio instance. Default: 10Gi'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      resources:
+                        description: Specify custom Pod resource requirements for
+                          this component.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      s3CredentialsSecret:
+                        description: Credentials for the S3 user (e.g. IAM user cred
+                          stored in a k8s secret.). Note that the S3 user should have
+                          the permissions to create a bucket if the provided bucket
+                          does not exist.
+                        properties:
+                          accessKey:
+                            description: The "Keys" in the k8sSecret key/value pairs.
+                              Not to be confused with the values.
+                            type: string
+                          secretKey:
+                            type: string
+                          secretName:
+                            description: The name of the Secret where the AccessKey
+                              and SecretKey are defined.
+                            type: string
+                        required:
+                        - accessKey
+                        - secretKey
+                        - secretName
+                        type: object
+                      storageClassName:
+                        description: Volume Mode Filesystem storageClass to use for
+                          PVC creation
+                        type: string
+                    required:
+                    - image
+                    type: object
+                type: object
+              persistenceAgent:
+                default:
+                  deploy: true
+                description: DS Pipelines PersistenceAgent configuration.
+                properties:
+                  deploy:
+                    default: true
+                    description: 'Enable DS Pipelines Operator management of Persisence
+                      Agent. Setting Deploy to false disables operator reconciliation.
+                      Default: true'
+                    type: boolean
+                  image:
+                    description: Specify a custom image for DSP PersistenceAgent.
+                    type: string
+                  numWorkers:
+                    default: 2
+                    description: 'Number of worker for Persistence Agent sync job.
+                      Default: 2'
+                    type: integer
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              podToPodTLS:
+                default: true
+                description: PodToPodTLS Set to "true" or "false" to enable or disable
+                  TLS communication between DSPA components (pods). Defaults to "true"
+                  to enable TLS between all pods. Only supported in DSP V2 on OpenShift.
+                type: boolean
+              scheduledWorkflow:
+                default:
+                  deploy: true
+                description: DS Pipelines Scheduled Workflow configuration.
+                properties:
+                  cronScheduleTimezone:
+                    default: UTC
+                    description: 'Specify the Cron timezone used for ScheduledWorkflow
+                      PipelineRuns. Default: UTC'
+                    type: string
+                  deploy:
+                    default: true
+                    description: 'Enable DS Pipelines Operator management of ScheduledWorkflow.
+                      Setting Deploy to false disables operator reconciliation. Default:
+                      true'
+                    type: boolean
+                  image:
+                    description: Specify a custom image for DSP ScheduledWorkflow
+                      controller.
+                    type: string
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              workflowController:
+                description: WorkflowController is an argo-specific component that
+                  manages a DSPA's Workflow objects and handles the orchestration
+                  of them with the central Argo server
+                properties:
+                  argoExecImage:
+                    type: string
+                  customConfig:
+                    type: string
+                  deploy:
+                    default: true
+                    type: boolean
+                  image:
+                    type: string
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+            required:
+            - objectStorage
+            type: object
+          status:
+            properties:
+              components:
+                properties:
+                  apiServer:
+                    properties:
+                      externalUrl:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  mlmdProxy:
+                    properties:
+                      externalUrl:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: datasciencepipelinesapplications.opendatahub.io/v1alpha1 is
+      deprecated.
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              apiServer:
+                default:
+                  deploy: true
+                description: DS Pipelines API Server configuration.
+                properties:
+                  applyTektonCustomResource:
+                    default: true
+                    description: |-
+                      Default: true
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: boolean
+                  archiveLogs:
+                    default: false
+                    description: |-
+                      Default: false
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: boolean
+                  argoDriverImage:
+                    description: Driver image used during pipeline execution.
+                    type: string
+                  argoLauncherImage:
+                    description: Launcher/Executor image used during pipeline execution.
+                    type: string
+                  artifactImage:
+                    description: 'Deprecated: DSP V1 only, will be removed in the
+                      future.'
+                    type: string
+                  artifactScriptConfigMap:
+                    description: 'Deprecated: DSP V1 only, will be removed in the
+                      future.'
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  artifactSignedURLExpirySeconds:
+                    default: 60
+                    description: |-
+                      The expiry time (seconds) for artifact download links when
+                      querying the dsp server via /apis/v2beta1/artifacts/{id}?share_url=true
+                      Default: 60
+                    type: integer
+                  autoUpdatePipelineDefaultVersion:
+                    default: true
+                    description: |-
+                      Default: true
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: boolean
+                  cABundle:
+                    description: |-
+                      If the Object store/DB is behind a TLS secured connection that is
+                      unrecognized by the host OpenShift/K8s cluster, then you can
+                      provide a PEM formatted CA bundle to be injected into the DSP
+                      server pod to trust this connection. CA Bundle should be provided
+                      as values within configmaps, mapped to keys.
+                    properties:
+                      configMapKey:
+                        description: |-
+                          Key should map to a CA bundle. The key is also used to name
+                          the CA bundle file (e.g. ca-bundle.crt)
+                        type: string
+                      configMapName:
+                        type: string
+                    required:
+                    - configMapKey
+                    - configMapName
+                    type: object
+                  caBundleFileMountPath:
+                    description: |-
+                      This is the path where the ca bundle will be mounted in the
+                      pipeline server and user executor pods
+                    type: string
+                  caBundleFileName:
+                    description: |-
+                      This is the filename of the ca bundle that will be created in the
+                      pipeline server and user executor pods
+                    type: string
+                  cacheImage:
+                    description: 'Deprecated: DSP V1 only, will be removed in the
+                      future.'
+                    type: string
+                  collectMetrics:
+                    default: true
+                    description: |-
+                      Default: true
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: boolean
+                  customKfpLauncherConfigMap:
+                    description: |-
+                      When specified, the `data` contents of the `kfp-launcher` ConfigMap that DSPO writes
+                      will be fully replaced with the `data` contents of the ConfigMap specified here.
+                      This allows the user to fully replace the `data` contents of the kfp-launcher ConfigMap.
+                      The `kfp-launcher` component requires a ConfigMap to exist in the namespace
+                      where it runs (i.e. the namespace where pipelines run). This ConfigMap contains
+                      object storage configuration, as well as pipeline root (object store root path
+                      where artifacts will be uploaded) configuration. Currently this ConfigMap *must*
+                      be named "kfp-launcher". We currently deploy a default copy of the kfp-launcher
+                      ConfigMap via DSPO, but a user may want to provide their own ConfigMap configuration,
+                      so that they can specify multiple object storage sources and paths.
+                    type: string
+                  customServerConfigMap:
+                    description: |-
+                      CustomServerConfig is a custom config file that you can provide
+                      for the api server to use instead.
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  dbConfigConMaxLifetimeSec:
+                    default: 120
+                    description: |-
+                      Default: 120
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: integer
+                  deploy:
+                    default: true
+                    description: 'Enable DS Pipelines Operator management of DSP API
+                      Server. Setting Deploy to false disables operator reconciliation.
+                      Default: true'
+                    type: boolean
+                  enableOauth:
+                    default: true
+                    description: 'Create an Openshift Route for this DSP API Server.
+                      Default: true'
+                    type: boolean
+                  enableSamplePipeline:
+                    default: false
+                    description: 'Include the Iris sample pipeline with the deployment
+                      of this DSP API Server. Default: true'
+                    type: boolean
+                  image:
+                    description: Specify a custom image for DSP API Server.
+                    type: string
+                  initResources:
+                    description: |-
+                      Specify init container resource requirements. The init container
+                      is used to build managed-pipelines and store them in a shared volume.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  injectDefaultScript:
+                    default: true
+                    description: |-
+                      Inject the archive step script. Default: true
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: boolean
+                  managedPipelines:
+                    description: Enable various managed pipelines on this DSP API
+                      server.
+                    properties:
+                      instructLab:
+                        description: |-
+                          Configures whether to automatically import the InstructLab pipeline.
+                          You must enable the trainingoperator component to run the InstructLab pipeline.
+                        properties:
+                          state:
+                            default: Removed
+                            description: "Set to one of the following values:\n\n-
+                              \"Managed\" : This pipeline is automatically imported.\n-
+                              \"Removed\" : This pipeline is not automatically imported.
+                              If previously set to \"Managed\", setting to \"Removed\"
+                              does not remove existing managed pipelines but does
+                              prevent future updates from being imported.\t//"
+                            enum:
+                            - Managed
+                            - Removed
+                            pattern: ^(Managed|Removed)$
+                            type: string
+                        type: object
+                    type: object
+                  moveResultsImage:
+                    description: |-
+                      Image used for internal artifact passing handling within Tekton taskruns. This field specifies the image used in the 'move-all-results-to-tekton-home' step.
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: string
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  rhelAIImage:
+                    description: RhelAI image used for ilab tasks in managed pipelines.
+                    type: string
+                  runtimeGenericImage:
+                    description: |-
+                      Generic runtime image used for building managed pipelines during
+                      api server init, and for basic runtime operations.
+                    type: string
+                  stripEOF:
+                    default: true
+                    description: |-
+                      Default: true
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: boolean
+                  terminateStatus:
+                    default: Cancelled
+                    description: |-
+                      Default: "Cancelled" - Allowed Values: "Cancelled", "StoppedRunFinally", "CancelledRunFinally"
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    enum:
+                    - Cancelled
+                    - StoppedRunFinally
+                    - CancelledRunFinally
+                    type: string
+                  toolboxImage:
+                    description: |-
+                      Toolbox image used for basic container spec runtime operations
+                      in managed pipelines.
+                    type: string
+                  trackArtifacts:
+                    default: true
+                    description: |-
+                      Default: true
+                      Deprecated: DSP V1 only, will be removed in the future.
+                    type: boolean
+                type: object
+              database:
+                default:
+                  mariaDB:
+                    deploy: true
+                description: Database specifies database configurations, used for
+                  DS Pipelines metadata tracking. Specify either the default MariaDB
+                  deployment, or configure your own External SQL DB.
+                properties:
+                  customExtraParams:
+                    description: |-
+                      CustomExtraParams allow users to further customize the sql dsn parameters used by the Pipeline Server
+                      when opening a connection with the Database.
+                      ref: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#dsn-data-source-name
+
+                      Value must be a JSON string. For example, to disable tls for Pipeline Server DB connection
+                      the user can provide a string: {"tls":"true"}
+
+                      If updating post DSPA deployment, then a manual restart of the pipeline server pod will be required
+                      so the new configmap may be consumed.
+                    type: string
+                  disableHealthCheck:
+                    default: false
+                    description: 'Default: false'
+                    type: boolean
+                  externalDB:
+                    properties:
+                      host:
+                        type: string
+                      passwordSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      pipelineDBName:
+                        type: string
+                      port:
+                        type: string
+                      username:
+                        type: string
+                    required:
+                    - host
+                    - passwordSecret
+                    - pipelineDBName
+                    - port
+                    - username
+                    type: object
+                  mariaDB:
+                    properties:
+                      deploy:
+                        default: true
+                        description: 'Enable DS Pipelines Operator management of MariaDB.
+                          Setting Deploy to false disables operator reconciliation.
+                          Default: true'
+                        type: boolean
+                      image:
+                        description: Specify a custom image for DSP MariaDB pod.
+                        type: string
+                      passwordSecret:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      pipelineDBName:
+                        default: mlpipeline
+                        description: 'The database name that will be created. Should
+                          match `^[a-zA-Z0-9_]+`. // Default: mlpipeline'
+                        pattern: ^[a-zA-Z0-9_]+$
+                        type: string
+                      pvcSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 10Gi
+                        description: 'Customize the size of the PVC created for the
+                          default MariaDB instance. Default: 10Gi'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      resources:
+                        description: Specify custom Pod resource requirements for
+                          this component.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      storageClassName:
+                        description: Volume Mode Filesystem storageClass to use for
+                          PVC creation
+                        type: string
+                      username:
+                        default: mlpipeline
+                        description: 'The MariadB username that will be created. Should
+                          match `^[a-zA-Z0-9_]+`. Default: mlpipeline'
+                        pattern: ^[a-zA-Z0-9_]+$
+                        type: string
+                    type: object
+                type: object
+              dspVersion:
+                default: v1
+                type: string
+              mlmd:
+                properties:
+                  deploy:
+                    default: false
+                    description: 'Enable DS Pipelines Operator management of MLMD.
+                      Setting Deploy to false disables operator reconciliation. Default:
+                      true'
+                    type: boolean
+                  envoy:
+                    properties:
+                      deployRoute:
+                        default: true
+                        type: boolean
+                      image:
+                        type: string
+                      resources:
+                        description: |-
+                          ResourceRequirements structures compute resource requirements.
+                          Replaces ResourceRequirements from corev1 which also includes optional storage field.
+                          We handle storage field separately, and should not include it as a subfield for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    type: object
+                  grpc:
+                    properties:
+                      image:
+                        type: string
+                      port:
+                        type: string
+                      resources:
+                        description: |-
+                          ResourceRequirements structures compute resource requirements.
+                          Replaces ResourceRequirements from corev1 which also includes optional storage field.
+                          We handle storage field separately, and should not include it as a subfield for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    type: object
+                  writer:
+                    description: 'Deprecated: DSP V1 only, will be removed in the
+                      future.'
+                    properties:
+                      image:
+                        type: string
+                      resources:
+                        description: |-
+                          ResourceRequirements structures compute resource requirements.
+                          Replaces ResourceRequirements from corev1 which also includes optional storage field.
+                          We handle storage field separately, and should not include it as a subfield for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    required:
+                    - image
+                    type: object
+                type: object
+              mlpipelineUI:
+                description: Deploy the KFP UI with DS Pipelines UI. This feature
+                  is unsupported, and primarily used for exploration, testing, and
+                  development purposes.
+                properties:
+                  configMap:
+                    type: string
+                  deploy:
+                    default: true
+                    description: 'Enable DS Pipelines Operator management of KFP UI.
+                      Setting Deploy to false disables operator reconciliation. Default:
+                      true'
+                    type: boolean
+                  image:
+                    description: Specify a custom image for KFP UI pod.
+                    type: string
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              objectStorage:
+                description: ObjectStorage specifies Object Store configurations,
+                  used for DS Pipelines artifact passing and storage. Specify either
+                  the your own External Storage (e.g. AWS S3), or use the default
+                  Minio deployment (unsupported, primarily for development, and testing)
+                  .
+                properties:
+                  disableHealthCheck:
+                    default: false
+                    description: 'Default: false'
+                    type: boolean
+                  enableExternalRoute:
+                    default: false
+                    description: 'Enable an external route so the object storage is
+                      reachable from outside the cluster. Default: false'
+                    type: boolean
+                  externalStorage:
+                    properties:
+                      basePath:
+                        description: Subpath where objects should be stored for this
+                          DSPA
+                        type: string
+                      bucket:
+                        type: string
+                      host:
+                        type: string
+                      port:
+                        type: string
+                      region:
+                        type: string
+                      s3CredentialsSecret:
+                        properties:
+                          accessKey:
+                            description: The "Keys" in the k8sSecret key/value pairs.
+                              Not to be confused with the values.
+                            type: string
+                          secretKey:
+                            type: string
+                          secretName:
+                            description: The name of the Secret where the AccessKey
+                              and SecretKey are defined.
+                            type: string
+                        required:
+                        - accessKey
+                        - secretKey
+                        - secretName
+                        type: object
+                      scheme:
+                        type: string
+                      secure:
+                        type: boolean
+                    required:
+                    - bucket
+                    - host
+                    - s3CredentialsSecret
+                    - scheme
+                    type: object
+                  minio:
+                    description: Enable DS Pipelines Operator management of Minio.
+                      Setting Deploy to false disables operator reconciliation.
+                    properties:
+                      bucket:
+                        default: mlpipeline
+                        description: 'Provide the Bucket name that will be used to
+                          store artifacts in S3. If provided bucket does not exist,
+                          DSP Apiserver will attempt to create it. As such the credentials
+                          provided should have sufficient permissions to do create
+                          buckets. Default: mlpipeline'
+                        type: string
+                      deploy:
+                        default: true
+                        description: 'Enable DS Pipelines Operator management of Minio.
+                          Setting Deploy to false disables operator reconciliation.
+                          Default: true'
+                        type: boolean
+                      image:
+                        description: Specify a custom image for Minio pod.
+                        type: string
+                      pvcSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 10Gi
+                        description: 'Customize the size of the PVC created for the
+                          Minio instance. Default: 10Gi'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      resources:
+                        description: Specify custom Pod resource requirements for
+                          this component.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                      s3CredentialsSecret:
+                        description: Credentials for the S3 user (e.g. IAM user cred
+                          stored in a k8s secret.). Note that the S3 user should have
+                          the permissions to create a bucket if the provided bucket
+                          does not exist.
+                        properties:
+                          accessKey:
+                            description: The "Keys" in the k8sSecret key/value pairs.
+                              Not to be confused with the values.
+                            type: string
+                          secretKey:
+                            type: string
+                          secretName:
+                            description: The name of the Secret where the AccessKey
+                              and SecretKey are defined.
+                            type: string
+                        required:
+                        - accessKey
+                        - secretKey
+                        - secretName
+                        type: object
+                      storageClassName:
+                        description: Volume Mode Filesystem storageClass to use for
+                          PVC creation
+                        type: string
+                    required:
+                    - image
+                    type: object
+                type: object
+              persistenceAgent:
+                default:
+                  deploy: true
+                description: DS Pipelines PersistenceAgent configuration.
+                properties:
+                  deploy:
+                    default: true
+                    description: 'Enable DS Pipelines Operator management of Persisence
+                      Agent. Setting Deploy to false disables operator reconciliation.
+                      Default: true'
+                    type: boolean
+                  image:
+                    description: Specify a custom image for DSP PersistenceAgent.
+                    type: string
+                  numWorkers:
+                    default: 2
+                    description: 'Number of worker for Persistence Agent sync job.
+                      Default: 2'
+                    type: integer
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              podToPodTLS:
+                default: true
+                description: PodToPodTLS Set to "true" or "false" to enable or disable
+                  TLS communication between DSPA components (pods). Defaults to "true"
+                  to enable TLS between all pods. Only supported in DSP V2 on OpenShift.
+                type: boolean
+              scheduledWorkflow:
+                default:
+                  deploy: true
+                description: DS Pipelines Scheduled Workflow configuration.
+                properties:
+                  cronScheduleTimezone:
+                    default: UTC
+                    description: 'Specify the Cron timezone used for ScheduledWorkflow
+                      PipelineRuns. Default: UTC'
+                    type: string
+                  deploy:
+                    default: true
+                    description: 'Enable DS Pipelines Operator management of ScheduledWorkflow.
+                      Setting Deploy to false disables operator reconciliation. Default:
+                      true'
+                    type: boolean
+                  image:
+                    description: Specify a custom image for DSP ScheduledWorkflow
+                      controller.
+                    type: string
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+              workflowController:
+                description: WorkflowController is an argo-specific component that
+                  manages a DSPA's Workflow objects and handles the orchestration
+                  of them with the central Argo server
+                properties:
+                  argoExecImage:
+                    type: string
+                  customConfig:
+                    type: string
+                  deploy:
+                    default: true
+                    type: boolean
+                  image:
+                    type: string
+                  resources:
+                    description: Specify custom Pod resource requirements for this
+                      component.
+                    properties:
+                      limits:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        properties:
+                          cpu:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          memory:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+            required:
+            - objectStorage
+            type: object
+          status:
+            properties:
+              components:
+                properties:
+                  apiServer:
+                    properties:
+                      externalUrl:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                  mlmdProxy:
+                    properties:
+                      externalUrl:
+                        type: string
+                      url:
+                        type: string
+                    type: object
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -57,3 +57,5 @@ spec:
           env:
             - name: SET_PIPELINE_RBAC
               value: "true"
+            - name: SET_PIPELINE_SECRET
+              value: "true"

--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -19,9 +19,25 @@ rules:
   - update
   - watch
 - apiGroups:
+  - components.platform.opendatahub.io
+  resources:
+  - dashboards
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - proxies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datasciencepipelinesapplications.opendatahub.io
+  resources:
+  - datasciencepipelinesapplications
   verbs:
   - get
   - list
@@ -111,22 +127,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - components.platform.opendatahub.io
-  resources:
-  - dashboards
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - datasciencepipelinesapplications.opendatahub.io
-  resources:
-  - datasciencepipelinesapplications
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-  

--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -111,3 +111,22 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - components.platform.opendatahub.io
+  resources:
+  - dashboards
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datasciencepipelinesapplications.opendatahub.io
+  resources:
+  - datasciencepipelinesapplications
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -37,6 +37,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -77,7 +78,7 @@ type OpenshiftNotebookReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=list;get;watch
-// +kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications,verbs=get;list;watch
 // +kubebuilder:rbac:groups="components.platform.opendatahub.io",resources=dashboards,verbs=get;list;watch
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -77,6 +77,8 @@ type OpenshiftNotebookReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=list;get;watch
+// +kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="components.platform.opendatahub.io",resources=dashboards,verbs=get;list;watch
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.
 func CompareNotebooks(nb1 nbv1.Notebook, nb2 nbv1.Notebook) bool {
@@ -205,6 +207,15 @@ func (r *OpenshiftNotebookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		err = r.ReconcileRoleBindings(notebook, ctx)
 		if err != nil {
 			log.Error(err, "Unable to Reconcile Rolebinding")
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Call the Elyra pipeline secret reconciler
+	if strings.ToLower(strings.TrimSpace(os.Getenv("SET_PIPELINE_SECRET"))) == "true" {
+		err = r.ReconcileElyraRuntimeConfigSecret(notebook, ctx)
+		if err != nil {
+			log.Error(err, "Unable to Reconcile Elyra runtime config secret")
 			return ctrl.Result{}, err
 		}
 	}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -28,12 +28,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -1076,6 +1080,269 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			}, duration, interval).Should(Succeed())
 
 			Expect(secrets.Items).To(BeEmpty())
+		})
+
+	})
+
+	When("Checking ds-pipeline-config secret lifecycle", func() {
+		const (
+			notebookName          = "dspa-notebook"
+			dsSecretName          = "ds-pipeline-config"
+			Namespace             = "dspa-test-namespace"
+			accessKeyKey          = "accesskey"
+			secretKeyKey          = "secretkey"
+			secretName            = "cos-secret"
+			dashboardInstanceName = "default-dashboard"
+		)
+
+		testNamespaces = append(testNamespaces, Namespace)
+
+		var (
+			dspaObj      *dspav1.DataSciencePipelinesApplication
+			s3CredSecret *corev1.Secret
+			dashboard    *unstructured.Unstructured
+		)
+		BeforeEach(func() {
+			//Pass env to be visible within test suite
+			_ = os.Setenv("SET_PIPELINE_SECRET", "true")
+			fmt.Printf("SET_PIPELINE_SECRET is: %s\n", os.Getenv("SET_PIPELINE_SECRET"))
+			if os.Getenv("SET_PIPELINE_SECRET") != "true" {
+				Skip("Skipping elyra secret creation reconciliation tests as SET_PIPELINE_SECRET is not set to 'true'")
+			}
+
+		})
+
+		It("should create a ds-pipeline-config secret if a DSPA is present", func() {
+
+			// Create all the necessary objects within dspa-test-namespace namespace: DSPA CR, Dashboard CR, and Dashboard Secret.
+			// These components require the 'ds-pipeline-config' secret to be generated beforehand.
+			By("Creating a DSPA object")
+			dspaObj = &dspav1.DataSciencePipelinesApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dspa",
+					Namespace: Namespace,
+				},
+				Spec: dspav1.DSPASpec{
+					ObjectStorage: &dspav1.ObjectStorage{
+						ExternalStorage: &dspav1.ExternalStorage{
+							Host:   "minio.default.svc.cluster.local",
+							Bucket: "pipelines",
+							S3CredentialSecret: &dspav1.S3CredentialSecret{
+								SecretName: secretName,
+								AccessKey:  accessKeyKey,
+								SecretKey:  secretKeyKey,
+							},
+						},
+					},
+				},
+				Status: dspav1.DSPAStatus{
+					Components: dspav1.ComponentStatus{
+						APIServer: dspav1.ComponentDetailStatus{
+							ExternalUrl: "https://pipeline-api.example.com",
+						},
+					},
+				},
+			}
+			Expect(cli.Create(ctx, dspaObj)).To(Succeed())
+
+			By("Creating a COS3 credentials Secret")
+			s3CredSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: Namespace,
+				},
+				Data: map[string][]byte{
+					accessKeyKey: []byte("testaccesskey"),
+					secretKeyKey: []byte("testsecretkey"),
+				},
+			}
+			Expect(cli.Create(ctx, s3CredSecret)).To(Succeed())
+
+			By("Creating a Dashboard CR")
+			dashboard = &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "components.platform.opendatahub.io/v1alpha1",
+					"kind":       "Dashboard",
+					"metadata": map[string]interface{}{
+						"name":      dashboardInstanceName,
+						"namespace": Namespace,
+					},
+				},
+			}
+			dashboard.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "components.platform.opendatahub.io",
+				Version: "v1alpha1",
+				Kind:    "Dashboard",
+			})
+			Expect(cli.Create(ctx, dashboard)).To(Succeed())
+
+			By("Patching the Dashboard status.url and Ready condition to simulate readiness")
+			// Fetch the Dashboard to get a valid resourceVersion
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(dashboard), dashboard)).To(Succeed())
+			// Create a patch with updated status.url and conditions
+			dashboardPatch := dashboard.DeepCopy()
+			err := unstructured.SetNestedField(dashboardPatch.Object, "https://dashboard.example.com", "status", "url")
+			Expect(err).ToNot(HaveOccurred())
+			readyCondition := map[string]interface{}{
+				"type":   "Ready",
+				"status": "True",
+				"reason": "ComponentsAvailable",
+			}
+			err = unstructured.SetNestedSlice(dashboardPatch.Object, []interface{}{readyCondition}, "status", "conditions")
+			Expect(err).ToNot(HaveOccurred())
+			patch := client.MergeFrom(dashboard)
+			Expect(cli.Status().Patch(ctx, dashboardPatch, patch)).To(Succeed())
+
+			By("Waiting the Dashboard object is present and Ready")
+			time.Sleep(10 * time.Millisecond)
+
+			By("Creating Notebook")
+			notebook := createNotebook(notebookName, Namespace)
+			Expect(cli.Create(ctx, notebook)).To(Succeed())
+
+			By("Waiting for ds-pipeline-config Secret to be created")
+			Eventually(func() error {
+				return cli.Get(ctx, types.NamespacedName{Name: dsSecretName, Namespace: Namespace}, &corev1.Secret{})
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			// This is needed until RHOAIENG-24545 bug get fix, related with the maybeRestartRunningNotebook func
+			By("Stopping the Notebook to allow volume injection")
+			stopPatch := notebook.DeepCopy()
+			if stopPatch.Annotations == nil {
+				stopPatch.Annotations = map[string]string{}
+			}
+			stopPatch.Annotations["kubeflow-resource-stopped"] = "true"
+			Expect(cli.Patch(ctx, stopPatch, client.MergeFrom(notebook))).To(Succeed())
+
+			By("Waiting for controller to reconcile after notebook is stopped")
+			Eventually(func(g Gomega) {
+				var refreshed nbv1.Notebook
+				g.Expect(cli.Get(ctx, types.NamespacedName{
+					Name:      notebookName,
+					Namespace: Namespace,
+				}, &refreshed)).To(Succeed())
+
+				found := false
+				for _, container := range refreshed.Spec.Template.Spec.Containers {
+					for _, vm := range container.VolumeMounts {
+						if vm.Name == "elyra-dsp-details" && vm.MountPath == "/opt/app-root/runtimes" {
+							found = true
+							break
+						}
+					}
+				}
+				g.Expect(found).To(BeTrue(), "Expected volumeMount 'elyra-dsp-details' after notebook was stopped")
+			}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+			By("Check notebook status")
+			notebook = &nbv1.Notebook{}
+			err = cli.Get(ctx, client.ObjectKey{Name: notebookName, Namespace: Namespace}, notebook)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Validating the presence of volumeMount 'elyra-dsp-details'")
+			foundVolumeMount := false
+			for _, container := range notebook.Spec.Template.Spec.Containers {
+				for _, vm := range container.VolumeMounts {
+					if vm.Name == "elyra-dsp-details" && vm.MountPath == "/opt/app-root/runtimes" {
+						foundVolumeMount = true
+						break
+					}
+				}
+			}
+			Expect(foundVolumeMount).To(BeTrue(), "Expected volumeMount 'elyra-dsp-details' to be present in notebook container")
+
+			By("Validating the content of the ds-pipeline-config Secret")
+			var fetchedSecret corev1.Secret
+			err = cli.Get(ctx, types.NamespacedName{
+				Name:      dsSecretName,
+				Namespace: Namespace,
+			}, &fetchedSecret)
+			Expect(err).NotTo(HaveOccurred(), "Expected ds-pipeline-config Secret to exist")
+			Expect(fetchedSecret.Data).To(HaveKey("odh_dsp.json"))
+			Expect(fetchedSecret.Data["odh_dsp.json"]).ToNot(BeEmpty())
+			Expect(fetchedSecret.OwnerReferences).ToNot(BeEmpty(), "ds-pipeline-config Secret should have ownerReference")
+
+			By("Modifying DSPA Bucket field to trigger update")
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(dspaObj), dspaObj)).To(Succeed())
+			dspaObj.Spec.ExternalStorage.Bucket = "changed-bucket"
+			Expect(cli.Update(ctx, dspaObj)).To(Succeed())
+
+			By("Checking if ds-pipeline-config Secret is updated")
+			Eventually(func(g Gomega) {
+				var updatedSecret corev1.Secret
+				g.Expect(cli.Get(ctx, types.NamespacedName{
+					Name:      dsSecretName,
+					Namespace: Namespace,
+				}, &updatedSecret)).To(Succeed())
+				g.Expect(updatedSecret.ResourceVersion).ToNot(Equal(fetchedSecret), "Secret resource version should change on DSPA update")
+			}, 10*time.Second, 500*time.Millisecond).Should(Succeed())
+
+			By("Deleting the DSPA and Notebook")
+			Expect(cli.Delete(ctx, notebook)).To(Succeed())
+			Expect(cli.Delete(ctx, dspaObj)).To(Succeed())
+
+			By("Ensuring the DSPA and secret is fully deleted")
+			Eventually(func() error {
+				var deletedDspa dspav1.DataSciencePipelinesApplication
+				return cli.Get(ctx, types.NamespacedName{
+					Name:      "dspa",
+					Namespace: Namespace,
+				}, &deletedDspa)
+			}, time.Second*10, time.Millisecond*250).ShouldNot(Succeed())
+			err = cli.Delete(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dsSecretName,
+					Namespace: Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Ensuring ds-pipeline-config Secret is garbage collected")
+			Eventually(func() error {
+				var fetched corev1.Secret
+				return cli.Get(ctx, types.NamespacedName{
+					Name:      dsSecretName,
+					Namespace: Namespace,
+				}, &fetched)
+			}, time.Second*10, time.Millisecond*250).ShouldNot(Succeed())
+
+		})
+
+		AfterEach(func() {
+			By("Cleaning up all created resources")
+
+			// Delete DSPA
+			if dspaObj != nil {
+				_ = cli.Delete(ctx, dspaObj)
+				Eventually(func() error {
+					return cli.Get(ctx, client.ObjectKeyFromObject(dspaObj), dspaObj)
+				}, time.Second*5, time.Millisecond*250).ShouldNot(Succeed())
+			}
+			// Simulate garbage collection of owned resources
+			// (only needed in tests due to lack of real GC)
+			eventuallyDeleted := &corev1.Secret{}
+			Eventually(func() bool {
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      dsSecretName,
+					Namespace: Namespace,
+				}, eventuallyDeleted)
+				return apierrors.IsNotFound(err)
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+
+			// Delete Dashboard
+			if dashboard != nil {
+				_ = cli.Delete(ctx, dashboard)
+				Eventually(func() error {
+					return cli.Get(ctx, client.ObjectKeyFromObject(dashboard), dashboard)
+				}, time.Second*5, time.Millisecond*250).ShouldNot(Succeed())
+			}
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: Namespace,
+				},
+			}
+			_ = cli.Delete(ctx, ns)
 		})
 
 	})

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -1113,7 +1113,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		})
 
 		It("should create a ds-pipeline-config secret if a DSPA is present", func() {
-
 			// Create all the necessary objects within dspa-test-namespace namespace: DSPA CR, Dashboard CR, and Dashboard Secret.
 			// These components require the 'ds-pipeline-config' secret to be generated beforehand.
 			By("Creating a DSPA object")
@@ -1135,15 +1134,18 @@ var _ = Describe("The Openshift Notebook controller", func() {
 						},
 					},
 				},
-				Status: dspav1.DSPAStatus{
-					Components: dspav1.ComponentStatus{
-						APIServer: dspav1.ComponentDetailStatus{
-							ExternalUrl: "https://pipeline-api.example.com",
-						},
+			}
+			Expect(cli.Create(ctx, dspaObj)).To(Succeed())
+			By("Setting DSPA Status with a API server URL")
+			dspaObj.Status = dspav1.DSPAStatus{
+				Components: dspav1.ComponentStatus{
+					APIServer: dspav1.ComponentDetailStatus{
+						ExternalUrl: "https://pipeline-api.example.com",
 					},
 				},
 			}
-			Expect(cli.Create(ctx, dspaObj)).To(Succeed())
+			// Update only the status subresource
+			Expect(cli.Status().Update(ctx, dspaObj)).To(Succeed())
 
 			By("Creating a COS3 credentials Secret")
 			s3CredSecret = &corev1.Secret{

--- a/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
@@ -1,0 +1,336 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	elyraRuntimeSecretName = "ds-pipeline-config"
+	elyraRuntimeMountPath  = "/opt/app-root/runtimes"
+	elyraRuntimeVolumeName = "elyra-dsp-details"
+
+	dashboardInstanceName = "default-dashboard"
+	dspaInstanceName      = "dspa"
+)
+
+// extractElyraRuntimeConfigInfo retrieves the essential configuration details from dspa and dashboard CRs used for pipeline execution.
+func extractElyraRuntimeConfigInfo(ctx context.Context, dynamicClient dynamic.Interface, client client.Client, notebook *nbv1.Notebook, log logr.Logger) (map[string]interface{}, error) {
+
+	// Define GVRs
+	dashboard := schema.GroupVersionResource{
+		Group:    "components.platform.opendatahub.io",
+		Version:  "v1alpha1",
+		Resource: "dashboards",
+	}
+
+	publicAPIEndpoint := ""
+	// Fetch Dashboard CR
+	dashboardInstance, err := dynamicClient.Resource(dashboard).Get(ctx, dashboardInstanceName, metav1.GetOptions{})
+	if err != nil {
+		log.Error(err, "Failed to get Dashboard CR")
+	} else {
+		// Extract dashboard URL
+		status, ok := dashboardInstance.Object["status"].(map[string]interface{})
+		if !ok {
+			log.Error(err, "invalid Dashboard CR: missing 'status'")
+		} else {
+			dashboardURL, ok := status["url"].(string)
+			if !ok || dashboardURL == "" {
+				log.Error(err, "invalid Dashboard CR: missing or empty 'url'")
+			} else {
+				publicAPIEndpoint = fmt.Sprintf("https://%s/experiments/%s/", dashboardURL, notebook.Namespace)
+			}
+		}
+	}
+
+	// Get the DSPA
+	dspaInstance := &dspav1.DataSciencePipelinesApplication{}
+	err = client.Get(ctx, types.NamespacedName{Name: dspaInstanceName, Namespace: notebook.Namespace}, dspaInstance)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			// DSPA CR not found; skipping Elyra config generation
+			return nil, nil
+		}
+		log.Error(err, "Failed to get DSPA CR")
+		return nil, fmt.Errorf("error retrieving DSPA CR: %w", err)
+	}
+
+	// Extract API Endpoint from DSPA status
+	apiEndpoint := dspaInstance.Status.Components.APIServer.ExternalUrl
+
+	// Extract info from DSPA spec
+	spec := dspaInstance.Spec
+	objectStorage := spec.ObjectStorage
+	externalStorage := objectStorage.ExternalStorage
+
+	// Extract host
+	host := externalStorage.Host
+	if host == "" {
+		return nil, fmt.Errorf("invalid DSPA CR: missing or invalid 'host'")
+	}
+	cosEndpoint := fmt.Sprintf("https://%s", host)
+
+	// Extract bucket
+	cosBucket := externalStorage.Bucket
+	if cosBucket == "" {
+		return nil, fmt.Errorf("invalid DSPA CR: missing or invalid 'bucket'")
+	}
+
+	// Extract S3 credentials
+	s3CredentialsSecret := externalStorage.S3CredentialSecret
+	cosSecret := s3CredentialsSecret.SecretName
+	usernameKey := s3CredentialsSecret.AccessKey
+	passwordKey := s3CredentialsSecret.SecretKey
+
+	// Fetch secret for credentials
+	dspaCOSSecret := &corev1.Secret{}
+	err = client.Get(ctx, types.NamespacedName{Name: cosSecret, Namespace: notebook.Namespace}, dspaCOSSecret)
+	if err != nil {
+		log.Error(err, "Failed to get secret", "secretName", cosSecret)
+		return nil, fmt.Errorf("failed to get secret '%s': %w", cosSecret, err)
+	}
+
+	// Extract values from the secret
+	usernameVal, ok := dspaCOSSecret.Data[usernameKey]
+	if !ok {
+		return nil, fmt.Errorf("missing key '%s' in secret '%s'", usernameKey, cosSecret)
+	}
+	passwordVal, ok := dspaCOSSecret.Data[passwordKey]
+	if !ok {
+		return nil, fmt.Errorf("missing key '%s' in secret '%s'", passwordKey, cosSecret)
+	}
+
+	cosUsername := string(usernameVal)
+	cosPassword := string(passwordVal)
+
+	// Construct and return the DSPA config
+	return map[string]interface{}{
+		"display_name": "Data Science Pipeline",
+		"schema_name":  "kfp",
+		"metadata": map[string]interface{}{
+			"tags":                []string{},
+			"display_name":        "Data Science Pipeline",
+			"engine":              "Argo",
+			"runtime_type":        "KUBEFLOW_PIPELINES",
+			"auth_type":           "KUBERNETES_SERVICE_ACCOUNT_TOKEN",
+			"cos_auth_type":       "KUBERNETES_SECRET",
+			"public_api_endpoint": publicAPIEndpoint,
+			"api_endpoint":        apiEndpoint,
+			"cos_endpoint":        cosEndpoint,
+			"cos_bucket":          cosBucket,
+			"cos_username":        cosUsername,
+			"cos_password":        cosPassword,
+			"cos_secret":          cosSecret,
+		},
+	}, nil
+}
+
+// NewElyraRuntimeConfigSecret defines and handles the creation, watch and update to the desired ElyraRuntimeConfig secret object
+func (r *OpenshiftNotebookReconciler) NewElyraRuntimeConfigSecret(ctx context.Context, dynamicConfig *rest.Config, c client.Client, notebook *nbv1.Notebook, controllerNamespace string, log logr.Logger) error {
+	dynamicClient, err := dynamic.NewForConfig(dynamicConfig)
+	if err != nil {
+		log.Error(err, "Failed to create dynamic client")
+		return err
+	}
+
+	dspData, err := extractElyraRuntimeConfigInfo(ctx, dynamicClient, c, notebook, log)
+	if err != nil {
+		log.Error(err, "Failed to extract Elyra runtime config info")
+		return err
+	}
+	// // In case No DSPA present in namespace skipping Elyra secret creation as DSPA is not present
+	if dspData == nil {
+		return nil
+	}
+
+	dspJSON, err := json.Marshal(dspData)
+	if err != nil {
+		log.Error(err, "Failed to marshal DSPA config to JSON")
+		return err
+	}
+
+	desiredSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      elyraRuntimeSecretName,
+			Namespace: notebook.Namespace,
+			Labels:    map[string]string{"opendatahub.io/managed-by": "workbenches"},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"odh_dsp.json": dspJSON,
+		},
+	}
+
+	// Fetch the DSPA instance
+	dspaInstance := &dspav1.DataSciencePipelinesApplication{}
+	err = c.Get(ctx, types.NamespacedName{Name: dspaInstanceName, Namespace: desiredSecret.Namespace}, dspaInstance)
+	if err != nil {
+		log.Error(err, "Failed to fetch DSPA instance")
+		return err
+	}
+
+	// Set owner reference only on the secrets created by nbc (avoid blockOwnerDeletion issue)
+	desiredSecret.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         dspav1.GroupVersion.String(),
+			Kind:               "DataSciencePipelinesApplication",
+			Name:               dspaInstance.Name,
+			UID:                dspaInstance.UID,
+			Controller:         ptr.To(true),
+			BlockOwnerDeletion: ptr.To(false),
+		},
+	}
+
+	// Check if the secret exists
+	existingSecret := &corev1.Secret{}
+	err = c.Get(ctx, types.NamespacedName{Name: elyraRuntimeSecretName, Namespace: notebook.Namespace}, existingSecret)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			log.Info("Creating Elyra runtime config secret", "name", elyraRuntimeSecretName)
+			if err := c.Create(ctx, desiredSecret); err != nil && !apierrs.IsAlreadyExists(err) {
+				log.Error(err, "Failed to create Elyra runtime config secret")
+				return err
+			}
+			log.Info("Secret created successfully")
+			return nil
+		}
+		log.Error(err, "Failed to get Elyra runtime config secret")
+		return err
+	}
+
+	// Update Secret
+	requiresUpdate := !reflect.DeepEqual(existingSecret.Data, desiredSecret.Data) ||
+		existingSecret.Labels["opendatahub.io/managed-by"] != "workbenches"
+
+	if requiresUpdate {
+		log.Info("Overriding existing Elyra runtime config secret", "name", elyraRuntimeSecretName)
+
+		// Set correct label and data
+		existingSecret.Labels = map[string]string{"opendatahub.io/managed-by": "workbenches"}
+		existingSecret.Data = desiredSecret.Data
+
+		if err := c.Update(ctx, existingSecret); err != nil {
+			log.Error(err, "Failed to override existing Elyra runtime config secret")
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MountElyraRuntimeConfigSecret injects the Elyra runtime configuration Secret as a volume mount into the Notebook pod.
+// This function is invoked by the webhook during Notebook mutation.
+func MountElyraRuntimeConfigSecret(ctx context.Context, client client.Client, notebook *nbv1.Notebook, log logr.Logger) error {
+
+	// Retrieve the Secret
+	secret := &corev1.Secret{}
+	err := client.Get(ctx, types.NamespacedName{Name: elyraRuntimeSecretName, Namespace: notebook.Namespace}, secret)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			log.Info("Secret is not available yet", "Secret", elyraRuntimeSecretName)
+			return nil
+		}
+		log.Error(err, "Error retrieving Secret", "Secret", elyraRuntimeSecretName)
+		return err
+	}
+
+	// Check that it's our managed secret and has expected data
+	if secret.Labels["opendatahub.io/managed-by"] != "workbenches" {
+		log.Info("Skipping mounting secret not managed by workbenches", "Secret", elyraRuntimeSecretName)
+		return nil
+	}
+	if len(secret.Data) == 0 {
+		log.Info("Secret is empty, skipping volume mount", "Secret", elyraRuntimeSecretName)
+		return nil
+	}
+
+	// Define the volume
+	secretVolume := corev1.Volume{
+		Name: elyraRuntimeVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: elyraRuntimeSecretName,
+				Optional:   ptr.To(true),
+			},
+		},
+	}
+
+	// Append the volume if it doesn't already exist
+	volumes := &notebook.Spec.Template.Spec.Volumes
+	volumeExists := false
+	for _, v := range *volumes {
+		if v.Name == elyraRuntimeVolumeName {
+			volumeExists = true
+			break
+		}
+	}
+	if !volumeExists {
+		*volumes = append(*volumes, secretVolume)
+		log.Info("Added elyra-dsp-details volume to notebook", "notebook", notebook.Name, "namespace", notebook.Namespace)
+	} else {
+		log.Info("elyra-dsp-details volume already exists, skipping", "notebook", notebook.Name, "namespace", notebook.Namespace)
+	}
+
+	log.Info("Injecting elyra-dsp-details volume into notebook", "notebook", notebook.Name, "namespace", notebook.Namespace)
+
+	// Append volume mount to container (ensure no duplication by name or mountPath)
+	for i, container := range notebook.Spec.Template.Spec.Containers {
+		mountExists := false
+		for _, vm := range container.VolumeMounts {
+			if vm.Name == elyraRuntimeVolumeName || vm.MountPath == elyraRuntimeMountPath {
+				mountExists = true
+				break
+			}
+		}
+		if !mountExists {
+			notebook.Spec.Template.Spec.Containers[i].VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+				Name:      elyraRuntimeVolumeName,
+				MountPath: elyraRuntimeMountPath,
+			})
+			log.Info("Added elyra-dsp-details volume mount", "container", container.Name, "mountPath", elyraRuntimeMountPath)
+		} else {
+			log.Info("elyra-dsp-details volume mount already exists, skipping", "container", container.Name, "mountPath", elyraRuntimeMountPath)
+		}
+	}
+
+	return nil
+}
+
+// ReconcileElyraRuntimeConfigSecret handles the reconciliation of the Elyra runtime config secret.
+// This function is invoked by the ODH Notebook Controller and is required for enabling Elyra functionality in notebooks.
+func (r *OpenshiftNotebookReconciler) ReconcileElyraRuntimeConfigSecret(notebook *nbv1.Notebook, ctx context.Context) error {
+	log := r.Log.WithValues("notebook", notebook.Name, "namespace", notebook.Namespace)
+	return r.NewElyraRuntimeConfigSecret(ctx, r.Config, r.Client, notebook, r.Namespace, log)
+}

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -355,6 +355,12 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
+
+		// Mount Secret ds-pipeline-config
+		err = MountElyraRuntimeConfigSecret(ctx, w.Client, notebook, log)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
 	}
 
 	// Inject the OAuth proxy if the annotation is present but only if Service Mesh is disabled

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -477,6 +477,12 @@ func (w *NotebookWebhook) maybeRestartRunningNotebook(ctx context.Context, req a
 		return mutatedNotebook, NoPendingUpdates, nil
 	}
 
+	// If generation is 1, allow updates on initial generation of the notebook CR
+	if updatedNotebook.GetGeneration() == 1 {
+		log.Info("Not blocking update, this is the initial generation of the Notebook")
+		return mutatedNotebook, NoPendingUpdates, nil
+	}
+
 	// Now we know we have to block the update
 	// Keep the old values and mark the Notebook as UpdatesPending
 	diff := getStructDiff(ctx, mutatedNotebook.Spec.Template.Spec, updatedNotebook.Spec.Template.Spec)

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -36,12 +36,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -156,6 +156,7 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(netv1.AddToScheme(scheme))
 	utilruntime.Must(imagev1.AddToScheme(scheme))
+	utilruntime.Must(dspav1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme
 

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -42,6 +42,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.7.0
 	github.com/kubeflow/kubeflow/components/notebook-controller v0.0.0-20220728153354-fc09bd1eefb8
-	github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad
+	github.com/opendatahub-io/data-science-pipelines-operator v1.1.1-0.20250318214030-560cbc1d827a
+	github.com/openshift/api v0.0.0-20231118005202-0f638a8a4705
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.26.0
 	k8s.io/api v0.29.0
@@ -74,7 +75,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
+	google.golang.org/protobuf v1.35.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/components/odh-notebook-controller/go.sum
+++ b/components/odh-notebook-controller/go.sum
@@ -104,8 +104,10 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad h1:MiZEukiPd7ll8BQDwBfc3LKBxbqyeXIx+wl4CzVj5EQ=
-github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/opendatahub-io/data-science-pipelines-operator v1.1.1-0.20250318214030-560cbc1d827a h1:u4lD0qhvxzgD3svWF7GrCs3NIpp61IJrHjkqAiyhJVA=
+github.com/opendatahub-io/data-science-pipelines-operator v1.1.1-0.20250318214030-560cbc1d827a/go.mod h1:pQZ5FCeM0z7lNG66C+d4Z7vmTETbgrK9l9ov9ZJyWuw=
+github.com/openshift/api v0.0.0-20231118005202-0f638a8a4705 h1:GwpCt0VhL9GjVGJhdF+96RoUkGTf/d+7ICL/3jKWRkA=
+github.com/openshift/api v0.0.0-20231118005202-0f638a8a4705/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -213,8 +215,8 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.35.0 h1:5FHv5qHqN8bh7EFIRK0/nQppniyPd5pqKgCXFCbGkTs=
+google.golang.org/protobuf v1.35.0/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -29,21 +29,23 @@ import (
 
 	"github.com/opendatahub-io/kubeflow/components/odh-notebook-controller/controllers"
 
+	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	routev1 "github.com/openshift/api/route/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
-	configv1 "github.com/openshift/api/config/v1"
-	imagev1 "github.com/openshift/api/image/v1"
-	oauthv1 "github.com/openshift/api/oauth/v1"
-	routev1 "github.com/openshift/api/route/v1"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -60,6 +62,7 @@ func init() {
 	utilruntime.Must(configv1.AddToScheme(scheme))
 	utilruntime.Must(oauthv1.AddToScheme(scheme))
 	utilruntime.Must(imagev1.AddToScheme(scheme))
+	utilruntime.Must(dspav1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
related to: https://issues.redhat.com/browse/RHOAIENG-23204

## Description
This PR introduces support for automatically generating the `ds-pipeline-config` secret required by Elyra to run pipelines on Data Science Pipelines.

Currently, the notebook-controller does not generate the ds-pipeline-config secret, which is needed by Elyra for runtime configuration, this workload is handled by dashboard currently. This PR enables the controller to read `DSPA` content and create the required secret automatically.

A new controller file is added called `controller_dspa_secret.go` to handle the lifecycle of the `ds-pipeline-config` secret. The controller generates the secret only if a DSPA object is detected in the namespace. The generated secret is owned by the DSPA object, ensuring it is deleted automatically when the DSPA is removed from the namespace.

**Notes:**
Unit tests are not included yet. I plan to add them after returning from PTO.
The feature is functionally complete, so early feedback and review on the implementation are welcome and appreciated.

## How Has This Been Tested?
On a cluster replace the workbench section on a DSP:

```
    workbenches:
      devFlags:
        manifests:
          - contextDir: components/odh-notebook-controller/config
            sourcePath: ''
            uri: 'https://github.com/atheo89/kubeflow/archive/dspa-secret.tar.gz'
      managementState: Managed
```

Then replace the odh-notebook-controller `image` on the deployment with this:
`quay.io/opendatahub/odh-notebook-controller:pr-607`

- Created a new namespace.
- Configured a pipeline server.
- Deleted the existing ds-pipeline-config secret (previously created by the dashboard).
- Created a new workbench.
- Verified that the ds-pipeline-config secret was re-created and properly attached to the workbench.
- Cloned and ran the following example pipeline:
[hello-generic-world.pipeline](https://github.com/atheo89/data-science-pipeline-example/blob/master/run-pipelines-on-data-science-pipelines/hello-generic-world.pipeline)
- Pipeline executed successfully.

----
Testing logs: 
https://github.com/opendatahub-io/kubeflow/actions/runs/15297357028/job/43029525201?pr=607#step:4:716 

```
--------------------
The Openshift Notebook controller when Checking ds-pipeline-config secret lifecycle 
  should create a ds-pipeline-config secret if a DSPA is present
  /Users/atheodor/Development/Code/GitHub/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:1115
[BeforeEach] when Checking ds-pipeline-config secret lifecycle
  /Users/atheodor/Development/Code/GitHub/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:1105
SET_PIPELINE_SECRET is: true
[It] should create a ds-pipeline-config secret if a DSPA is present
  /Users/atheodor/Development/Code/GitHub/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:1115
STEP: Creating a DSPA object
STEP: Creating a COS3 credentials Secret
STEP: Creating a Dashboard CR
STEP: Patching the Dashboard status.url and Ready condition to simulate readiness
STEP: Waiting the Dashboard object is present and Ready
STEP: Creating Notebook
2025-06-03T15:55:12+02:00       INFO    controllers.notebook-controller odh-trusted-ca-bundle ConfigMap is not present, not starting mounting process.  {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
2025-06-03T15:55:12+02:00       INFO    controllers.notebook-controller ConfigMap does not exist        {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace", "ConfigMap": "pipeline-runtime-images"}
2025-06-03T15:55:12+02:00       INFO    controllers.notebook-controller Secret is not available yet     {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace", "Secret": "ds-pipeline-config"}
2025-06-03T15:55:12+02:00       INFO    controllers.notebook-controller Not blocking update, notebook is being newly created    {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
STEP: Waiting for ds-pipeline-config Secret to be created
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller odh-trusted-ca-bundle ConfigMap is not present, not starting mounting process.  {"notebook": "test-notebook-mesh", "namespace": "mesh-ns"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller ConfigMap does not exist        {"notebook": "test-notebook-mesh", "namespace": "mesh-ns", "ConfigMap": "pipeline-runtime-images"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller Secret is not available yet     {"notebook": "test-notebook-mesh", "namespace": "mesh-ns", "Secret": "ds-pipeline-config"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller Not blocking update, the pod template is not being modified at all      {"notebook": "test-notebook-mesh", "namespace": "mesh-ns"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller Creating Network Policy {"name": "dspa-notebook-ctrl-np"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller Creating Network Policy {"name": "dspa-notebook-oauth-np"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller No runtime images found. Skipping creation of empty ConfigMap.  {"namespace": "dspa-test-namespace"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller Creating Elyra runtime config secret    {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace", "secret": "ds-pipeline-config", "notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller Secret created successfully     {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller Creating Route  {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
2025-06-03T15:55:18+02:00       INFO    controllers.notebook-controller Removing reconciliation lock    {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
STEP: Waiting and validating for volumeMount 'elyra-dsp-details' to be injected into the Notebook
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller odh-trusted-ca-bundle ConfigMap is not present, not starting mounting process.  {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller ConfigMap does not exist        {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace", "ConfigMap": "pipeline-runtime-images"}
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller Added elyra-dsp-details volume to notebook      {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace", "notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller Injecting elyra-dsp-details volume into notebook        {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace", "notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller Added elyra-dsp-details volume mount    {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace", "container": "dspa-notebook", "mountPath": "/opt/app-root/runtimes"}
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller Not blocking update, this is the initial generation of the Notebook     {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller No runtime images found. Skipping creation of empty ConfigMap.  {"namespace": "mesh-ns"}
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller No runtime images found. Skipping creation of empty ConfigMap.  {"namespace": "dspa-test-namespace"}
STEP: Check notebook status
STEP: Validating the content of the ds-pipeline-config Secret
STEP: Modifying DSPA Bucket field to trigger update
STEP: Checking if ds-pipeline-config Secret is updated
STEP: Deleting the DSPA and Notebook
2025-06-03T15:55:24+02:00       INFO    controllers.notebook-controller Stop Notebook reconciliation    {"notebook": "dspa-notebook", "namespace": "dspa-test-namespace"}
STEP: Ensuring the DSPA and secret is fully deleted
STEP: Ensuring ds-pipeline-config Secret is garbage collected
[AfterEach] when Checking ds-pipeline-config secret lifecycle
  /Users/atheodor/Development/Code/GitHub/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:1291
STEP: Cleaning up all created resources

• [SLOW TEST:12.621 seconds]
The Openshift Notebook controller
/Users/atheodor/Development/Code/GitHub/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:50
  when Checking ds-pipeline-config secret lifecycle
  /Users/atheodor/Development/Code/GitHub/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:1087
    should create a ds-pipeline-config secret if a DSPA is present
    /Users/atheodor/Development/Code/GitHub/kubeflow/components/odh-notebook-controller/controllers/notebook_controller_test.go:1115
------------------------------
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
