### PR TITLE
Add .editorconfig to enforce coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,8 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+[*.md]
+trim_trailing_whitespace = false
 [Makefile]
 indent_style = tab
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,py,go,sh}]
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yaml,yml,md}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.go]
+indent_style = tab


### PR DESCRIPTION
Fixes: #546
Inspired what we have in: https://github.com/red-hat-data-services/notebooks/blob/9db3af0b9993a8d1bbcc95097a440bdf0e6be728/.editorconfig

This commit introduces an .editorconfig file to help maintain consistent coding styles across different editors and IDEs. It includes rules for:

- End-of-line characters (lf)
- Final newline insertion
- Trailing whitespace trimming
- Character set (utf-8 for js, py, go, sh)
- Indentation styles (spaces for Python, YAML, Markdown; tabs for Makefiles, Go)

Includes a reference link to editorconfig.org at the top of the file.

## Description
This PR introduces an `.editorconfig` file to the root of the repository. This file helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. It defines rules for line endings, final newlines, trailing whitespace, character sets, and indentation for common file types used in this project.

## How Has This Been Tested?
This change adds a configuration file and does not directly modify existing code or functionality. The `.editorconfig` file itself has been validated for correct syntax and its rules are based on standard practices and the file types present in this repository. Editors and IDEs that support EditorConfig will automatically pick up these settings.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a configuration to enforce consistent coding styles and formatting across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->