### PR TITLE
Replace local context.Background() with global context in notebook controller tests

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -93,8 +93,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		route := &routev1.Route{}
 
 		It("Should create a Route to expose the traffic externally", func() {
-			ctx := context.Background()
-
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
@@ -185,8 +183,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		})
 
 		It("Should create a RoleBinding when the referenced Role exists", func() {
-			ctx := context.Background()
-
 			By("Creating a Notebook and ensuring the Role exists")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 			time.Sleep(interval)
@@ -217,8 +213,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		})
 
 		It("Should delete the RoleBinding when the Notebook is deleted", func() {
-			ctx := context.Background()
-
 			By("Ensuring the RoleBinding exists")
 			roleBinding := &rbacv1.RoleBinding{}
 			Eventually(func() error {
@@ -244,7 +238,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		)
 
 		It("Should mount a trusted-ca when it exists on the given namespace", func() {
-			ctx := context.Background()
 			logger := logr.Discard()
 
 			By("By simulating the existence of odh-trusted-ca-bundle ConfigMap")
@@ -381,8 +374,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		route := &routev1.Route{}
 
 		It("Should create a Route to expose the traffic externally", func() {
-			ctx := context.Background()
-
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 			time.Sleep(interval)
@@ -471,8 +462,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		notebook := createNotebook(Name, Namespace)
 
 		It("Should update the Notebook specification", func() {
-			ctx := context.Background()
-
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
@@ -492,7 +481,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		})
 
 		It("When notebook CR is updated, should mount a trusted-ca if it exists on the given namespace", func() {
-			ctx := context.Background()
 			logger := logr.Discard()
 
 			By("By simulating the existence of odh-trusted-ca-bundle ConfigMap")
@@ -622,8 +610,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		notebookOAuthNetworkPolicy := &netv1.NetworkPolicy{}
 
 		It("Should create network policies to restrict undesired traffic", func() {
-			ctx := context.Background()
-
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
@@ -803,8 +789,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		}
 
 		It("Should inject the OAuth proxy as a sidecar container", func() {
-			ctx := context.Background()
-
 			By("By creating a new Notebook")
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
@@ -1045,7 +1029,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should not add OAuth sidecar", func() {
 			notebook := createNotebook(name, namespace)
 			notebook.SetAnnotations(map[string]string{AnnotationServiceMesh: "true"})
-			ctx := context.Background()
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
 			actualNotebook := &nbv1.Notebook{}
@@ -1060,7 +1043,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should not define OAuth network policy", func() {
 			policies := &netv1.NetworkPolicyList{}
 			Eventually(func() error {
-				return cli.List(context.Background(), policies, client.InNamespace(namespace))
+				return cli.List(ctx, policies, client.InNamespace(namespace))
 			}, duration, interval).Should(Succeed())
 
 			Expect(policies.Items).To(Not(ContainElement(notebookOAuthNetworkPolicy)))
@@ -1069,7 +1052,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should not create routes", func() {
 			routes := &routev1.RouteList{}
 			Eventually(func() error {
-				return cli.List(context.Background(), routes, client.InNamespace(namespace))
+				return cli.List(ctx, routes, client.InNamespace(namespace))
 			}, duration, interval).Should(Succeed())
 
 			Expect(routes.Items).To(BeEmpty())
@@ -1080,7 +1063,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			serviceAccounts := &corev1.ServiceAccountList{}
 			Eventually(func() error {
-				return cli.List(context.Background(), serviceAccounts, client.InNamespace(namespace))
+				return cli.List(ctx, serviceAccounts, client.InNamespace(namespace))
 			}, duration, interval).Should(Succeed())
 
 			Expect(serviceAccounts.Items).ToNot(ContainElement(oauthServiceAccount))
@@ -1094,7 +1077,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				},
 			}
 			Eventually(func() error {
-				return cli.List(context.Background(), secrets, client.InNamespace(namespace))
+				return cli.List(ctx, secrets, client.InNamespace(namespace))
 			}, duration, interval).Should(Succeed())
 
 			Expect(secrets.Items).To(BeEmpty())

--- a/components/odh-notebook-controller/controllers/notebook_runtime_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_runtime_test.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -27,8 +26,6 @@ const (
 )
 
 var _ = Describe("Runtime images ConfigMap should be mounted", func() {
-	ctx := context.Background()
-
 	When("Empty ConfigMap for runtime images", func() {
 
 		BeforeEach(func() {

--- a/components/odh-notebook-controller/controllers/notebook_webhook_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -33,8 +32,6 @@ import (
 )
 
 var _ = Describe("The Openshift Notebook webhook", func() {
-	ctx := context.Background()
-
 	When("Creating a Notebook with internal registry disabled", func() {
 		const (
 			Name      = "test-notebook-with-last-image-selection"
@@ -290,7 +287,7 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 		}
 
 		BeforeEach(func() {
-			Expect(tracings.TraceProvider.ForceFlush(context.Background())).To(Succeed())
+			Expect(tracings.TraceProvider.ForceFlush(ctx)).To(Succeed())
 			tracings.SpanExporter.Reset()
 		})
 
@@ -311,7 +308,7 @@ var _ = Describe("The Openshift Notebook webhook", func() {
 					Expect(testCase.notebook.Spec.Template.Spec.Containers[0].Image).To(Equal(testCase.expectedImage))
 
 					By("Checking telemetry events")
-					Expect(tracings.TraceProvider.ForceFlush(context.Background())).To(Succeed())
+					Expect(tracings.TraceProvider.ForceFlush(ctx)).To(Succeed())
 					spans := tracings.SpanExporter.GetSpans()
 					events := make([]string, 0)
 					for _, span := range spans {

--- a/components/odh-notebook-controller/controllers/notebook_webhook_utils_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_utils_test.go
@@ -57,6 +57,7 @@ func TestGetStructDiff(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
+			// global context isn´t used here (tests were failing)
 			diff := getStructDiff(context.Background(), v.a, v.b)
 			assert.Equal(t, diff, v.expected)
 		})


### PR DESCRIPTION
fixes #648

## Description
In notebook_controller_test.go I replaced local context with global one.  

## How Has This Been Tested?
I ran basic tests (go test in controllers directory) and they passed.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined usage of context variables in tests for improved consistency. No changes to test logic or outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->