### PR TITLE
RHOAIENG-27813: extend coverage for the runtime config map tests

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_runtime_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_runtime_test.go
@@ -3,25 +3,33 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
-	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("When Creating a notebook should mount the configMap", func() {
+const (
+	resource_reconciliation_timeout      = time.Second * 30
+	resource_reconciliation_check_period = time.Second * 2
+	Namespace                            = "default"
+	RuntimeImagesCMName                  = "pipeline-runtime-images"
+	expectedMountName                    = "runtime-images"
+	expectedMountPath                    = "/opt/app-root/pipeline-runtimes/"
+)
+
+var _ = Describe("Runtime images ConfigMap should be mounted", func() {
 	ctx := context.Background()
 
-	When("Creating a Notebook", func() {
-
-		const (
-			Namespace = "default"
-		)
+	When("Empty ConfigMap for runtime images", func() {
 
 		BeforeEach(func() {
 			err := cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: odhNotebookControllerTestNamespace}}, &client.CreateOptions{})
@@ -31,110 +39,399 @@ var _ = Describe("When Creating a notebook should mount the configMap", func() {
 		})
 
 		testCases := []struct {
-			name              string
-			notebook          *nbv1.Notebook
-			notebookName      string
-			ConfigMap         *unstructured.Unstructured
-			expectedMountName string
-			expectedMountPath string
+			name         string
+			notebook     *nbv1.Notebook
+			notebookName string
+			ConfigMap    *corev1.ConfigMap
 		}{
 			{
-				name:         "ConfigMap with data",
-				notebookName: "test-notebook-runtime-1",
-				ConfigMap: &unstructured.Unstructured{
-					Object: map[string]any{
-						"kind":       "ConfigMap",
-						"apiVersion": "v1",
-						"metadata": map[string]any{
-							"name":      "pipeline-runtime-images",
-							"namespace": Namespace,
-						},
-						"data": map[string]string{
-							"datascience.json": `{"image_name":"quay.io/opendatahub/test"}`,
-						},
-					},
-				},
-				expectedMountName: "runtime-images",
-				expectedMountPath: "/opt/app-root/pipeline-runtimes/",
-			},
-			{
 				name:         "ConfigMap without data",
-				notebookName: "test-notebook-runtime-2",
-				ConfigMap: &unstructured.Unstructured{
-					Object: map[string]any{
-						"kind":       "ConfigMap",
-						"apiVersion": "v1",
-						"metadata": map[string]any{
-							"name":      "pipeline-runtime-images",
-							"namespace": Namespace,
-						},
-						"data": map[string]string{},
+				notebookName: "test-notebook-runtime-empty-cf",
+				ConfigMap: &corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "v1",
 					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RuntimeImagesCMName,
+						Namespace: Namespace,
+					},
+					Data: map[string]string{},
 				},
-				expectedMountName: "",
-				expectedMountPath: "",
 			},
 		}
 
 		for _, testCase := range testCases {
-			testCase := testCase
-			It(fmt.Sprintf("Should mount ConfigMap correctly: %s", testCase.name), func() {
+			Context(fmt.Sprintf("The Notebook runtime pipeline images ConfigMap test case: %s", testCase.name), func() {
 				notebook := createNotebook(testCase.notebookName, Namespace)
+				configMap := &corev1.ConfigMap{}
+				It(fmt.Sprintf("Should mount ConfigMap correctly: %s", testCase.name), func() {
 
-				// cleanup first
-				_ = cli.Delete(ctx, notebook, &client.DeleteOptions{})
-				_ = cli.Delete(ctx, testCase.ConfigMap, &client.DeleteOptions{})
+					// cleanup first
+					_ = cli.Delete(ctx, notebook, &client.DeleteOptions{})
+					_ = cli.Delete(ctx, testCase.ConfigMap, &client.DeleteOptions{})
 
-				// wait until deleted
-				By("Waiting for the Notebook to be deleted")
-				Eventually(func(g Gomega) {
-					err := cli.Get(ctx, client.ObjectKey{Name: testCase.notebookName, Namespace: Namespace}, &nbv1.Notebook{})
-					g.Expect(apierrs.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("expected Notebook %q to be deleted", testCase.notebookName))
-				}).WithOffset(1).Should(Succeed())
+					// wait until deleted
+					By("Waiting for the Notebook to be deleted")
+					Eventually(func(g Gomega) {
+						err := cli.Get(ctx, client.ObjectKey{Name: testCase.notebookName, Namespace: Namespace}, &nbv1.Notebook{})
+						g.Expect(apierrs.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("expected Notebook %q to be deleted", testCase.notebookName))
+					}).WithOffset(1).Should(Succeed())
 
-				By("Creating the ConfigMap")
-				Expect(cli.Create(ctx, testCase.ConfigMap)).To(Succeed())
+					// test code start
+					By("Create the ConfigMap directly")
+					Expect(cli.Create(ctx, testCase.ConfigMap)).To(Succeed())
 
-				By("Creating the Notebook")
-				Expect(cli.Create(ctx, notebook)).To(Succeed())
+					By("Creating the Notebook")
+					Expect(cli.Create(ctx, notebook)).To(Succeed())
 
-				By("Fetching the created Notebook as typed object")
-				typedNotebook := &nbv1.Notebook{}
-				Eventually(func(g Gomega) {
-					err := cli.Get(ctx, client.ObjectKey{Name: testCase.notebookName, Namespace: Namespace}, typedNotebook)
-					g.Expect(err).ToNot(HaveOccurred())
-				}).Should(Succeed())
+					By("Fetching the ConfigMap for the runtime images")
+					Eventually(func(g Gomega) {
+						err := cli.Get(ctx, client.ObjectKey{Name: RuntimeImagesCMName, Namespace: Namespace}, configMap)
+						g.Expect(err).ToNot(HaveOccurred())
+					}, resource_reconciliation_timeout, resource_reconciliation_check_period).Should(Succeed())
 
-				// Check volumeMounts
-				c := typedNotebook.Spec.Template.Spec.Containers[0]
-				foundMount := false
-				for _, vm := range c.VolumeMounts {
-					if vm.Name == testCase.expectedMountName && vm.MountPath == testCase.expectedMountPath {
-						foundMount = true
+					// Check volumeMounts
+					By("Fetching the created Notebook CR as typed object and volumeMounts check")
+					typedNotebook := &nbv1.Notebook{}
+					Eventually(func(g Gomega) {
+						err := cli.Get(ctx, client.ObjectKey{Name: testCase.notebookName, Namespace: Namespace}, typedNotebook)
+						g.Expect(err).ToNot(HaveOccurred())
+
+						c := typedNotebook.Spec.Template.Spec.Containers[0]
+
+						foundMount := false
+						for _, vm := range c.VolumeMounts {
+							if vm.Name == expectedMountName && vm.MountPath == expectedMountPath {
+								foundMount = true
+							}
+						}
+
+						g.Expect(foundMount).To(BeFalse(), "unexpected VolumeMount found")
+					}, resource_reconciliation_timeout, resource_reconciliation_check_period).Should(Succeed())
+
+					// Check volumes
+					foundVolume := false
+					for _, v := range typedNotebook.Spec.Template.Spec.Volumes {
+						if v.Name == expectedMountName && v.ConfigMap != nil && v.ConfigMap.Name == RuntimeImagesCMName {
+							foundVolume = true
+						}
 					}
-				}
-				if testCase.expectedMountName != "" {
-					Expect(foundMount).To(BeTrue(), "expected VolumeMount not found")
-				} else {
-					Expect(foundMount).To(BeFalse(), "unexpected VolumeMount found")
-				}
-
-				// Check volumes
-				foundVolume := false
-				for _, v := range typedNotebook.Spec.Template.Spec.Volumes {
-					if v.Name == testCase.expectedMountName && v.ConfigMap != nil && v.ConfigMap.Name == "pipeline-runtime-images" {
-						foundVolume = true
-					}
-				}
-				if testCase.expectedMountName != "" {
-					Expect(foundVolume).To(BeTrue(), "expected ConfigMap volume not found")
-				} else {
 					Expect(foundVolume).To(BeFalse(), "unexpected ConfigMap volume found")
-				}
+				})
+				AfterEach(func() {
+					By("Deleting the created resources")
+					Expect(cli.Delete(ctx, notebook, &client.DeleteOptions{})).To(Succeed())
+					Expect(cli.Delete(ctx, configMap, &client.DeleteOptions{})).To(Succeed())
+				})
+			})
+		}
+	})
 
-				By("Deleting the created resources")
-				Expect(cli.Delete(ctx, notebook, &client.DeleteOptions{})).To(Succeed())
-				Expect(cli.Delete(ctx, testCase.ConfigMap, &client.DeleteOptions{})).To(Succeed())
+	When("Creating a Notebook", func() {
+
+		BeforeEach(func() {
+			err := cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: odhNotebookControllerTestNamespace}}, &client.CreateOptions{})
+			if err != nil && !apierrs.IsAlreadyExists(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		testCases := []struct {
+			name                  string
+			notebook              *nbv1.Notebook
+			notebookName          string
+			expectedConfigMapData map[string]string
+			imageStream           *imagev1.ImageStream
+		}{
+			{
+				name:         "ImageStream with two tags",
+				notebookName: "test-notebook-runtime-1",
+				expectedConfigMapData: map[string]string{
+					"python-3.11-ubi9.json":        `{"display_name":"Python 3.11 (UBI9)","metadata":{"display_name":"Python 3.11 (UBI9)","image_name":"quay.io/opendatahub/test","pull_policy":"IfNotPresent","tags":["some-tag"]},"schema_name":"runtime-image"}`,
+					"hohoho-python-3.12-ubi9.json": `{"display_name":"Hohoho Python 3.12 (UBI9)","metadata":{"display_name":"Python 3.12 (UBI9)","image_name":"quay.io/opendatahub/test2","pull_policy":"IfNotPresent","tags":["some-tag2"]},"schema_name":"runtime-image"}`,
+				},
+				imageStream: &imagev1.ImageStream{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ImageStream",
+						APIVersion: "image.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-image",
+						Namespace: "redhat-ods-applications",
+						Labels: map[string]string{
+							"opendatahub.io/runtime-image": "true",
+						},
+					},
+					Spec: imagev1.ImageStreamSpec{
+						LookupPolicy: imagev1.ImageLookupPolicy{
+							Local: true,
+						},
+						Tags: []imagev1.TagReference{
+							{
+								Name: "some-tag",
+								Annotations: map[string]string{
+									"opendatahub.io/runtime-image-metadata": `
+										[
+											{
+												"display_name": "Python 3.11 (UBI9)",
+												"metadata": {
+													"tags": [
+														"some-tag"
+													],
+													"display_name": "Python 3.11 (UBI9)",
+													"pull_policy": "IfNotPresent"
+												},
+												"schema_name": "runtime-image"
+											}
+										]
+									`,
+								},
+								From: &corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "quay.io/opendatahub/test",
+								},
+							},
+							{
+								Name: "some-tag2",
+								Annotations: map[string]string{
+									"opendatahub.io/runtime-image-metadata": `
+										[
+											{
+												"display_name": "Hohoho Python 3.12 (UBI9)",
+												"metadata": {
+													"tags": [
+														"some-tag2"
+													],
+													"display_name": "Python 3.12 (UBI9)",
+													"pull_policy": "IfNotPresent"
+												},
+												"schema_name": "runtime-image"
+											}
+										]
+									`,
+								},
+								From: &corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "quay.io/opendatahub/test2",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				name:         "ImageStream with one tag",
+				notebookName: "test-notebook-runtime-2",
+				expectedConfigMapData: map[string]string{
+					"python-3.11-ubi9.json": `{"display_name":"Python 3.11 (UBI9)","metadata":{"display_name":"Python 3.11 (UBI9)","image_name":"quay.io/modh/odh-pipeline-runtime-datascience-cpu-py311-ubi9@sha256:5aa8868be00f304084ce6632586c757bc56b28300779495d14b08bcfbcd3357f","pull_policy":"IfNotPresent","tags":["some-tag"]},"schema_name":"runtime-image"}`,
+				},
+				imageStream: &imagev1.ImageStream{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ImageStream",
+						APIVersion: "image.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-image",
+						Namespace: "redhat-ods-applications",
+						Labels: map[string]string{
+							"opendatahub.io/runtime-image": "true",
+						},
+					},
+					Spec: imagev1.ImageStreamSpec{
+						LookupPolicy: imagev1.ImageLookupPolicy{
+							Local: true,
+						},
+						Tags: []imagev1.TagReference{
+							{
+								Name: "some-tag",
+								Annotations: map[string]string{
+									"opendatahub.io/runtime-image-metadata": `
+										[
+											{
+												"display_name": "Python 3.11 (UBI9)",
+												"metadata": {
+													"tags": [
+														"some-tag"
+													],
+													"display_name": "Python 3.11 (UBI9)",
+													"pull_policy": "IfNotPresent"
+												},
+												"schema_name": "runtime-image"
+											}
+										]
+									`,
+								},
+								From: &corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "quay.io/modh/odh-pipeline-runtime-datascience-cpu-py311-ubi9@sha256:5aa8868be00f304084ce6632586c757bc56b28300779495d14b08bcfbcd3357f",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				name:                  "ImageStream with irrelevant data",
+				notebookName:          "test-notebook-runtime-3",
+				expectedConfigMapData: nil,
+				imageStream: &imagev1.ImageStream{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ImageStream",
+						APIVersion: "image.openshift.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-image",
+						Namespace: "redhat-ods-applications",
+						Labels: map[string]string{
+							"opendatahub.io/runtime-image": "true",
+						},
+					},
+					Spec: imagev1.ImageStreamSpec{
+						LookupPolicy: imagev1.ImageLookupPolicy{
+							Local: true,
+						},
+						Tags: []imagev1.TagReference{
+							{
+								Name: "some-tag",
+								Annotations: map[string]string{
+									"opendatahub.io/runtime-image-metadata-fake": `
+										[
+											{
+												"display_name": "Python 3.11 (UBI9)",
+												"metadata": {
+													"tags": [
+														"some-tag"
+													],
+													"display_name": "Python 3.11 (UBI9)",
+													"pull_policy": "IfNotPresent"
+												},
+												"schema_name": "runtime-image-fake"
+											}
+										]
+									`,
+								},
+								From: &corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "quay.io/opendatahub/test",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		for _, testCase := range testCases {
+			Context(fmt.Sprintf("The Notebook runtime pipeline images ConfigMap test case: %s", testCase.name), func() {
+				notebook := createNotebook(testCase.notebookName, Namespace)
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RuntimeImagesCMName,
+						Namespace: Namespace,
+					},
+				}
+				It(fmt.Sprintf("Should mount ConfigMap correctly: %s", testCase.name), func() {
+
+					// cleanup first
+					_ = cli.Delete(ctx, notebook, &client.DeleteOptions{})
+					_ = cli.Delete(ctx, testCase.imageStream, &client.DeleteOptions{})
+					_ = cli.Delete(ctx, configMap, &client.DeleteOptions{})
+
+					// wait until deleted
+					By("Waiting for the Notebook to be deleted")
+					Eventually(func(g Gomega) {
+						err := cli.Get(ctx, client.ObjectKey{Name: testCase.notebookName, Namespace: Namespace}, &nbv1.Notebook{})
+						g.Expect(apierrs.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("expected Notebook %q to be deleted", testCase.notebookName))
+					}).WithOffset(1).Should(Succeed())
+
+					// test code start
+					By("Create the ImageStream")
+					Expect(cli.Create(ctx, testCase.imageStream)).To(Succeed())
+
+					By("Creating the Notebook")
+					Expect(cli.Create(ctx, notebook)).To(Succeed())
+
+					By("Fetching the ConfigMap for the runtime images")
+					if testCase.expectedConfigMapData != nil {
+						Eventually(func(g Gomega) {
+							err := cli.Get(ctx, client.ObjectKey{Name: RuntimeImagesCMName, Namespace: Namespace}, configMap)
+							g.Expect(err).ToNot(HaveOccurred())
+						}, resource_reconciliation_timeout, resource_reconciliation_check_period).Should(Succeed())
+
+						// Let's check the content of the ConfigMap created from the given ImageStream.
+						Expect(configMap.GetName()).To(Equal(RuntimeImagesCMName))
+						Expect(configMap.Data).To(Equal(testCase.expectedConfigMapData))
+
+						// Check volumeMounts
+						By("Fetching the created Notebook CR as typed object and volumeMounts check")
+						typedNotebook := &nbv1.Notebook{}
+						Eventually(func(g Gomega) {
+							err := cli.Get(ctx, client.ObjectKey{Name: testCase.notebookName, Namespace: Namespace}, typedNotebook)
+							g.Expect(err).ToNot(HaveOccurred())
+
+							c := typedNotebook.Spec.Template.Spec.Containers[0]
+
+							foundMount := false
+							for _, vm := range c.VolumeMounts {
+								if vm.Name == expectedMountName && vm.MountPath == expectedMountPath {
+									foundMount = true
+								}
+							}
+							g.Expect(foundMount).To(BeTrue(), "expected VolumeMount not found")
+						}, resource_reconciliation_timeout, resource_reconciliation_check_period).Should(Succeed())
+
+						// Check volumes
+						foundVolume := false
+						for _, v := range typedNotebook.Spec.Template.Spec.Volumes {
+							if v.Name == expectedMountName && v.ConfigMap != nil && v.ConfigMap.Name == RuntimeImagesCMName {
+								foundVolume = true
+							}
+						}
+						Expect(foundVolume).To(BeTrue(), "expected ConfigMap volume not found")
+					} else {
+						// The data in the given ImageStream weren't supposed to create a runtime image configmap
+						Eventually(func(g Gomega) {
+							err := cli.Get(ctx, client.ObjectKey{Name: RuntimeImagesCMName, Namespace: Namespace}, configMap)
+							g.Expect(err).ToNot(HaveOccurred())
+						}, resource_reconciliation_timeout, resource_reconciliation_check_period).ShouldNot(Succeed())
+
+						// Check volumeMounts
+						By("Fetching the created Notebook CR as typed object and volumeMounts check")
+						typedNotebook := &nbv1.Notebook{}
+						Eventually(func(g Gomega) {
+							err := cli.Get(ctx, client.ObjectKey{Name: testCase.notebookName, Namespace: Namespace}, typedNotebook)
+							g.Expect(err).ToNot(HaveOccurred())
+
+							c := typedNotebook.Spec.Template.Spec.Containers[0]
+
+							foundMount := false
+							for _, vm := range c.VolumeMounts {
+								if vm.Name == expectedMountName && vm.MountPath == expectedMountPath {
+									foundMount = true
+								}
+							}
+							g.Expect(foundMount).To(BeTrue(), "expected VolumeMount not found")
+						}, resource_reconciliation_timeout, resource_reconciliation_check_period).ShouldNot(Succeed())
+
+						// Check volumes
+						foundVolume := false
+						for _, v := range typedNotebook.Spec.Template.Spec.Volumes {
+							if v.Name == expectedMountName && v.ConfigMap != nil && v.ConfigMap.Name == RuntimeImagesCMName {
+								foundVolume = true
+							}
+						}
+						Expect(foundVolume).To(BeFalse(), "expected ConfigMap volume not found")
+					}
+				})
+				AfterEach(func() {
+					By("Deleting the created resources")
+					Expect(cli.Delete(ctx, notebook, &client.DeleteOptions{})).To(Succeed())
+					Expect(cli.Delete(ctx, testCase.imageStream, &client.DeleteOptions{})).To(Succeed())
+					if testCase.expectedConfigMapData != nil {
+						Expect(cli.Delete(ctx, configMap, &client.DeleteOptions{})).To(Succeed())
+					}
+				})
 			})
 		}
 	})


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-27813 (https://issues.redhat.com/browse/RHOAIENG-24545)

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Refactored and expanded test coverage for ConfigMap mounting in Notebooks, including scenarios for empty ConfigMaps and ImageStream-driven ConfigMap creation.
  - Improved test structure, clarity, and type safety.
  - Added explicit checks for ConfigMap presence and volume mounts in Notebooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->