### PR TITLE
Update the logger names in odh-notebook-controller tests

### DIFF
--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -187,7 +187,7 @@ var _ = BeforeSuite(func() {
 	// Setup notebook controller
 	err = (&OpenshiftNotebookReconciler{
 		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("notebook-controller"),
+		Log:       ctrl.Log.WithName("controllers").WithName("odh-notebook-controller"),
 		Scheme:    mgr.GetScheme(),
 		Namespace: odhNotebookControllerTestNamespace,
 		Config:    mgr.GetConfig(),
@@ -198,7 +198,7 @@ var _ = BeforeSuite(func() {
 	hookServer := mgr.GetWebhookServer()
 	notebookWebhook := &webhook.Admission{
 		Handler: &NotebookWebhook{
-			Log:       ctrl.Log.WithName("controllers").WithName("notebook-controller"),
+			Log:       ctrl.Log.WithName("controllers").WithName("odh-notebook-webhook"),
 			Client:    mgr.GetClient(),
 			Config:    mgr.GetConfig(),
 			Namespace: odhNotebookControllerTestNamespace,


### PR DESCRIPTION
We used the very same logger names for both the odh-notebook-controller and the notebook-webhook components which could make it harder to distinguish what component logged what.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
