### PR TITLE
RHOAIENG-26099: Make cluster-proxy env in workbenches as optional

### DIFF
--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -59,3 +59,10 @@ spec:
               value: "true"
             - name: SET_PIPELINE_SECRET
               value: "true"
+            - name: INJECT_CLUSTER_PROXY_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: notebook-controller-setting-config
+                  key: INJECT_CLUSTER_PROXY_ENV
+                  optional: true
+

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -380,8 +381,17 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		}
 	}
 
-	// If cluster-wide-proxy is enabled add environment variables
-	if w.ClusterWideProxyIsEnabled() {
+	// If cluster-wide-proxy is enabled, and INJECT_CLUSTER_PROXY_ENV is set to true,
+	// inject the environment variables.
+	// RHOAIENG-26099: This is a temporary solution to inject the proxy environment variables
+	// until the notebooks controller supports injecting the proxy environment variables
+	injectClusterProxy := false
+	if raw, ok := os.LookupEnv("INJECT_CLUSTER_PROXY_ENV"); ok {
+		if val, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
+			injectClusterProxy = val
+		}
+	}
+	if w.ClusterWideProxyIsEnabled() && injectClusterProxy {
 		err = InjectProxyConfigEnvVars(notebook)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)


### PR DESCRIPTION
[RHOAIENG-26099](https://issues.redhat.com//browse/RHOAIENG-26099): Make cluster-proxy env in workbenches as optional
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Related-to: https://issues.redhat.com/browse/RHOAIENG-26099

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an environment variable to allow explicit opt-in control for injecting cluster-wide proxy settings into notebooks.

- **Chores**
  - Updated deployment configuration to support the new environment variable for proxy injection control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->