### PR TITLE
Switch SET_PIPELINE_RBAC env to true

### DIFF
--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -56,4 +56,4 @@ spec:
               memory: 256Mi
           env:
             - name: SET_PIPELINE_RBAC
-              value: "false"
+              value: "true"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Related to: https://issues.redhat.com/browse/RHOAIENG-23205

## Description
<!--- Describe your changes in detail -->
This PR Switch SET_PIPELINE_RBAC env to true. Switching to true means that the odh-notebook-controller take care of the RBAC creation used for the data science pipeline operations. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This works has been tested on https://github.com/opendatahub-io/kubeflow/pull/434 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
