### PR TITLE
[RHOAIENG-31730] extract the oauth proxy image into params.env file

### DIFF
--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -193,7 +193,7 @@ jobs:
           cd components/odh-notebook-controller/config/base
           kubectl create ns opendatahub
 
-          echo "odh-notebook-controller-image=localhost/${{env.IMG}}:${{env.TAG}}" > params.env
+          sed -i "s|odh-notebook-controller-image=.*|odh-notebook-controller-image=localhost/${{env.IMG}}:${{env.TAG}}|" params.env
 
           cat <<EOF | kubectl apply -f -
           ---

--- a/components/odh-notebook-controller/config/base/kustomization.yaml
+++ b/components/odh-notebook-controller/config/base/kustomization.yaml
@@ -25,3 +25,17 @@ replacements:
       name: manager
       namespace: system
       version: v1
+- source:
+    fieldPath: data.oauth-proxy-image
+    kind: ConfigMap
+    name: odh-notebook-controller-image-parameters
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.0.args.1
+    select:
+      group: apps
+      kind: Deployment
+      name: manager
+      namespace: system
+      version: v1

--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,1 +1,2 @@
 odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:main
+oauth-proxy-image=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5

--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: Always
           command:
             - /manager
-          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"]
+          args: ["--oauth-proxy-image", "oauth-proxy-image_PLACEHOLDER"]
           securityContext:
             allowPrivilegeEscalation: false
           ports:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-31730

This is to enable automate update in the product builds.

We still have a reference of the oauth proxy image in the
notebook_oauth.go file. It is used as a fallback if the
--oauth-proxy-image argument isn't given to the manager process.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
```
~/workspace/rhosai/odh/kubeflow on  main
$ ./ci/kustomize.sh ; echo $?
...
  - /tmp/kustomize-8LfTCEWQXa/kustomize-5.0.3-stdout.yaml
 ...

~/workspace/rhosai/odh/kubeflow on  extractOauthParams
$ ./ci/kustomize.sh ; echo $?
...
  - /tmp/kustomize-SvARl1ypAs/kustomize-5.0.3-stdout.yaml
...

$ diff /tmp/kustomize-8LfTCEWQXa/kustomize-5.0.3-stdout.yaml /tmp/kustomize-SvARl1ypAs/kustomize-5.0.3-stdout.yaml
91928a91929
>   oauth-proxy-image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
92436c92437
<         - registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
---
>         - oauth-proxy-image_PLACEHOLDER
92765a92767
>   oauth-proxy-image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
93034c93036
<         - registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
---
>         - oauth-proxy-image_PLACEHOLDER
104934a104937
>   oauth-proxy-image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
```

There are some differences that shows that we don't expand this placeholder everywhere. But looking on the rest of the generated parts, it looks like this `oauth-proxy-image_PLACEHOLDER` isn't expanded where also the `odh-notebook-controller-image_PLACEHOLDER` isn't expanded, so this probably shouldn't be a problem - we may review what we are generating there in a separate work.

I haven't performed manual build of the opendatahub-operator - I can do that if it's desired.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made the OAuth proxy image configurable via a new parameter for easier updates and environment-specific overrides.

* **Chores**
  * Wired the new parameter into the controller so the selected OAuth proxy image is applied at runtime.
  * Updated CI to modify the image parameter in-place (preserving other config) and ensure the parameter propagates through deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->