### PR TITLE
[RHOAIENG-30871] chore(oauth-proxy): updated misleading comment and GHA image

### DIFF
--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -227,7 +227,7 @@ jobs:
           # switching to unauthenticated oauth-proxy image, c.f. https://github.com/opendatahub-io/opendatahub-community/issues/100
           kustomize build . | \
             sed 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' | \
-            sed 's|registry.redhat.io/openshift4/ose-oauth-proxy.*|quay.io/openshift/origin-oauth-proxy@sha256:1ece77d14a685ef2397c3a327844eea45ded00c95471e9e333e35ef3860b1895|g' | \
+            sed 's|registry.redhat.io/openshift4/ose-oauth-proxy.*|quay.io/openshift/origin-oauth-proxy:4.19|g' | \
             kubectl apply -f -
 
           # patch the webhook with our self-signed CA

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -41,7 +41,7 @@ import (
 const (
 	OAuthServicePort     = 443
 	OAuthServicePortName = "oauth-proxy"
-	// OAuthProxyImage uses sha256 manifest list digest value of v4.14 image for AMD64 as default to be compatible with imagePullPolicy: IfNotPresent, overridable
+	// OAuthProxyImage uses sha256 manifest list digest value of v4.19 image as default to be compatible with imagePullPolicy: IfNotPresent, overridable
 	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy-rhel9/652809b7ad45c632d2163eed?container-tabs=overview&image=6889112836269c65855c1573
 	// and kept in sync with the manifests here and in ClusterServiceVersion metadata of opendatahub operator
 	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"


### PR DESCRIPTION
This is a followup for the #669 and updates the misleading comment for the referenced oauth proxy image. Also updates the image we use for our GHA with some recent build.

The reason I updated the image from a specific hash to a tag:
* we use this in our GHA so we probably don't need exact same image the whole time - in exchange we have decent regular updates without necessity to take care
* with the updates we may detect eventual issues in time
* looks like the specific hash images aren't shown in that quay.io repo for long time anyway

https://issues.redhat.com/browse/RHOAIENG-30871
fixes #673

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Not tested manually, let's see the GHA results.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the integration test workflow to use a tag-based OAuth proxy image reference, improving alignment with current releases and easing maintenance during manifest application in CI.
- Documentation
  - Refined an inline comment to reference the v4.19 OAuth proxy image for clarity; no functional impact or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->