### PR TITLE
NO-JIRA: fix(run-e2e-test*): make e2e test running scrips more robust

### DIFF
--- a/components/odh-notebook-controller/run-e2e-test.sh
+++ b/components/odh-notebook-controller/run-e2e-test.sh
@@ -31,10 +31,24 @@ export K8S_NAMESPACE="${TEST_NAMESPACE}"
 # From now on we want to be sure that undeploy and testing project deletion are called
 
 function cleanup() {
+    local ret_code=0
+
     echo "Performing deployment cleanup of the ${0}"
-    make undeploy && oc delete project "${TEST_NAMESPACE}"
+    make undeploy || {
+        echo "Warning [cleanup]: make undeploy failed, continuing with project deletion!"
+        ret_code=1
+    }
+    oc delete --wait=true --ignore-not-found=true project "${TEST_NAMESPACE}" || {
+        echo "Warning [cleanup]: project deletion failed!"
+        ret_code=1
+    }
+    return ${ret_code}
 }
 trap cleanup EXIT
+
+# assure that the project is deleted on the cluster before running the tests
+# Note: We only delete the project here, not calling cleanup() to avoid unnecessary make undeploy
+oc delete --wait=true --ignore-not-found=true project "${TEST_NAMESPACE}" || echo "Warning [pre-test-cleanup]: project deletion failed!"
 
 # setup and deploy the controller
 oc new-project "${TEST_NAMESPACE}"


### PR DESCRIPTION
Improved the cleanup logic.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Ensure a clean test namespace before runs by unconditionally deleting the test project to avoid leftovers.
  - Make teardown more tolerant: undeploy/delete failures are logged as warnings, do not abort cleanup, and return a non-zero status while allowing deletion to proceed.
  - Added explicit comments clarifying pre-test deletion and cleanup flow.
  - Aligned service-mesh and standard E2E scripts for more consistent setup/teardown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->