### PR TITLE
[Add] Propagate labels from NB to StatefulSets

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -439,6 +439,7 @@ func generateStatefulSet(instance *v1beta1.Notebook, isGenerateName bool) *appsv
 	ssObjectMeta := metav1.ObjectMeta{
 		Name:      instance.Name,
 		Namespace: instance.Namespace,
+		Labels:    map[string]string{},
 	}
 	if isGenerateName {
 		ssObjectMeta = metav1.ObjectMeta{
@@ -468,6 +469,11 @@ func generateStatefulSet(instance *v1beta1.Notebook, isGenerateName bool) *appsv
 				Spec: *instance.Spec.Template.Spec.DeepCopy(),
 			},
 		},
+	}
+
+	sl := &ss.Labels
+	for k, v := range instance.Labels {
+		(*sl)[k] = v
 	}
 
 	// copy all of the Notebook labels to the pod including poddefault related labels

--- a/components/notebook-controller/controllers/notebook_controller_bdd_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_bdd_test.go
@@ -37,6 +37,9 @@ var _ = Describe("Notebook controller", func() {
 		Namespace = "default"
 		timeout   = time.Second * 10
 		interval  = time.Millisecond * 250
+
+		testLabelName  = "testLabel"
+		testLabelValue = "testLabelValue"
 	)
 
 	Context("When validating the notebook controller", func() {
@@ -47,6 +50,9 @@ var _ = Describe("Notebook controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      Name,
 					Namespace: Namespace,
+					Labels: map[string]string{
+						testLabelName: testLabelValue,
+					},
 				},
 				Spec: nbv1beta1.NotebookSpec{
 					Template: nbv1beta1.NotebookTemplateSpec{
@@ -62,10 +68,7 @@ var _ = Describe("Notebook controller", func() {
 
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, notebookLookupKey, createdNotebook)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			/*
 				Checking for the underlying statefulset.
@@ -82,6 +85,10 @@ var _ = Describe("Notebook controller", func() {
 				if err != nil {
 					return false, err
 				}
+
+				By("By checking that the StatefulSet has identical Labels as the Notebook")
+				Expect(sts.GetLabels()).To(Equal(notebook.GetLabels()))
+
 				return true, nil
 			}, timeout, interval).Should(BeTrue())
 		})


### PR DESCRIPTION
This commit propagates labels from Notebooks to statefulsets. This is required to enable NBs to be managed by Kueue. When a user adds the label to point a NB to the right LocalQueue where it needs to be admitted, it needs to propagate to the underlying StatefulSet, so that Kueue can manage it.

(cherry picked from commit f6abf13cf8032fe273fedf8a413f89805b5f4fc8) --- kubeflow/kubeflow#7674

https://issues.redhat.com/browse/RHOAIENG-28544

## How Has This Been Tested?

I created a very simple test to the existing bdd ginkgo suite.

Regarding the manual testing I did:
1. Installed the RHOAI 2.22RC1
2. Created one simple workbench in a new DS project
3. Scaled down the `rhods-operator` deployment to 0
4. Updated the Deployment of the notebook-controller to use my custom image build from this branch (quay.io/opendatahub/kubeflow-notebook-controller:pr-646)
5. I can see that the running workbench StatefulSet now contains the same labels as are defined for its Notebook CR:
```
  labels:
    app: ffff
    opendatahub.io/dashboard: 'true'
    opendatahub.io/odh-managed: 'true'
    opendatahub.io/user: htpasswd-2dcluster-2dadmin-2duser
```
6. I created a new workbench and I can see that the labels are identical between Notebook and StatefulSet CRs (similarly as above)
7. When I manually add a new label to the Notebook CR, it is propagated to the StatefulSet right away
8. When I manually remove this new label from the Notebook CR, it is then removed from the StatefulSet too right away
9. When I manually remove the new label from the StatefulSet CR, it is added back to match the value in the Notebook CR

I haven't performed any actual functional checks with the kueue yet.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that all labels from the Notebook resource are correctly applied to the associated StatefulSet, improving label consistency.

* **Tests**
  * Added and updated tests to verify that labels on the StatefulSet exactly match those on the Notebook resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->