### PR TITLE
NO-JIRA: chore(log): use regular hyphen instead of a dash

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
@@ -62,7 +62,7 @@ func getDashboardInstance(ctx context.Context, dynamicClient dynamic.Interface, 
 		}
 		// Catch "no matches for kind" when CRD is missing
 		if meta.IsNoMatchError(err) {
-			log.Info("Dashboard CRD is not installed in the cluster — skipping")
+			log.Info("Dashboard CRD is not installed in the cluster - skipping")
 			return nil, nil
 		}
 		log.Error(err, "Failed to retrieve Dashboard CR", "name", dashboardInstanceName)
@@ -82,7 +82,7 @@ func getDSPAInstance(ctx context.Context, k8sClient client.Client, namespace str
 		}
 		// Catch "no matches for kind" when CRD is missing
 		if meta.IsNoMatchError(err) {
-			log.Info("DSPA CRD is not installed in the cluster — skipping")
+			log.Info("DSPA CRD is not installed in the cluster - skipping")
 			return nil, nil
 		}
 		log.Error(err, "Failed to retrieve DSPA CR", "name", dspaInstanceName, "namespace", namespace)
@@ -194,7 +194,7 @@ func (r *OpenshiftNotebookReconciler) NewElyraRuntimeConfigSecret(ctx context.Co
 	if err != nil {
 		return err
 	}
-	// Neither DSPA nor Dashboard CRs are present — skipping Elyra secret creation
+	// Neither DSPA nor Dashboard CRs are present - skipping Elyra secret creation
 	if dspaInstance == nil && len(dashboardInstance) == 0 {
 		return nil
 	}


### PR DESCRIPTION
In raw OpenShift logs (no UTF-8) we would see:
```
DSPA CRD is not installed in the cluster â€” skipping
```
instead of the
```
DSPA CRD is not installed in the cluster — skipping
```

There's no need to be special, so let's use standard hyphen for simplicity.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized punctuation in log messages, replacing em dashes with hyphens for consistency across outputs.
  * Improved readability of runtime logs; no behavioral or functional impact.

* **Documentation**
  * Updated an inline comment to use consistent punctuation.

* **Chores**
  * No changes to APIs, configuration, or control flow; purely textual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->