### PR TITLE
fix(params.env): missing oauth-proxy data for kustomization input

### DIFF
--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,1 +1,2 @@
 odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:v1.10.0-4
+oauth-proxy-image=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5


### PR DESCRIPTION
This got lost during the [main->v1.10-branch sync](https://github.com/opendatahub-io/kubeflow/actions/runs/17091951545) yesterday.

Using the data we have in ODH, see opendatahub-io/kubeflow#671.

https://issues.redhat.com/browse/RHOAIENG-31730

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
