### PR TITLE
RHOAIENG-11681: Running 'kustomize edit fix --vars' on each component to upgrade to kustomize v5

### DIFF
--- a/components/base/kustomization.yaml
+++ b/components/base/kustomization.yaml
@@ -1,6 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../notebook-controller/config/overlays/openshift
-  - ../odh-notebook-controller/config/base
+resources:
+- ../notebook-controller/config/overlays/openshift
+- ../odh-notebook-controller/config/base

--- a/components/notebook-controller/config/crd/kustomization.yaml
+++ b/components/notebook-controller/config/crd/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 - bases/kubeflow.org_notebooks.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-- patches/trivial_conversion_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
@@ -22,11 +20,13 @@ patchesStrategicMerge:
 configurations:
 - kustomizeconfig.yaml
 
-patchesJson6902:
-  - target:
-      group: apiextensions.k8s.io
-      version: v1
-      kind: CustomResourceDefinition
-      name: notebooks.kubeflow.org
-    path: patches/validation_patches.yaml
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: patches/validation_patches.yaml
+  target:
+    group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    name: notebooks.kubeflow.org
+    version: v1
+- path: patches/trivial_conversion_patch.yaml

--- a/components/notebook-controller/config/default/kustomization.yaml
+++ b/components/notebook-controller/config/default/kustomization.yaml
@@ -9,15 +9,8 @@ namespace: notebook-controller-system
 namePrefix: notebook-controller-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app: notebook-controller
-  kustomize.component: notebook-controller
 
 
-bases:
-- ../rbac
-- ../manager
-- ../crd
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
@@ -45,31 +38,14 @@ bases:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-# - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#   objref:
-#     kind: Certificate
-#     group: certmanager.k8s.io
-#     version: v1alpha1
-#     name: serving-cert # this name should match the one in certificate.yaml
-#   fieldref:
-#     fieldpath: metadata.namespace
-# - name: CERTIFICATE_NAME
-#   objref:
-#     kind: Certificate
-#     group: certmanager.k8s.io
-#     version: v1alpha1
-#     name: serving-cert # this name should match the one in certificate.yaml
-# - name: SERVICE_NAMESPACE # namespace of the service
-#   objref:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#   fieldref:
-#     fieldpath: metadata.namespace
-# - name: SERVICE_NAME
-#   objref:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../rbac
+- ../manager
+- ../crd
+labels:
+- includeSelectors: true
+  pairs:
+    app: notebook-controller
+    kustomize.component: notebook-controller

--- a/components/notebook-controller/config/manager/kustomization.yaml
+++ b/components/notebook-controller/config/manager/kustomization.yaml
@@ -3,8 +3,10 @@ resources:
 - service-account.yaml
 - service.yaml
 configMapGenerator:
-- name: config
-  envs:
+- envs:
   - params.env
+  name: config
 generatorOptions:
   disableNameSuffixHash: true
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/notebook-controller/config/overlays/kubeflow/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/kubeflow/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 resources:
 - ../../base
 namespace: kubeflow
-patchesStrategicMerge:
-- patches/remove-namespace.yaml
 configMapGenerator:
-- name: config
-  behavior: merge
+- behavior: merge
   literals:
   - USE_ISTIO=true
   - ISTIO_GATEWAY=kubeflow/kubeflow-gateway
+  name: config
+patches:
+- path: patches/remove-namespace.yaml

--- a/components/notebook-controller/config/overlays/openshift/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/openshift/kustomization.yaml
@@ -1,34 +1,42 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+- ../../base
 namespace: opendatahub
-commonLabels:
-  app.kubernetes.io/part-of: odh-notebook-controller
-  component.opendatahub.io/name: kf-notebook-controller
-  opendatahub.io/component: "true"
 configurations:
-  - params.yaml
+- params.yaml
 configMapGenerator:
-  - name: kf-notebook-controller-image-parameters
-    env: params.env
-  - name: config
-    behavior: merge
-    literals:
-      - USE_ISTIO=false
-      - ADD_FSGROUP=false
+- envs:
+  - params.env
+  name: kf-notebook-controller-image-parameters
+- behavior: merge
+  literals:
+  - USE_ISTIO=false
+  - ADD_FSGROUP=false
+  name: config
 generatorOptions:
   disableNameSuffixHash: true
