### PR TITLE
Add logging for INJECT_CLUSTER_PROXY_ENV parse errors

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -392,9 +392,11 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 	if raw, ok := os.LookupEnv("INJECT_CLUSTER_PROXY_ENV"); ok {
 		if val, err := strconv.ParseBool(strings.TrimSpace(raw)); err == nil {
 			injectClusterProxy = val
+		} else {
+			log.Info("Failed to parse INJECT_CLUSTER_PROXY_ENV as boolean, defaulting to false", "value", raw, "error", err)
 		}
 	}
-	if w.ClusterWideProxyIsEnabled() && injectClusterProxy {
+	if injectClusterProxy && w.ClusterWideProxyIsEnabled() {
 		err = InjectProxyConfigEnvVars(notebook)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes #632 
## Description
Adding logging for INJECT_CLUSTER_PROXY_ENV parse errors.

## How Has This Been Tested?
I created my own tests with different INJECT_CLUSTER_PROXY_ENV values 
Also I tried the error logging in the wild, with OpenShift cluster:
```
{"level":"info","ts":"2025-07-18T10:41:35Z","logger":"controllers.odh-notebook-webhook","msg":"Failed to parse 
INJECT_CLUSTER_PROXY_ENV as boolean, defaulting false","notebook":"olala","namespace":"test","value":"idk",
"error":"strconv.ParseBool: parsing \"idk\": invalid syntax"}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for invalid environment variable values related to proxy configuration, providing clearer information if issues occur during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->