### PR TITLE
NO-JIRA: chore(dev): ensure same webhookCertDir location on Linux and macOS

### DIFF
--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -79,7 +79,7 @@ func getControllerNamespace() (string, error) {
 }
 
 func main() {
-	var metricsAddr, probeAddr, oauthProxyImage string
+	var metricsAddr, probeAddr, oauthProxyImage, webhookCertDir string
 	var webhookPort int
 	var enableLeaderElection, enableDebugLogging bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080",
@@ -88,6 +88,10 @@ func main() {
 		"The address the probe endpoint binds to.")
 	flag.StringVar(&oauthProxyImage, "oauth-proxy-image", controllers.OAuthProxyImage,
 		"Image of the OAuth proxy sidecar container.")
+	// specified explicitly, since on macOS the default temporary directory often resolves to a path under /var/folders/...
+	// this default path in /tmp/ is already hardcoded in the Makefile and manifests used for ktunnel deployment
+	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs",
+		"Directory that contains the server key and certificate for the webhook server.")
 	flag.IntVar(&webhookPort, "webhook-port", 8443,
 		"Port that the webhook server serves at.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -112,7 +116,8 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "odh-notebook-controller",
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: webhookPort,
+			Port:    webhookPort,
+			CertDir: webhookCertDir,
 		}),
 	}
 


### PR DESCRIPTION
This is necessary to make the ktunnel deployment work on macOS.

## Description

[/tmp/k8s-webhook-server/serving-certs](https://github.com/opendatahub-io/kubeflow/blob/3408b8c28a4b58a6f4f147626450ea208efb69a0/components/odh-notebook-controller/Makefile#L20-L22)

https://github.com/opendatahub-io/kubeflow/blob/3408b8c28a4b58a6f4f147626450ea208efb69a0/components/notebook-controller/config/default/manager_webhook_patch.yaml#L15C1-L23C42

https://github.com/opendatahub-io/kubeflow/blob/3408b8c28a4b58a6f4f147626450ea208efb69a0/components/odh-notebook-controller/config/default/webhook_manager_patch.yaml#L17-L24

## How Has This Been Tested?

Works on my macOS machine.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
