### PR TITLE
NO-JIRA: chore(dev): update the logger names for the ODH notebook ctrl

### DIFF
--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -137,12 +137,12 @@ func main() {
 	setupLog.Info("Controller is running in namespace", "namespace", namespace)
 	if err = (&controllers.OpenshiftNotebookReconciler{
 		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("Notebook"),
+		Log:       ctrl.Log.WithName("controllers").WithName("odh-notebook-controller"),
 		Namespace: namespace,
 		Scheme:    mgr.GetScheme(),
 		Config:    mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Notebook")
+		setupLog.Error(err, "unable to create controller", "controller", "odh-notebook-controller")
 		os.Exit(1)
 	}
 
@@ -150,7 +150,7 @@ func main() {
 	hookServer := mgr.GetWebhookServer()
 	notebookWebhook := &webhook.Admission{
 		Handler: &controllers.NotebookWebhook{
-			Log:       ctrl.Log.WithName("controllers").WithName("Notebook"),
+			Log:       ctrl.Log.WithName("controllers").WithName("odh-notebook-webhook"),
 			Client:    mgr.GetClient(),
 			Config:    mgr.GetConfig(),
 			Namespace: namespace,


### PR DESCRIPTION
This is a followup of the #611 where we updated logger names only for tests but not for the production code.

The logger names for the kf-notebook-controller seems quite okay to me right now: https://github.com/opendatahub-io/kubeflow/blob/0247e407b62ab1263c4f6e70c4febdd927382389/components/notebook-controller/main.go#L100-L123

I'm open for discussion whether you see any problem with this changing or have any other ideas.

## How Has This Been Tested?
I haven't tested this in any way.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
