### PR TITLE
remove ACK_GINKGO_DEPRECATIONS=1.16.5 env var in make test

### DIFF
--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -93,12 +93,10 @@ vet: ## Run go vet against code.
 test: test-with-rbac-false test-with-rbac-true
 test-with-rbac-false: manifests generate fmt vet envtest ## Run tests.
 	export SET_PIPELINE_RBAC=false && \
-	ACK_GINKGO_DEPRECATIONS=1.16.5 \
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
 		go test ./controllers/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover-rbac-false.out
 test-with-rbac-true: manifests generate fmt vet envtest ## Run tests.
 	export SET_PIPELINE_RBAC=true && \
-	ACK_GINKGO_DEPRECATIONS=1.16.5 \
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
 		go test ./controllers/... -ginkgo.v -ginkgo.progress -test.v -coverprofile cover-rbac-true.out
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes #431 
## Description
In Makefile I deleted ACK_GINKGO_DEPRECATIONS=1.16.5 env var, because supposedly they were useless.

## How Has This Been Tested?
I ran basic tests with make test and they passed

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to remove a deprecated environment variable from certain test targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->