### PR TITLE
RHOAIENG-25707: feat(webhook): read namespace annotation on Notebook CR to locate ImageStream

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -746,9 +746,12 @@ func SetContainerImageFromRegistry(ctx context.Context, cli client.Client, noteb
 					imagestreamName := imageSelected[0]
 					imgSelection := &imagev1.ImageStream{}
 
+					// in user-created Notebook CRs, the annotation may be missing
+					// Dashboard creates it with an empty value (null in TypeScript) when the controllerNamespace is intended
+					//  https://github.com/opendatahub-io/odh-dashboard/blob/2692224c3157f00a6fe93a2ca5bd267e3ff964ca/frontend/src/api/k8s/notebooks.ts#L215-L216
 					imageNamespace, nsExists := annotations[WorkbenchImageNamespaceAnnotation]
-					if !nsExists {
-						log.Info("Unable to find the namespace annotation in the Notebook CR, will search in controller namespace",
+					if !nsExists || strings.TrimSpace(imageNamespace) == "" {
+						log.Info("Unable to find the namespace annotation in the Notebook CR, or the value of it is an empty string. Will search in controller namespace",
 							"annotationName", WorkbenchImageNamespaceAnnotation,
 							"controllerNamespace", controllerNamespace)
 						imageNamespace = controllerNamespace

--- a/components/odh-notebook-controller/controllers/notebook_webhook_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_test.go
@@ -99,6 +99,8 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 						Namespace: Namespace,
 						Annotations: map[string]string{
 							"notebooks.opendatahub.io/last-image-selection": "some-image:some-tag",
+							// dashboard gives an empty string here to mean the image is from the operator's namespace
+							"opendatahub.io/workbench-image-namespace": "",
 						},
 					},
 					Spec: nbv1.NotebookSpec{


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-25707

follows up on https://issues.redhat.com/browse/RHOAIENG-25734

* https://github.com/opendatahub-io/odh-dashboard/pull/4260

## Description

Read `opendatahub.io/workbench-image-namespace` and `notebooks.opendatahub.io/last-image-selection` annotations to identify the correct ImageStream from which the imageHash needs to be used.

## How Has This Been Tested?

```
make test
```

Create a workbench in a cluster without internal image registry, one from imagestream in the controller namespace, and one from imagestream in user's project.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved image resource lookup by using a configurable namespace annotation, enhancing flexibility and reducing redundant searches.
- **Tests**
  - Updated tests to support the new namespace annotation for image resource selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->