### PR TITLE
Bump go-toolset images from UBI8 to UBI9 and from golang 1.23 to 1.24

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -7,7 +7,7 @@ This guide outlines the steps to upgrade the Go version and dependencies in the 
 Upgrading the Go version should be done in a separate PR to isolate the changes and make review easier.
 
 > [!IMPORTANT]  
-> Images are to be built in the [ubi8/go-toolset](https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1) container.
+> Images are to be built in the [ubi9/go-toolset](https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690) container.
 > It contains a customized FIPS-compatible version of Go, that however lags behind the latest upstream Go version.
 > Always use a Go version that has a supporting go-toolset image available.
 
@@ -32,7 +32,7 @@ Upgrading the Go version should be done in a separate PR to isolate the changes 
 5. After merging the Go upgrade PR, update the fork at https://github.com/red-hat-data-services/kubeflow:
    - Locate all `Dockerfile.konflux` files in the repository.
    - Update the Go version in each of these files to match the new version.
-   - Refer to the [ubi8/go-toolset](https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1) in Red Hat image catalog to locate `sha256` hash
+   - Refer to the [ubi9/go-toolset](https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690) in Red Hat image catalog to locate `sha256` hash
    - Create a pull request in the fork repository with these changes.
 
 6. Review CI/CD configuration files (especially openshift/release OCP-CI yamls) that specify a Go version.

--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -7,7 +7,7 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.23
+ARG GOLANG_VERSION=1.24
 
 # Use ubi8/go-toolset as base image
 # https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1

--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -9,10 +9,10 @@
 ARG SOURCE_CODE=.
 ARG GOLANG_VERSION=1.24
 
-# Use ubi8/go-toolset as base image
-# https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1
+# Use ubi9/go-toolset as base image
+# https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690
 # image sets GOTOOLCHAIN=local so it won't end up downloading if go.mod requests different version
-FROM registry.access.redhat.com/ubi8/go-toolset:${GOLANG_VERSION} as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:${GOLANG_VERSION} as builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -41,8 +41,8 @@ USER root
 RUN if [ -z ${CACHITO_ENV_FILE} ]; then go mod download; else source ${CACHITO_ENV_FILE}; fi && \
   CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -a -o ./bin/manager main.go
 
-# Use ubi8/ubi-minimal as base image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# Use ubi9/ubi-minimal as base image
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ## Install additional packages
 RUN microdnf install -y shadow-utils &&\

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -1,8 +1,8 @@
 module github.com/kubeflow/kubeflow/components/notebook-controller
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.5
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -7,7 +7,7 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.23
+ARG GOLANG_VERSION=1.24
 
 # Use ubi8/go-toolset as base image
 # https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -9,10 +9,10 @@
 ARG SOURCE_CODE=.
 ARG GOLANG_VERSION=1.24
 
-# Use ubi8/go-toolset as base image
-# https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1
+# Use ubi9/go-toolset as base image
+# https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690
 # image sets GOTOOLCHAIN=local so it won't end up downloading if go.mod requests different version
-FROM registry.access.redhat.com/ubi8/go-toolset:${GOLANG_VERSION} as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:${GOLANG_VERSION} as builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -39,8 +39,8 @@ USER root
 RUN if [ -z ${CACHITO_ENV_FILE} ]; then go mod download; else source ${CACHITO_ENV_FILE}; fi && \
   CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -tags strictfipsruntime -a -o ./bin/manager main.go
 
-# Use ubi8/ubi-minimal as base image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# Use ubi9/ubi-minimal as base image
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ## Install additional packages
 RUN microdnf install -y shadow-utils &&\

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -469,7 +469,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			key := types.NamespacedName{Name: Name, Namespace: Namespace}
 			Expect(cli.Get(ctx, key, notebook)).Should(Succeed())
 
-			updatedImage := "registry.redhat.io/ubi8/ubi:updated"
+			updatedImage := "registry.redhat.io/ubi9/ubi:updated"
 			notebook.Spec.Template.Spec.Containers[0].Image = updatedImage
 			Expect(cli.Update(ctx, notebook)).Should(Succeed())
 
@@ -510,7 +510,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			key := types.NamespacedName{Name: Name, Namespace: Namespace}
 			Expect(cli.Get(ctx, key, notebook)).Should(Succeed())
 
-			updatedImage := "registry.redhat.io/ubi8/ubi:updated"
+			updatedImage := "registry.redhat.io/ubi9/ubi:updated"
 			notebook.Spec.Template.Spec.Containers[0].Image = updatedImage
 			Expect(cli.Update(ctx, notebook)).Should(Succeed())
 
@@ -705,7 +705,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  Name,
-						Image: "registry.redhat.io/ubi8/ubi:latest",
+						Image: "registry.redhat.io/ubi9/ubi:latest",
 					}},
 					Volumes: []corev1.Volume{
 						{
@@ -742,7 +742,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 						Containers: []corev1.Container{
 							{
 								Name:  Name,
-								Image: "registry.redhat.io/ubi8/ubi:latest",
+								Image: "registry.redhat.io/ubi9/ubi:latest",
 							},
 							createOAuthContainer(Name, Namespace),
 						},
@@ -1352,7 +1352,7 @@ func createNotebook(name, namespace string) *nbv1.Notebook {
 			Template: nbv1.NotebookTemplateSpec{
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{
 					Name:  name,
-					Image: "registry.redhat.io/ubi8/ubi:latest",
+					Image: "registry.redhat.io/ubi9/ubi:latest",
 				}}}},
 		},
 	}

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -1,8 +1,8 @@
 module github.com/opendatahub-io/kubeflow/components/odh-notebook-controller
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.6
+toolchain go1.24.5
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://issues.redhat.com/browse/RHOAIENG-29976

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go version and toolchain to 1.24 for improved compatibility and support.
  * Upgraded base images in relevant components to use the latest Universal Base Image 9 (ubi9).
  * Updated documentation and tests to reflect the new base image versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->