### PR TITLE
NO-JIRA: chore(gh): permit filling blank github issues on the opendatahub-io/kubeflow repo again

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Kubeflow Documentation
     url: https://www.kubeflow.org/


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Kubeflow upstream disabled filling new issues on kubeflow/kubeflow and we inherited the setting for our own repos.

Undo this. It's great to be able to jot down ideas in GH issue tracker, when the ticket is not ready for the ceremonies heavy agile process we have in our company Jira.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
