### PR TITLE
[RHOAIENG-30871] bump the oauth proxy image to RHEL9 and latest

### DIFF
--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: Always
           command:
             - /manager
-          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695"]
+          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"]
           securityContext:
             allowPrivilegeEscalation: false
           ports:

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -42,9 +42,9 @@ const (
 	OAuthServicePort     = 443
 	OAuthServicePortName = "oauth-proxy"
 	// OAuthProxyImage uses sha256 manifest list digest value of v4.14 image for AMD64 as default to be compatible with imagePullPolicy: IfNotPresent, overridable
-	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64?image=66cefc14401df6ff4664ec43&architecture=amd64&container-tabs=overview
+	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy-rhel9/652809b7ad45c632d2163eed?container-tabs=overview&image=6889112836269c65855c1573
 	// and kept in sync with the manifests here and in ClusterServiceVersion metadata of opendatahub operator
-	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695"
+	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"
 
 	// Strings used in secret generation
 	letterRunes = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-30871

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
1. I took the latest ODH nightly build and installed it on my OCP 4.19 cluster
2. Then I amended the subscription CSV replacing the original ODH operator image with my custom build `quay.io/jstourac/opendatahub-operator@sha256:32547e3bbc66f91d01c6c5f340f0513688f143919d9b8c4985de9fd1ff76df02`
3. Then I created the DSC instance
4. Started a basic workbench and checked which image is used for the oauth proxy `registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5`
5. Logged into the running workbench successfully

We should probably check with the OCP 4.14 as the oldest supported OCP version too.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the OAuth proxy image to the RHEL9 variant from the previous release. This updates the base image source for controller deployments to a newer, supported image; no user-facing features or functionality were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->