-patchesStrategicMerge:
-  - remove_namespace_patch.yaml
-  - manager_openshift_patch.yaml
-  - manager_service_openshift_patch.yaml
-vars:
-- name: odh-kf-notebook-controller-image
-  objref:
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/part-of: odh-notebook-controller
+    component.opendatahub.io/name: kf-notebook-controller
+    opendatahub.io/component: "true"
+patches:
+- path: remove_namespace_patch.yaml
+- path: manager_openshift_patch.yaml
+- path: manager_service_openshift_patch.yaml
+replacements:
+- source:
+    fieldPath: data.odh-kf-notebook-controller-image
     kind: ConfigMap
     name: kf-notebook-controller-image-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.odh-kf-notebook-controller-image
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.0.image
+    select:
+      group: apps
+      kind: Deployment
+      name: deployment
+      version: v1

--- a/components/notebook-controller/config/overlays/openshift/manager_openshift_patch.yaml
+++ b/components/notebook-controller/config/overlays/openshift/manager_openshift_patch.yaml
@@ -32,7 +32,7 @@ spec:
                   name: notebook-controller-culler-config
                   key: IDLENESS_CHECK_PERIOD
                   optional: true
-          image: $(odh-kf-notebook-controller-image)
+          image: odh-kf-notebook-controller-image_PLACEHOLDER
           resources:
             limits:
               cpu: 500m

--- a/components/notebook-controller/config/overlays/service-mesh/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/service-mesh/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-- ../openshift
 
 configMapGenerator:
-- name: config
-  behavior: merge
+- behavior: merge
   envs:
   - ossm.env
+  name: config
+resources:
+- ../openshift

--- a/components/notebook-controller/config/overlays/standalone-service-mesh/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/standalone-service-mesh/kustomization.yaml
@@ -1,48 +1,46 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../openshift
-  - gateway.yaml
-  - gateway-route.yaml
-  - cert-secret.yaml
-  - smm.yaml
+- ../openshift
+- gateway.yaml
+- gateway-route.yaml
+- cert-secret.yaml
+- smm.yaml
 namespace: odh-notebook-controller-system
 
 configMapGenerator:
-  - name: config
-    behavior: merge
-    literals:
-      - USE_ISTIO=true
-      - ISTIO_GATEWAY=odh-notebook-controller-system/odh-gateway
+- behavior: merge
+  literals:
+  - USE_ISTIO=true
+  - ISTIO_GATEWAY=odh-notebook-controller-system/odh-gateway
+  name: config
 
-patchesJson6902:  
-  - patch: |-
-      - op: replace
-        path: /metadata/namespace
-        value: istio-system
-    target:
-      group: route.openshift.io
-      kind: Route
-      version: v1
-      namespace: odh-notebook-controller-system
-      name: opendatahub-odh-gateway
-  - patch: |-
-      - op: replace
-        path: /metadata/namespace
-        value: istio-system
-    target:
-      kind: Secret
-      version: v1
-      namespace: odh-notebook-controller-system
-      name: odh-dashboard-cert
-  - patch: |-
-      - op: replace
-        path: /spec/controlPlaneRef/namespace
-        value: istio-system
-    target:
-      group: maistra.io
-      version: v1
-      kind: ServiceMeshMember
-      name: default
-
+patches:
+- patch: |-
+    - op: replace
+      path: /metadata/namespace
+      value: istio-system
+  target:
+    group: route.openshift.io
+    kind: Route
+    name: opendatahub-odh-gateway
+    namespace: odh-notebook-controller-system
+    version: v1
+- patch: |-
+    - op: replace
+      path: /metadata/namespace
+      value: istio-system
+  target:
+    kind: Secret
+    name: odh-dashboard-cert
+    namespace: odh-notebook-controller-system
+    version: v1
+- patch: |-
+    - op: replace
+      path: /spec/controlPlaneRef/namespace
+      value: istio-system
+  target:
+    group: maistra.io
+    kind: ServiceMeshMember
+    name: default
+    version: v1

--- a/components/notebook-controller/config/overlays/standalone/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/standalone/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ../../base
 namespace: notebook-controller-system
 configMapGenerator:
-- name: config
-  behavior: merge
+- behavior: merge
   literals:
   - USE_ISTIO=false
+  name: config

--- a/components/notebook-controller/config/rbac/kustomization.yaml
+++ b/components/notebook-controller/config/rbac/kustomization.yaml
@@ -2,15 +2,5 @@ resources:
 - role.yaml
 - role_binding.yaml
 - user_cluster_roles.yaml
