### PR TITLE
NO-JIRA: chore(dev): log error when imagestream is found but could not be fetched

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -726,7 +726,7 @@ func SetContainerImageFromRegistry(ctx context.Context, cli client.Client, noteb
 					// if not found, search in the notebook namespace
 					// Note: This is in this order, so users should not overwrite the ImageStream
 					err := cli.Get(ctx, types.NamespacedName{Name: imagestreamName, Namespace: controllerNamespace}, imgSelection)
-					if err != nil && apierrs.IsNotFound(err) {
+					if apierrs.IsNotFound(err) {
 						log.Info("Unable to find the ImageStream in controller namespace, try finding in notebook namespace", "imagestream", imagestreamName, "controllerNamespace", controllerNamespace)
 						// Check if the ImageStream is present in the notebook namespace
 						err = cli.Get(ctx, types.NamespacedName{Name: imagestreamName, Namespace: notebook.Namespace}, imgSelection)
@@ -738,6 +738,8 @@ func SetContainerImageFromRegistry(ctx context.Context, cli client.Client, noteb
 							imagestreamFound = true
 							log.Info("ImageStream found in notebook namespace", "imagestream", imagestreamName, "namespace", notebook.Namespace)
 						}
+					} else if err != nil {
+						log.Error(err, "Error getting ImageStream", "imagestream", imagestreamName, "controllerNamespace", controllerNamespace)
 					} else {
 						// ImageStream found in the controller namespace
 						imagestreamFound = true


### PR DESCRIPTION
## Description

This is something that should not normally happen, but it happened to me when I was working with faked imagestreams in tests and the lack of logging confused me.

I had to resort to running the webhook in debugger to understand what was going on.

With this log message, such error should be easier to debug, without stepping through the code.

## How Has This Been Tested?

CI

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
