### PR TITLE
[RHOAIENG-363] Include service-ca cert bundle to workbench-ca bundle

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -263,11 +263,29 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					"odh-ca-bundle.crt": "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTMyMzI2NTlaFw0yNTExMTMy\nMzI2NTlaMAAwKjAFBgMrZXADIQB/v02zcoIIcuan/8bd7cvrBuCGTuVZBrYr1RdA\n0k58yzAFBgMrZXADQQBKsL1tkpOZ6NW+zEX3mD7bhmhxtODQHnANMXEXs0aljWrm\nAxDrLdmzsRRYFYxe23OdXhWqPs8SfO8EZWEvXoME\n-----END CERTIFICATE-----",
 				})
 
+			serviceCACertBundle := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openshift-service-ca.crt",
+					Namespace: "default",
+					// Annotations: map[string]string{
+					// 	"service.beta.openshift.io/inject-cabundle": "true",
+					// },
+				},
+				Data: map[string]string{
+					"service-ca.crt": "-----BEGIN CERTIFICATE-----\nMIIBATCBtKADAgECAgEBMAUGAytlcDAAMB4XDTI1MDYxNjE2MTg0MVoXDTI2MDYx\nNjE2MTg0MVowADAqMAUGAytlcAMhAP7g8UxhoFPZXQiy4sSbOsLrlXq2RgFTzQOD\nj8O8e9qmo1MwUTAdBgNVHQ4EFgQUTCWpJDtMDVadBlVpkVTiLnCihqMwHwYDVR0j\nBBgwFoAUTCWpJDtMDVadBlVpkVTiLnCihqMwDwYDVR0TAQH/BAUwAwEB/zAFBgMr\nZXADQQDKpiapbn7ub7/hT7Whad9wbvIY8wXrWojgZXXbWaMQFV8i8GW7QN4w/C1p\nB8i0efvecoLP/mqmXNyl7KgTnC4D\n-----END CERTIFICATE-----",
+				},
+			}
+
 			// Create the ConfigMap
 			Expect(cli.Create(ctx, trustedCACertBundle)).Should(Succeed())
+			Expect(cli.Create(ctx, serviceCACertBundle)).Should(Succeed())
 			defer func() {
 				// Clean up the ConfigMap after the test
 				if err := cli.Delete(ctx, trustedCACertBundle); err != nil {
+					// Log the error without failing the test
+					logger.Info("Error occurred during deletion of ConfigMap: %v", err)
+				}
+				if err := cli.Delete(ctx, serviceCACertBundle); err != nil {
 					// Log the error without failing the test
 					logger.Info("Error occurred during deletion of ConfigMap: %v", err)
 				}
@@ -308,12 +326,12 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			Expect(notebook.Spec.Template.Spec.Volumes).To(ContainElement(expectedVolume))
 
 			// Check the content in workbench-trusted-ca-bundle matches what we expect:
-			//   - have 2 certificates there in ca-bundle.crt
-			//   - both certificates are valid
+			//   - have 3 certificates there in ca-bundle.crt
+			//   - all certificates are valid
 			// TODO(RHOAIENG-15907): adding sleep to reduce flakiness
 			time.Sleep(2 * time.Second)
 			configMapName := "workbench-trusted-ca-bundle"
-			checkCertConfigMap(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 2)
+			checkCertConfigMap(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 3)
 		})
 
 	})
@@ -537,12 +555,12 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			Expect(notebook.Spec.Template.Spec.Volumes).To(ContainElement(expectedVolume))
 
 			// Check the content in workbench-trusted-ca-bundle matches what we expect:
-			//   - have 2 certificates there in ca-bundle.crt
-			//   - both certificates are valid
+			//   - have 3 certificates there in ca-bundle.crt
+			//   - all certificates are valid
 			// TODO(RHOAIENG-15907): adding sleep to reduce flakiness
 			time.Sleep(2 * time.Second)
 			configMapName := "workbench-trusted-ca-bundle"
-			checkCertConfigMap(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 2)
+			checkCertConfigMap(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 3)
 		})
 	})
 


### PR DESCRIPTION
Include service-ca cert bundle to workbench-ca bundle
- For service-to-service interaction, the service-ca bundle is relied upon

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Releted-to: https://issues.redhat.com/browse/RHOAIENG-363

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`It ensures secure service-to-service communication and enabling features like mTLS`
https://docs.redhat.com/en/documentation/openshift_container_platform/4.1/html/authentication/configuring-certificates#understanding-service-serving_service-serving-certificate
This would allow service to service communication in disconnected clusters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On code: `make test`

in cluster:
- switch to the controller image by using image from PR
- spawn to notebook 
- Try to make connection to a internal service.
example:
```
from kfp.client import Client
sa_token_file_path = '/var/run/secrets/kubernetes.io/serviceaccount/token'
with open(sa_token_file_path, 'r') as token_file:
    bearer_token = token_file.read()
 
client = Client(
    host='<service-url>',
    existing_token=bearer_token,
    ssl_ca_cert='/etc/pki/tls/custom-certs/ca-bundle.crt'
)
 
print(client.list_experiments())
```
![Screenshot from 2025-06-16 23-28-13](https://github.com/user-attachments/assets/266ececa-6fb2-43d7-9150-4f15e69289ff)


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for including the "openshift-service-ca.crt" ConfigMap when aggregating trusted certificate authorities for notebooks.
  - Notebooks now automatically update their trusted CA bundles when the "openshift-service-ca.crt" ConfigMap changes.

- **Tests**
  - Enhanced test coverage to validate handling of the new "openshift-service-ca.crt" ConfigMap in notebook certificate mounting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->