-
-# Uncomment the following lines if we want to enable
-# leader election for the controller manager.
-# - leader_election_role.yaml
-# - leader_election_role_binding.yaml
-
-# Comment the following 3 lines if you want to disable
-# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
-# which protects your /metrics endpoint.
-# - auth_proxy_service.yaml
-# - auth_proxy_role.yaml
-# - auth_proxy_role_binding.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/odh-notebook-controller/config/base/kustomization.yaml
+++ b/components/odh-notebook-controller/config/base/kustomization.yaml
@@ -1,20 +1,27 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../default
+- ../default
 
 configMapGenerator:
-- name: odh-notebook-controller-image-parameters
-  env: params.env
+- envs:
+  - params.env
+  name: odh-notebook-controller-image-parameters
 generatorOptions:
   disableNameSuffixHash: true
 
-vars:
-- name: odh-notebook-controller-image
-  objref:
+replacements:
+- source:
+    fieldPath: data.odh-notebook-controller-image
     kind: ConfigMap
     name: odh-notebook-controller-image-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.odh-notebook-controller-image
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.0.image
+    select:
+      group: apps
+      kind: Deployment
+      name: manager
+      namespace: system
+      version: v1

--- a/components/odh-notebook-controller/config/default/kustomization.yaml
+++ b/components/odh-notebook-controller/config/default/kustomization.yaml
@@ -1,11 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
   # - ../crd
-  - ../rbac
-  - ../manager
-  - ../webhook
 
 # Adds namespace to all resources.
 namespace: opendatahub
@@ -16,12 +11,18 @@ namespace: opendatahub
 namePrefix: odh-notebook-controller-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app: odh-notebook-controller
-  app.kubernetes.io/part-of: odh-notebook-controller
-  kustomize.component: odh-notebook-controller
-  component.opendatahub.io/name: odh-notebook-controller
-  opendatahub.io/component: "true"
 
-patchesStrategicMerge:
-  - webhook_manager_patch.yaml
+resources:
+- ../rbac
+- ../manager
+- ../webhook
+labels:
+- includeSelectors: true
+  pairs:
+    app: odh-notebook-controller
+    app.kubernetes.io/part-of: odh-notebook-controller
+    component.opendatahub.io/name: odh-notebook-controller
+    kustomize.component: odh-notebook-controller
+    opendatahub.io/component: "true"
+patches:
+- path: webhook_manager_patch.yaml

--- a/components/odh-notebook-controller/config/development/kustomization.yaml
+++ b/components/odh-notebook-controller/config/development/kustomization.yaml
@@ -1,10 +1,8 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../base
 resources:
-  - ktunnel.yaml
+- ktunnel.yaml
+- ../base
 replicas:
-  - name: odh-notebook-controller-manager
-    count: 0
+- count: 0
+  name: odh-notebook-controller-manager

--- a/components/odh-notebook-controller/config/manager/kustomization.yaml
+++ b/components/odh-notebook-controller/config/manager/kustomization.yaml
@@ -1,8 +1,7 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - manager.yaml
-  - service.yaml
+- manager.yaml
+- service.yaml
 configurations:
 - params.yaml

--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: $(odh-notebook-controller-image)
+          image: odh-notebook-controller-image_PLACEHOLDER
           imagePullPolicy: Always
           command:
             - /manager

--- a/components/odh-notebook-controller/config/rbac/kustomization.yaml
+++ b/components/odh-notebook-controller/config/rbac/kustomization.yaml
@@ -1,12 +1,9 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
   # All RBAC will be applied under this service account in the deployment
   # namespace.
-  - service_account.yaml
-  - role.yaml
-  - role_binding.yaml
-  - user_cluster_roles.yaml
-  # - leader_election_role.yaml
-  # - leader_election_role_binding.yaml
+resources:
+- service_account.yaml
+- role.yaml
+- role_binding.yaml
+- user_cluster_roles.yaml

--- a/components/odh-notebook-controller/config/webhook/kustomization.yaml
+++ b/components/odh-notebook-controller/config/webhook/kustomization.yaml
@@ -1,10 +1,9 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - manifests.yaml
-  - service.yaml
+- manifests.yaml
+- service.yaml
 commonAnnotations:
   service.beta.openshift.io/inject-cabundle: "true"
 configurations:
-  - kustomizeconfig.yaml
+- kustomizeconfig.yaml


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-11681

## Description
update the kustomize to for each component i.e (notebook-controller, odh-notebook-controller)
using the command:
`kustomize edit fix --vars`
Execute the above command in each dir of the component.

## How Has This Been Tested?
verify the new set of deployment manifests.
`kustomize build <path>`
verify this on a cluster using devflags:
inside the RHOAI operator, update the DSC (data science cluster) yaml, with Workbenches devflags included

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
