### PR TITLE
E2e extra logging

### DIFF
--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -192,7 +192,7 @@ undeploy-dev: setup undeploy-kf ## Undeploy controller from the Openshift cluste
 .PHONY: e2e-test
 e2e-test: ## Run e2e tests for the controller
 	# Default timeout is 10m but we need to increase it to 20m for the e2e tests
-	go test ./e2e/ -timeout=20m -run ^TestE2ENotebookController -v \
+	E2E_LOG_LEVEL=$(E2E_LOG_LEVEL) go test ./e2e/ -timeout=20m -run ^TestE2ENotebookController -v \
 		--nb-namespace=$(K8S_NAMESPACE) \
 		${E2E_TEST_FLAGS}
 

--- a/components/odh-notebook-controller/e2e/DEBUG_LOGGING.md
+++ b/components/odh-notebook-controller/e2e/DEBUG_LOGGING.md
@@ -1,0 +1,220 @@
+# E2E Structured Logging
+
+This document describes the structured logging framework implemented for the E2E tests in the ODH Notebook Controller using the same logr infrastructure as the main controller.
+
+## Overview
+
+The E2E logging framework provides configurable, structured logging to help with debugging test failures, especially in CI environments. It uses the same logging infrastructure as the main controller (logr + zap) for consistency and professional-grade logging capabilities.
+
+## Features
+
+- **Multiple log levels**: `debug`, `info`, `warn`, `error`
+- **Configurable via environment variable**: `E2E_LOG_LEVEL=debug|info|warn|error`
+- **INFO level by default**: Provides basic information without overwhelming output
+- **DEBUG level in CI**: Detailed logging enabled by default in CI environments
+- **Structured logging**: Key-value pairs for easy filtering and analysis
+- **Context-aware**: Different loggers for different test areas (helper, creation, culling, etc.)
+- **Consistent with controller**: Uses the same logr/zap infrastructure
+
+## Usage
+
+### Log Levels
+
+- **ERROR**: Only errors and failures (minimal output)
+- **WARN**: Warnings and errors
+- **INFO**: General information about test progress (default)
+- **DEBUG**: Detailed debugging information including polling, status checks, etc.
+
+### Local Development
+
+```bash
+# Default INFO level - clean, informative output
+make e2e-test
+
+# Debug level for troubleshooting
+export E2E_LOG_LEVEL=debug
+make e2e-test
+
+# Minimal output - only errors
+export E2E_LOG_LEVEL=error
+make e2e-test
+```
+
+### CI Environment
+
+In CI environments, debug logging is enabled by default but can be overridden:
+
+```bash
+# Default in CI - debug level
+./run-e2e-test.sh
+
+# Override to info level in CI
+export E2E_LOG_LEVEL=info
+./run-e2e-test.sh
+```
+
+## Log Format
+
+Structured logs follow the standard logr/zap format with key-value pairs:
+
+```
+2023-09-15T15:04:05.123Z	INFO	e2e-tests.helper	Waiting for controller deployment	{"deployment": "odh-notebook-controller-manager", "replicas": 1, "timeout": "1m0s"}
+2023-09-15T15:04:05.456Z	INFO	e2e-tests.creation	Starting notebook creation test	{"notebook": "thoth-minimal-oauth-notebook", "namespace": "e2e-notebook-controller"}
+```
+
+With structured data for easy parsing:
+
+```
+2023-09-15T15:04:10.789Z	INFO	e2e-tests.helper	Controller deployment ready	{"deployment": "odh-notebook-controller-manager", "duration": "5.333s", "polls": 3}
+```
+
+Debug level logs (V(1)) provide additional detail:
+
+```
+2023-09-15T15:04:06.123Z	DEBUG	e2e-tests.helper	Deployment status	{"poll": 2, "readyReplicas": 1, "expectedReplicas": 1, "availableReplicas": 1}
+```
+
+## Logger Contexts
+
+The logging framework provides different logger contexts for different test areas:
+
+- **helper** - Helper functions (waiting for deployments, getting routes, etc.)
+- **creation** - Notebook creation tests
+- **deletion** - Notebook deletion tests  
+- **update** - Notebook update tests
+- **culling** - Notebook culling tests
+- **validation** - Validation tests
+
+## Implementation Details
+
+### Core Components
+
+1. **debug_logger.go**: Structured logging framework using logr/zap
+2. **Environment variable**: `E2E_LOG_LEVEL` controls log level (debug|info|warn|error)
+3. **Context-based loggers**: Specialized loggers for different test areas
+4. **Structured fields**: Key-value pairs for easy parsing and filtering
+
+### Key Functions
+
+- `GetLogger(name)` - Get a logger with custom name
+- `GetHelperLogger()` - Helper function logging
+- `GetCreationLogger()` - Creation test logging  
+- `GetCullingLogger()` - Culling test logging
+- `GetValidationLogger()` - Validation test logging
+
+### Integration Points
+
+The structured logging is integrated into:
+
+- **Controller deployment waiting** - Polling status with structured data
+- **Route retrieval** - Network policy and route discovery with context
+- **Notebook creation** - Step-by-step creation process tracking
+- **Culling tests** - Comprehensive workflow with timing and status
+- **HTTP requests** - Request details and response status tracking
+
+## Examples
+
+### Sample Output (INFO Level - Default)
+
+```
+2023-09-15T15:04:05.123Z	INFO	e2e-tests	E2E logging initialized	{"level": "info"}
+2023-09-15T15:04:05.200Z	INFO	e2e-tests.helper	Waiting for controller deployment	{"deployment": "odh-notebook-controller-manager", "replicas": 1, "timeout": "1m0s"}
+2023-09-15T15:04:10.456Z	INFO	e2e-tests.helper	Controller deployment ready	{"duration": "5.256s", "polls": 3}
+2023-09-15T15:04:11.123Z	INFO	e2e-tests.creation	Starting notebook creation test	{"notebook": "thoth-minimal-oauth-notebook", "namespace": "e2e-notebook-controller"}
+2023-09-15T15:04:15.789Z	INFO	e2e-tests.creation	Notebook creation test completed successfully	{"duration": "4.666s"}
+```
+
+### Sample Output (DEBUG Level)
+
+```
+2023-09-15T15:04:05.123Z	INFO	e2e-tests	E2E logging initialized	{"level": "debug"}
+2023-09-15T15:04:05.200Z	INFO	e2e-tests.helper	Waiting for controller deployment	{"deployment": "odh-notebook-controller-manager", "replicas": 1, "timeout": "1m0s"}
+2023-09-15T15:04:06.250Z	DEBUG	e2e-tests.helper	Deployment not found, continuing to wait	{"poll": 1}
+2023-09-15T15:04:08.300Z	DEBUG	e2e-tests.helper	Deployment status	{"poll": 2, "readyReplicas": 0, "expectedReplicas": 1, "availableReplicas": 0, "unavailableReplicas": 1}
+2023-09-15T15:04:10.456Z	INFO	e2e-tests.helper	Controller deployment ready	{"duration": "5.256s", "polls": 3}
+2023-09-15T15:04:11.123Z	INFO	e2e-tests.creation	Starting notebook creation test	{"notebook": "thoth-minimal-oauth-notebook", "namespace": "e2e-notebook-controller"}
+2023-09-15T15:04:11.200Z	DEBUG	e2e-tests.creation	Checking if notebook already exists
+2023-09-15T15:04:11.250Z	INFO	e2e-tests.creation	Notebook not found, creating new notebook
+2023-09-15T15:04:15.789Z	INFO	e2e-tests.creation	Notebook creation test completed successfully	{"duration": "4.666s"}
+```
+
+### Sample Output (ERROR Level - Minimal)
+
+```
+2023-09-15T15:04:05.123Z	INFO	e2e-tests	E2E logging initialized	{"level": "error"}
+# Only errors would be shown, providing minimal output for fast feedback
+```
+
+## Filtering and Analysis
+
+### Filtering Logs
+
+You can filter structured logs by context or fields using standard tools:
+
+```bash
+# Show only helper operations
+make e2e-test 2>&1 | grep "e2e-tests.helper"
+
+# Show only creation tests
+make e2e-test 2>&1 | grep "e2e-tests.creation"
+
+# Show only errors
+make e2e-test 2>&1 | grep "ERROR"
+
+# Filter by specific notebook
+make e2e-test 2>&1 | grep '"notebook":"thoth-minimal-oauth-notebook"'
+```
+
+### JSON Processing
+
+Since logs are structured, you can process them with tools like `jq`:
+
+```bash
+# Extract timing information
+make e2e-test 2>&1 | grep "duration" | jq -r .duration
+
+# Find operations that took longer than 5 seconds
+make e2e-test 2>&1 | jq -r 'select(.duration > "5s")'
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Environment variable not set**: Ensure `E2E_LOG_LEVEL` is exported before running tests
+2. **Invalid log level**: Valid values are `debug`, `info`, `warn`, `error` (case-insensitive)
+3. **Override in CI**: To change CI logging level, set `E2E_LOG_LEVEL` before running scripts
+
+### Performance Impact
+
+- **ERROR level**: Minimal overhead, fastest execution
+- **INFO level**: Low overhead, good balance (default)
+- **DEBUG level**: Higher overhead but detailed information
+- **Development mode**: DEBUG level enables development mode in zap for more readable output
+
+## Contributing
+
+When adding new E2E tests or modifying existing ones:
+
+1. Use appropriate logger context (`GetCreationLogger()`, `GetHelperLogger()`, etc.)
+2. Include structured fields for important data (`"notebook": name`, `"duration": time`)
+3. Use `logger.Info()` for important events, `logger.V(1).Info()` for debug details
+4. Use `logger.Error()` for error conditions with structured context
+5. Add timing information for long-running operations
+
+### Adding New Logger Contexts
+
+To add a new logger context:
+
+1. Add a new convenience function to `debug_logger.go`:
+   ```go
+   func GetMyNewLogger() logr.Logger {
+       return e2eLogger.WithName("mynew")
+   }
+   ```
+2. Use it in your tests:
+   ```go
+   logger := GetMyNewLogger().WithValues("key", "value")
+   logger.Info("My operation started")
+   ```
+3. Update this documentation with the new context

--- a/components/odh-notebook-controller/e2e/debug_logger.go
+++ b/components/odh-notebook-controller/e2e/debug_logger.go
@@ -1,0 +1,94 @@
+package e2e
+
+import (
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
+	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// e2eLogger is the structured logger for E2E tests
+var e2eLogger logr.Logger
+
+func init() {
+	// Initialize structured logger using the same infrastructure as the controller
+	logLevel := getLogLevel()
+
+	opts := ctrlzap.Options{
+		Development: logLevel <= zapcore.DebugLevel,
+		Level:       logLevel,
+		TimeEncoder: zapcore.TimeEncoderOfLayout(time.RFC3339),
+	}
+
+	zapLogger := ctrlzap.New(ctrlzap.UseFlagOptions(&opts))
+	e2eLogger = zapLogger.WithName("e2e-tests")
+
+	// Log initialization
+	e2eLogger.Info("E2E logging initialized", "level", logLevel.String())
+}
+
+// getLogLevel determines log level from environment variable
+// E2E_LOG_LEVEL can be: debug, info, warn, error
+// Default is INFO level for normal operation
+func getLogLevel() zapcore.Level {
+	envValue := os.Getenv("E2E_LOG_LEVEL")
+	switch envValue {
+	case "debug", "DEBUG":
+		return zapcore.DebugLevel
+	case "info", "INFO":
+		return zapcore.InfoLevel
+	case "warn", "WARN":
+		return zapcore.WarnLevel
+	case "error", "ERROR":
+		return zapcore.ErrorLevel
+	default:
+		// Default to INFO level (normal operation)
+		// In CI, we can set E2E_LOG_LEVEL=debug for detailed logging
+		return zapcore.InfoLevel
+	}
+}
+
+// GetLogger returns a logger with the specified context name
+func GetLogger(name string) logr.Logger {
+	return e2eLogger.WithName(name)
+}
+
+// Convenience functions for common E2E test contexts
+// These provide pre-configured loggers for different test areas
+
+// GetHelperLogger returns a logger for helper functions
+func GetHelperLogger() logr.Logger {
+	return e2eLogger.WithName("helper")
+}
+
+// GetCreationLogger returns a logger for creation tests
+func GetCreationLogger() logr.Logger {
+	return e2eLogger.WithName("creation")
+}
+
+// GetDeletionLogger returns a logger for deletion tests
+func GetDeletionLogger() logr.Logger {
+	return e2eLogger.WithName("deletion")
+}
+
+// GetUpdateLogger returns a logger for update tests
+func GetUpdateLogger() logr.Logger {
+	return e2eLogger.WithName("update")
+}
+
+// GetCullingLogger returns a logger for culling tests
+func GetCullingLogger() logr.Logger {
+	return e2eLogger.WithName("culling")
+}
+
+// GetValidationLogger returns a logger for validation tests
+func GetValidationLogger() logr.Logger {
+	return e2eLogger.WithName("validation")
+}
+
+// IsDebugEnabled returns whether debug level logging is enabled
+func IsDebugEnabled() bool {
+	return e2eLogger.V(1).Enabled()
+}

--- a/components/odh-notebook-controller/e2e/helper_test.go
+++ b/components/odh-notebook-controller/e2e/helper_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -307,10 +309,38 @@ func (tc *testContext) waitForStatefulSet(nbMeta *metav1.ObjectMeta, availableRe
 			}
 		}
 
+		// Enhanced logging with detailed StatefulSet status
 		logger.V(1).Info("StatefulSet status",
 			"poll", pollCount,
 			"availableReplicas", notebookStatefulSet.Status.AvailableReplicas,
-			"readyReplicas", notebookStatefulSet.Status.ReadyReplicas)
+			"readyReplicas", notebookStatefulSet.Status.ReadyReplicas,
+			"replicas", notebookStatefulSet.Status.Replicas,
+			"currentReplicas", notebookStatefulSet.Status.CurrentReplicas,
+			"updatedReplicas", notebookStatefulSet.Status.UpdatedReplicas,
+			"observedGeneration", notebookStatefulSet.Status.ObservedGeneration,
+			"currentRevision", notebookStatefulSet.Status.CurrentRevision,
+			"updateRevision", notebookStatefulSet.Status.UpdateRevision)
+
+		// Log StatefulSet conditions if any
+		if len(notebookStatefulSet.Status.Conditions) > 0 {
+			for _, condition := range notebookStatefulSet.Status.Conditions {
+				logger.V(1).Info("StatefulSet condition",
+					"poll", pollCount,
+					"type", condition.Type,
+					"status", condition.Status,
+					"reason", condition.Reason,
+					"message", condition.Message)
+			}
+		}
+
+		// If replicas are not as expected, get detailed pod information
+		if notebookStatefulSet.Status.AvailableReplicas != availableReplicas ||
+			notebookStatefulSet.Status.ReadyReplicas != readyReplicas {
+			tc.logDetailedPodStatus(nbMeta, pollCount, logger)
+
+			// Log cluster resource availability to help diagnose resource constraints
+			tc.logClusterResourceAvailability(pollCount, logger)
+		}
 
 		if notebookStatefulSet.Status.AvailableReplicas == availableReplicas &&
 			notebookStatefulSet.Status.ReadyReplicas == readyReplicas {
@@ -325,6 +355,10 @@ func (tc *testContext) waitForStatefulSet(nbMeta *metav1.ObjectMeta, availableRe
 		logger.V(1).Info("StatefulSet failed to reach expected replica count",
 			"polls", pollCount,
 			"error", err)
+		// Log final detailed status on failure
+		tc.logFinalStatefulSetAndPodStatus(nbMeta, logger)
+		// Log final cluster resource status to help diagnose resource issues
+		tc.logClusterResourceAvailability(0, logger)
 	}
 	return err
 }
@@ -570,4 +604,586 @@ func setupThothRbacCustomResourcesNotebook() notebookContext {
 		nbSpec:       &testNotebook.Spec,
 	}
 	return thothRbacCustomResourcesNbContext
+}
+
+// logDetailedPodStatus logs detailed information about pods when StatefulSet is not ready
+func (tc *testContext) logDetailedPodStatus(nbMeta *metav1.ObjectMeta, pollCount int, logger logr.Logger) {
+	pods, err := tc.kubeClient.CoreV1().Pods(tc.testNamespace).List(tc.ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("statefulset=%s", nbMeta.Name),
+	})
+	if err != nil {
+		logger.V(1).Info("Failed to get pods for detailed status",
+			"poll", pollCount,
+			"error", err)
+		return
+	}
+
+	logger.V(1).Info("Pod count for StatefulSet",
+		"poll", pollCount,
+		"totalPods", len(pods.Items))
+
+	for i, pod := range pods.Items {
+		logger.V(1).Info("Pod detailed status",
+			"poll", pollCount,
+			"podIndex", i,
+			"podName", pod.Name,
+			"phase", pod.Status.Phase,
+			"message", pod.Status.Message,
+			"reason", pod.Status.Reason,
+			"deletionTimestamp", pod.DeletionTimestamp,
+			"creationTimestamp", pod.CreationTimestamp)
+
+		// Log container statuses
+		for j, containerStatus := range pod.Status.ContainerStatuses {
+			logger.V(1).Info("Container status",
+				"poll", pollCount,
+				"podName", pod.Name,
+				"containerIndex", j,
+				"containerName", containerStatus.Name,
+				"ready", containerStatus.Ready,
+				"started", containerStatus.Started,
+				"restartCount", containerStatus.RestartCount,
+				"image", containerStatus.Image)
+
+			// Log waiting state details if present
+			if containerStatus.State.Waiting != nil {
+				logger.V(1).Info("Container waiting state",
+					"poll", pollCount,
+					"podName", pod.Name,
+					"containerName", containerStatus.Name,
+					"reason", containerStatus.State.Waiting.Reason,
+					"message", containerStatus.State.Waiting.Message)
+			}
+
+			// Log terminated state details if present
+			if containerStatus.State.Terminated != nil {
+				logger.V(1).Info("Container terminated state",
+					"poll", pollCount,
+					"podName", pod.Name,
+					"containerName", containerStatus.Name,
+					"reason", containerStatus.State.Terminated.Reason,
+					"message", containerStatus.State.Terminated.Message,
+					"exitCode", containerStatus.State.Terminated.ExitCode)
+			}
+		}
+
+		// Log pod conditions
+		for k, condition := range pod.Status.Conditions {
+			logger.V(1).Info("Pod condition",
+				"poll", pollCount,
+				"podName", pod.Name,
+				"conditionIndex", k,
+				"type", condition.Type,
+				"status", condition.Status,
+				"reason", condition.Reason,
+				"message", condition.Message)
+		}
+	}
+
+	// Also log recent events for the pods
+	tc.logPodEvents(nbMeta, pollCount, logger)
+}
+
+// logPodEvents logs recent events related to the notebook pods
+func (tc *testContext) logPodEvents(nbMeta *metav1.ObjectMeta, pollCount int, logger logr.Logger) {
+	events, err := tc.kubeClient.CoreV1().Events(tc.testNamespace).List(tc.ctx, metav1.ListOptions{
+		FieldSelector: "involvedObject.kind=Pod",
+	})
+	if err != nil {
+		logger.V(1).Info("Failed to get events",
+			"poll", pollCount,
+			"error", err)
+		return
+	}
+
+	// Filter events related to our notebook pods
+	relevantEvents := []v1.Event{}
+	for _, event := range events.Items {
+		if strings.Contains(event.InvolvedObject.Name, nbMeta.Name) {
+			relevantEvents = append(relevantEvents, event)
+		}
+	}
+
+	if len(relevantEvents) > 0 {
+		logger.V(1).Info("Recent pod events found",
+			"poll", pollCount,
+			"eventCount", len(relevantEvents))
+
+		for i, event := range relevantEvents {
+			logger.V(1).Info("Pod event",
+				"poll", pollCount,
+				"eventIndex", i,
+				"podName", event.InvolvedObject.Name,
+				"type", event.Type,
+				"reason", event.Reason,
+				"message", event.Message,
+				"count", event.Count,
+				"firstTimestamp", event.FirstTimestamp,
+				"lastTimestamp", event.LastTimestamp)
+		}
+	}
+}
+
+// logFinalStatefulSetAndPodStatus logs comprehensive status when StatefulSet validation fails
+func (tc *testContext) logFinalStatefulSetAndPodStatus(nbMeta *metav1.ObjectMeta, logger logr.Logger) {
+	logger.Info("Logging final StatefulSet and Pod status for debugging")
+
+	// Get StatefulSet details
+	ss, err := tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(tc.ctx, nbMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		logger.Info("Failed to get StatefulSet for final status",
+			"error", err)
+	} else {
+		logger.Info("Final StatefulSet status",
+			"name", ss.Name,
+			"replicas", ss.Status.Replicas,
+			"readyReplicas", ss.Status.ReadyReplicas,
+			"availableReplicas", ss.Status.AvailableReplicas,
+			"currentReplicas", ss.Status.CurrentReplicas,
+			"updatedReplicas", ss.Status.UpdatedReplicas,
+			"observedGeneration", ss.Status.ObservedGeneration)
+
+		// Log final conditions
+		for _, condition := range ss.Status.Conditions {
+			logger.Info("Final StatefulSet condition",
+				"type", condition.Type,
+				"status", condition.Status,
+				"reason", condition.Reason,
+				"message", condition.Message)
+		}
+	}
+
+	// Get pod details
+	pods, err := tc.kubeClient.CoreV1().Pods(tc.testNamespace).List(tc.ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("statefulset=%s", nbMeta.Name),
+	})
+	if err != nil {
+		logger.Info("Failed to get pods for final status",
+			"error", err)
+		return
+	}
+
+	logger.Info("Final pod status summary",
+		"totalPods", len(pods.Items))
+
+	for _, pod := range pods.Items {
+		logger.Info("Final pod status",
+			"podName", pod.Name,
+			"phase", pod.Status.Phase,
+			"message", pod.Status.Message,
+			"reason", pod.Status.Reason,
+			"startTime", pod.Status.StartTime,
+			"deletionTimestamp", pod.DeletionTimestamp)
+
+		// Log final container statuses
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			logger.Info("Final container status",
+				"podName", pod.Name,
+				"containerName", containerStatus.Name,
+				"ready", containerStatus.Ready,
+				"restartCount", containerStatus.RestartCount,
+				"image", containerStatus.Image)
+
+			if containerStatus.State.Waiting != nil {
+				logger.Info("Final container waiting state",
+					"podName", pod.Name,
+					"containerName", containerStatus.Name,
+					"reason", containerStatus.State.Waiting.Reason,
+					"message", containerStatus.State.Waiting.Message)
+			}
+
+			if containerStatus.State.Terminated != nil {
+				logger.Info("Final container terminated state",
+					"podName", pod.Name,
+					"containerName", containerStatus.Name,
+					"reason", containerStatus.State.Terminated.Reason,
+					"message", containerStatus.State.Terminated.Message,
+					"exitCode", containerStatus.State.Terminated.ExitCode)
+			}
+		}
+	}
+
+	// Log all recent events one final time
+	events, err := tc.kubeClient.CoreV1().Events(tc.testNamespace).List(tc.ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.Info("Failed to get events for final status",
+			"error", err)
+		return
+	}
+
+	relevantEvents := []v1.Event{}
+	for _, event := range events.Items {
+		if strings.Contains(event.InvolvedObject.Name, nbMeta.Name) ||
+			(event.InvolvedObject.Kind == "StatefulSet" && event.InvolvedObject.Name == nbMeta.Name) {
+			relevantEvents = append(relevantEvents, event)
+		}
+	}
+
+	if len(relevantEvents) > 0 {
+		logger.Info("Final events summary",
+			"relevantEventCount", len(relevantEvents))
+
+		for _, event := range relevantEvents {
+			logger.Info("Final event",
+				"objectKind", event.InvolvedObject.Kind,
+				"objectName", event.InvolvedObject.Name,
+				"type", event.Type,
+				"reason", event.Reason,
+				"message", event.Message,
+				"count", event.Count,
+				"lastTimestamp", event.LastTimestamp)
+		}
+	}
+}
+
+// logClusterResourceAvailability logs cluster resource availability to help diagnose resource constraints
+func (tc *testContext) logClusterResourceAvailability(pollCount int, logger logr.Logger) {
+	logger.V(1).Info("Checking cluster resource availability",
+		"poll", pollCount)
+
+	// Get all nodes in the cluster
+	nodes, err := tc.kubeClient.CoreV1().Nodes().List(tc.ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.V(1).Info("Failed to get cluster nodes",
+			"poll", pollCount,
+			"error", err)
+		return
+	}
+
+	logger.V(1).Info("Cluster node summary",
+		"poll", pollCount,
+		"totalNodes", len(nodes.Items))
+
+	var totalAllocatableCPU, totalAllocatableMemory, totalCapacityCPU, totalCapacityMemory resource.Quantity
+	var readyNodes, schedulableNodes int
+
+	for i, node := range nodes.Items {
+		// Check node conditions
+		var nodeReady, nodeSchedulable bool = false, true
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+				nodeReady = true
+			}
+		}
+		if node.Spec.Unschedulable {
+			nodeSchedulable = false
+		}
+
+		if nodeReady {
+			readyNodes++
+		}
+		if nodeSchedulable && nodeReady {
+			schedulableNodes++
+		}
+
+		logger.V(1).Info("Node resource details",
+			"poll", pollCount,
+			"nodeIndex", i,
+			"nodeName", node.Name,
+			"ready", nodeReady,
+			"schedulable", nodeSchedulable,
+			"unschedulable", node.Spec.Unschedulable,
+			"capacityCPU", node.Status.Capacity.Cpu().String(),
+			"capacityMemory", node.Status.Capacity.Memory().String(),
+			"allocatableCPU", node.Status.Allocatable.Cpu().String(),
+			"allocatableMemory", node.Status.Allocatable.Memory().String())
+
+		// Log node conditions that might affect scheduling
+		for _, condition := range node.Status.Conditions {
+			if condition.Status != v1.ConditionTrue {
+				logger.V(1).Info("Node condition issue",
+					"poll", pollCount,
+					"nodeName", node.Name,
+					"conditionType", condition.Type,
+					"status", condition.Status,
+					"reason", condition.Reason,
+					"message", condition.Message)
+			}
+		}
+
+		// Log node taints that might prevent scheduling
+		if len(node.Spec.Taints) > 0 {
+			for _, taint := range node.Spec.Taints {
+				logger.V(1).Info("Node taint",
+					"poll", pollCount,
+					"nodeName", node.Name,
+					"key", taint.Key,
+					"value", taint.Value,
+					"effect", taint.Effect)
+			}
+		}
+
+		// Add to totals (only for schedulable and ready nodes)
+		if nodeSchedulable && nodeReady {
+			if cpu := node.Status.Allocatable.Cpu(); cpu != nil {
+				totalAllocatableCPU.Add(*cpu)
+			}
+			if memory := node.Status.Allocatable.Memory(); memory != nil {
+				totalAllocatableMemory.Add(*memory)
+			}
+			if cpu := node.Status.Capacity.Cpu(); cpu != nil {
+				totalCapacityCPU.Add(*cpu)
+			}
+			if memory := node.Status.Capacity.Memory(); memory != nil {
+				totalCapacityMemory.Add(*memory)
+			}
+		}
+	}
+
+	logger.V(1).Info("Cluster resource summary",
+		"poll", pollCount,
+		"readyNodes", readyNodes,
+		"schedulableNodes", schedulableNodes,
+		"totalCapacityCPU", totalCapacityCPU.String(),
+		"totalCapacityMemory", totalCapacityMemory.String(),
+		"totalAllocatableCPU", totalAllocatableCPU.String(),
+		"totalAllocatableMemory", totalAllocatableMemory.String())
+
+	// Get resource usage from all pods in the cluster to calculate available resources
+	tc.logClusterResourceUsage(pollCount, logger, totalAllocatableCPU, totalAllocatableMemory)
+
+	// Log specific namespace resource usage
+	tc.logNamespaceResourceUsage(pollCount, logger)
+}
+
+// logClusterResourceUsage logs current resource usage across the cluster
+func (tc *testContext) logClusterResourceUsage(pollCount int, logger logr.Logger, totalAllocatableCPU, totalAllocatableMemory resource.Quantity) {
+	// Get all pods in the cluster to calculate resource usage
+	allPods, err := tc.kubeClient.CoreV1().Pods("").List(tc.ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.V(1).Info("Failed to get all cluster pods for resource usage",
+			"poll", pollCount,
+			"error", err)
+		return
+	}
+
+	var usedCPU, usedMemory resource.Quantity
+	var runningPods, pendingPods, failedPods int
+
+	for _, pod := range allPods.Items {
+		switch pod.Status.Phase {
+		case v1.PodRunning:
+			runningPods++
+			// Add resource requests for running pods
+			for _, container := range pod.Spec.Containers {
+				if cpu := container.Resources.Requests.Cpu(); cpu != nil {
+					usedCPU.Add(*cpu)
+				}
+				if memory := container.Resources.Requests.Memory(); memory != nil {
+					usedMemory.Add(*memory)
+				}
+			}
+		case v1.PodPending:
+			pendingPods++
+		case v1.PodFailed:
+			failedPods++
+		}
+	}
+
+	// Calculate available resources
+	availableCPU := totalAllocatableCPU.DeepCopy()
+	availableCPU.Sub(usedCPU)
+	availableMemory := totalAllocatableMemory.DeepCopy()
+	availableMemory.Sub(usedMemory)
+
+	logger.V(1).Info("Cluster resource usage",
+		"poll", pollCount,
+		"totalPods", len(allPods.Items),
+		"runningPods", runningPods,
+		"pendingPods", pendingPods,
+		"failedPods", failedPods,
+		"usedCPU", usedCPU.String(),
+		"usedMemory", usedMemory.String(),
+		"availableCPU", availableCPU.String(),
+		"availableMemory", availableMemory.String())
+
+	// Calculate utilization percentages
+	if !totalAllocatableCPU.IsZero() {
+		cpuUtilization := float64(usedCPU.MilliValue()) / float64(totalAllocatableCPU.MilliValue()) * 100
+		logger.V(1).Info("Cluster CPU utilization",
+			"poll", pollCount,
+			"utilizationPercent", fmt.Sprintf("%.2f%%", cpuUtilization))
+	}
+
+	if !totalAllocatableMemory.IsZero() {
+		memoryUtilization := float64(usedMemory.Value()) / float64(totalAllocatableMemory.Value()) * 100
+		logger.V(1).Info("Cluster memory utilization",
+			"poll", pollCount,
+			"utilizationPercent", fmt.Sprintf("%.2f%%", memoryUtilization))
+	}
+
+	// Log pending pods with resource requests to understand scheduling pressure
+	pendingPodsWithResources := 0
+	var pendingCPURequests, pendingMemoryRequests resource.Quantity
+
+	for _, pod := range allPods.Items {
+		if pod.Status.Phase == v1.PodPending {
+			hasCPURequest := false
+			hasMemoryRequest := false
+			for _, container := range pod.Spec.Containers {
+				if cpu := container.Resources.Requests.Cpu(); cpu != nil && !cpu.IsZero() {
+					pendingCPURequests.Add(*cpu)
+					hasCPURequest = true
+				}
+				if memory := container.Resources.Requests.Memory(); memory != nil && !memory.IsZero() {
+					pendingMemoryRequests.Add(*memory)
+					hasMemoryRequest = true
+				}
+			}
+			if hasCPURequest || hasMemoryRequest {
+				pendingPodsWithResources++
+			}
+		}
+	}
+
+	if pendingPodsWithResources > 0 {
+		logger.V(1).Info("Pending pods resource pressure",
+			"poll", pollCount,
+			"pendingPodsWithResources", pendingPodsWithResources,
+			"pendingCPURequests", pendingCPURequests.String(),
+			"pendingMemoryRequests", pendingMemoryRequests.String())
+	}
+}
+
+// logNamespaceResourceUsage logs resource usage specifically in the test namespace
+func (tc *testContext) logNamespaceResourceUsage(pollCount int, logger logr.Logger) {
+	namespacePods, err := tc.kubeClient.CoreV1().Pods(tc.testNamespace).List(tc.ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.V(1).Info("Failed to get namespace pods for resource usage",
+			"poll", pollCount,
+			"namespace", tc.testNamespace,
+			"error", err)
+		return
+	}
+
+	var namespaceCPU, namespaceMemory resource.Quantity
+	var namespaceRunning, namespacePending, namespaceFailed int
+
+	for _, pod := range namespacePods.Items {
+		switch pod.Status.Phase {
+		case v1.PodRunning:
+			namespaceRunning++
+		case v1.PodPending:
+			namespacePending++
+		case v1.PodFailed:
+			namespaceFailed++
+		}
+
+		// Add resource requests
+		for _, container := range pod.Spec.Containers {
+			if cpu := container.Resources.Requests.Cpu(); cpu != nil {
+				namespaceCPU.Add(*cpu)
+			}
+			if memory := container.Resources.Requests.Memory(); memory != nil {
+				namespaceMemory.Add(*memory)
+			}
+		}
+	}
+
+	logger.V(1).Info("Test namespace resource usage",
+		"poll", pollCount,
+		"namespace", tc.testNamespace,
+		"totalPods", len(namespacePods.Items),
+		"runningPods", namespaceRunning,
+		"pendingPods", namespacePending,
+		"failedPods", namespaceFailed,
+		"totalCPURequests", namespaceCPU.String(),
+		"totalMemoryRequests", namespaceMemory.String())
+
+	// Log details of any pending pods in the namespace
+	for _, pod := range namespacePods.Items {
+		if pod.Status.Phase == v1.PodPending {
+			logger.V(1).Info("Pending pod in test namespace",
+				"poll", pollCount,
+				"namespace", tc.testNamespace,
+				"podName", pod.Name,
+				"reason", pod.Status.Reason,
+				"message", pod.Status.Message)
+
+			// Log specific container resource requests for pending pods
+			for _, container := range pod.Spec.Containers {
+				logger.V(1).Info("Pending pod container resources",
+					"poll", pollCount,
+					"podName", pod.Name,
+					"containerName", container.Name,
+					"cpuRequest", container.Resources.Requests.Cpu().String(),
+					"memoryRequest", container.Resources.Requests.Memory().String(),
+					"cpuLimit", container.Resources.Limits.Cpu().String(),
+					"memoryLimit", container.Resources.Limits.Memory().String())
+			}
+		}
+	}
+
+	// Check for resource quotas in the namespace
+	tc.logNamespaceResourceQuotas(pollCount, logger)
+}
+
+// logNamespaceResourceQuotas logs any resource quotas that might be limiting pod creation
+func (tc *testContext) logNamespaceResourceQuotas(pollCount int, logger logr.Logger) {
+	resourceQuotas, err := tc.kubeClient.CoreV1().ResourceQuotas(tc.testNamespace).List(tc.ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.V(1).Info("Failed to get resource quotas",
+			"poll", pollCount,
+			"namespace", tc.testNamespace,
+			"error", err)
+		return
+	}
+
+	if len(resourceQuotas.Items) == 0 {
+		logger.V(1).Info("No resource quotas found in namespace",
+			"poll", pollCount,
+			"namespace", tc.testNamespace)
+		return
+	}
+
+	for i, quota := range resourceQuotas.Items {
+		logger.V(1).Info("Resource quota details",
+			"poll", pollCount,
+			"namespace", tc.testNamespace,
+			"quotaIndex", i,
+			"quotaName", quota.Name)
+
+		// Log hard limits
+		for resource, limit := range quota.Status.Hard {
+			used := quota.Status.Used[resource]
+			logger.V(1).Info("Resource quota limit",
+				"poll", pollCount,
+				"quotaName", quota.Name,
+				"resource", resource,
+				"limit", limit.String(),
+				"used", used.String())
+		}
+	}
+
+	// Check for limit ranges that might affect pod scheduling
+	limitRanges, err := tc.kubeClient.CoreV1().LimitRanges(tc.testNamespace).List(tc.ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.V(1).Info("Failed to get limit ranges",
+			"poll", pollCount,
+			"namespace", tc.testNamespace,
+			"error", err)
+		return
+	}
+
+	for i, limitRange := range limitRanges.Items {
+		logger.V(1).Info("Limit range details",
+			"poll", pollCount,
+			"namespace", tc.testNamespace,
+			"limitRangeIndex", i,
+			"limitRangeName", limitRange.Name)
+
+		for j, limit := range limitRange.Spec.Limits {
+			logger.V(1).Info("Limit range specification",
+				"poll", pollCount,
+				"limitRangeName", limitRange.Name,
+				"limitIndex", j,
+				"type", limit.Type,
+				"defaultCPU", limit.Default.Cpu().String(),
+				"defaultMemory", limit.Default.Memory().String(),
+				"maxCPU", limit.Max.Cpu().String(),
+				"maxMemory", limit.Max.Memory().String(),
+				"minCPU", limit.Min.Cpu().String(),
+				"minMemory", limit.Min.Memory().String())
+		}
+	}
 }

--- a/components/odh-notebook-controller/e2e/notebook_creation_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_creation_test.go
@@ -590,8 +590,8 @@ func (tc *testContext) monitorNotebookCulling(nbMeta *metav1.ObjectMeta, logger 
 		elapsedSinceStart := time.Since(cullingStartTime)
 		elapsedSinceTestStart := time.Since(testStartTime)
 
-		// Check notebook CR for last activity annotation
-		lastActivity, annotationErr := tc.getNotebookLastActivity(nbMeta)
+		// Get all culling-related annotations for detailed logging
+		cullingAnnotations, cullingErr := tc.getCullingAnnotations(nbMeta)
 
 		// Check StatefulSet status (primary culling indicator)
 		isCulled, ssReplicas, podCount, err := tc.checkNotebookCullingStatus(nbMeta)
@@ -606,10 +606,21 @@ func (tc *testContext) monitorNotebookCulling(nbMeta *metav1.ObjectMeta, logger 
 			"podCount", podCount,
 		}
 
-		if annotationErr == nil && lastActivity != "" {
-			logFields = append(logFields, "lastActivity", lastActivity)
-		} else if annotationErr != nil {
-			logFields = append(logFields, "lastActivityError", annotationErr.Error())
+		// Add detailed culling annotations to the log
+		if cullingErr == nil {
+			for key, value := range cullingAnnotations {
+				logFields = append(logFields, "annotation_"+key, value)
+			}
+			// Calculate time since last activity if annotation exists
+			if lastActivityTime, exists := cullingAnnotations["notebooks.kubeflow.org/last-activity"]; exists {
+				if parsedTime, err := time.Parse(time.RFC3339, lastActivityTime); err == nil {
+					timeSinceLastActivity := time.Since(parsedTime)
+					logFields = append(logFields, "timeSinceLastActivity", timeSinceLastActivity.String())
+					logFields = append(logFields, "shouldBeCulledAfter", "2m0s") // From test config
+				}
+			}
+		} else {
+			logFields = append(logFields, "cullingAnnotationsError", cullingErr.Error())
 		}
 
 		if err != nil {
@@ -620,12 +631,17 @@ func (tc *testContext) monitorNotebookCulling(nbMeta *metav1.ObjectMeta, logger 
 
 		// If notebook has been culled (StatefulSet scaled to 0 or pods removed)
 		if isCulled {
+			lastActivityValue := ""
+			if cullingErr == nil {
+				lastActivityValue = cullingAnnotations["notebooks.kubeflow.org/last-activity"]
+			}
+
 			if elapsedSinceStart < minimumCullTime {
 				logger.Info("Notebook was culled too early - this may indicate a timing issue",
 					"actualCullTime", elapsedSinceStart,
 					"minimumExpectedTime", minimumCullTime,
 					"checks", checkCount,
-					"lastActivity", lastActivity)
+					"lastActivity", lastActivityValue)
 				return fmt.Errorf("notebook was culled too early: culled after %v, expected minimum %v",
 					elapsedSinceStart, minimumCullTime)
 			}
@@ -634,7 +650,7 @@ func (tc *testContext) monitorNotebookCulling(nbMeta *metav1.ObjectMeta, logger 
 				"actualCullTime", elapsedSinceStart,
 				"totalTestTime", elapsedSinceTestStart,
 				"checks", checkCount,
-				"lastActivity", lastActivity,
+				"lastActivity", lastActivityValue,
 				"finalStatefulSetReplicas", ssReplicas,
 				"finalPodCount", podCount)
 			return nil
@@ -642,11 +658,16 @@ func (tc *testContext) monitorNotebookCulling(nbMeta *metav1.ObjectMeta, logger 
 
 		// If we've exceeded maximum time and notebook is still active
 		if elapsedSinceStart >= maximumCullTime {
+			lastActivityValue := ""
+			if cullingErr == nil {
+				lastActivityValue = cullingAnnotations["notebooks.kubeflow.org/last-activity"]
+			}
+
 			logger.Info("Notebook was not culled within maximum expected time",
 				"actualTime", elapsedSinceStart,
 				"maximumExpectedTime", maximumCullTime,
 				"checks", checkCount,
-				"lastActivity", lastActivity,
+				"lastActivity", lastActivityValue,
 				"statefulSetReplicas", ssReplicas,
 				"podCount", podCount)
 			return fmt.Errorf("notebook was not culled within expected timeframe: still active after %v (replicas: %d, pods: %d)",
@@ -666,8 +687,8 @@ func (tc *testContext) monitorNotebookCulling(nbMeta *metav1.ObjectMeta, logger 
 	}
 }
 
-// getNotebookLastActivity retrieves the last activity annotation from the Notebook CR
-func (tc *testContext) getNotebookLastActivity(nbMeta *metav1.ObjectMeta) (string, error) {
+// getCullingAnnotations retrieves all culling-related annotations from the Notebook CR
+func (tc *testContext) getCullingAnnotations(nbMeta *metav1.ObjectMeta) (map[string]string, error) {
 	notebook := &nbv1.Notebook{}
 	err := tc.customClient.Get(tc.ctx, types.NamespacedName{
 		Name:      nbMeta.Name,
@@ -675,23 +696,26 @@ func (tc *testContext) getNotebookLastActivity(nbMeta *metav1.ObjectMeta) (strin
 	}, notebook)
 
 	if err != nil {
-		return "", fmt.Errorf("failed to get notebook CR: %v", err)
+		return nil, fmt.Errorf("failed to get notebook CR: %v", err)
 	}
 
-	// Look for common last activity annotation keys
-	lastActivityKeys := []string{
+	// Extract culling-related annotations
+	cullingAnnotations := make(map[string]string)
+	cullingKeys := []string{
 		"notebooks.kubeflow.org/last-activity",
+		"notebooks.kubeflow.org/last_activity_check_timestamp",
+		"kubeflow-resource-stopped",
 		"opendatahub.io/last-activity",
 		"last-activity",
 	}
 
-	for _, key := range lastActivityKeys {
+	for _, key := range cullingKeys {
 		if value, exists := notebook.Annotations[key]; exists {
-			return value, nil
+			cullingAnnotations[key] = value
 		}
 	}
 
-	return "", nil // No last activity annotation found
+	return cullingAnnotations, nil
 }
 
 // checkNotebookCullingStatus checks if the notebook has been culled by examining StatefulSet and Pod status

--- a/components/odh-notebook-controller/e2e/notebook_deletion_test.go
+++ b/components/odh-notebook-controller/e2e/notebook_deletion_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"log"
 	"testing"
 
 	netv1 "k8s.io/api/networking/v1"
@@ -37,50 +36,88 @@ func deletionTestSuite(t *testing.T) {
 }
 
 func (tc *testContext) testNotebookDeletion(nbMeta *metav1.ObjectMeta) error {
+	logger := GetDeletionLogger().WithValues(
+		"notebook", nbMeta.Name,
+		"namespace", nbMeta.Namespace,
+	)
+	logger.Info("Starting notebook deletion test")
+
 	// Delete test Notebook resource if found
 	notebookLookupKey := types.NamespacedName{Name: nbMeta.Name, Namespace: nbMeta.Namespace}
 	createdNotebook := &nbv1.Notebook{}
 
+	logger.V(1).Info("Checking if notebook exists for deletion")
 	err := tc.customClient.Get(tc.ctx, notebookLookupKey, createdNotebook)
 	if err == nil {
+		logger.Info("Deleting notebook")
 		nberr := tc.customClient.Delete(tc.ctx, createdNotebook, &client.DeleteOptions{})
 		if nberr != nil {
+			logger.V(1).Info("Error deleting notebook", "error", nberr)
 			return fmt.Errorf("error deleting test Notebook %s: %v", nbMeta.Name, nberr)
 		}
+		logger.Info("Notebook deleted successfully")
 	} else if !errors.IsNotFound(err) {
+		logger.V(1).Info("Error getting notebook instance", "error", err)
 		return fmt.Errorf("error getting test Notebook instance :%v", err)
+	} else {
+		logger.Info("Notebook not found, skipping deletion")
 	}
 	return nil
 }
 
 func (tc *testContext) testNotebookResourcesDeletion(nbMeta *metav1.ObjectMeta) error {
+	logger := GetDeletionLogger().WithValues(
+		"notebook", nbMeta.Name,
+		"namespace", nbMeta.Namespace,
+	)
+	logger.Info("Starting notebook resources deletion verification")
+
 	// Verify Notebook StatefulSet resource is deleted
+	logger.V(1).Info("Verifying StatefulSet deletion")
+	pollCount := 0
 	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
+		pollCount++
 		_, err = tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(ctx, nbMeta.Name, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
+				logger.V(1).Info("StatefulSet successfully deleted",
+					"polls", pollCount)
 				return true, nil
 			}
-			log.Printf("Failed to get %s statefulset", nbMeta.Name)
+			logger.V(1).Info("Error getting StatefulSet (continuing to poll)",
+				"poll", pollCount,
+				"error", err)
 			return false, err
 
 		}
+		logger.V(1).Info("StatefulSet still exists, continuing to poll",
+			"poll", pollCount)
 		return false, nil
 	})
 	if err != nil {
+		logger.V(1).Info("StatefulSet deletion verification failed",
+			"polls", pollCount,
+			"error", err)
 		return fmt.Errorf("unable to delete Statefulset %s :%v ", nbMeta.Name, err)
 	}
 
 	// Verify Notebook Network Policies are deleted
+	logger.V(1).Info("Verifying Network Policies deletion")
 	nbNetworkPolicyList := netv1.NetworkPolicyList{}
 	opts := []client.ListOption{client.InNamespace(nbMeta.Namespace)}
+	pollCount = 0
 	err = wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
+		pollCount++
 		nperr := tc.customClient.List(ctx, &nbNetworkPolicyList, opts...)
 		if nperr != nil {
 			if errors.IsNotFound(nperr) {
+				logger.V(1).Info("Network policies successfully deleted",
+					"polls", pollCount)
 				return true, nil
 			}
-			log.Printf("Failed to get Network policies for %v", nbMeta.Name)
+			logger.V(1).Info("Error listing network policies (continuing to poll)",
+				"poll", pollCount,
+				"error", nperr)
 			return false, err
 		}
 
@@ -92,30 +129,54 @@ func (tc *testContext) testNotebookResourcesDeletion(nbMeta *metav1.ObjectMeta) 
 			}
 		}
 
+		logger.V(1).Info("Checking notebook-specific network policies",
+			"poll", pollCount,
+			"totalPolicies", len(nbNetworkPolicyList.Items),
+			"notebookSpecificPolicies", len(notebookSpecificPolicies))
+
 		if len(notebookSpecificPolicies) == 0 {
+			logger.V(1).Info("All notebook-specific network policies deleted",
+				"polls", pollCount)
 			return true, nil
 		}
 		return false, nil
 	})
 	if err != nil {
+		logger.V(1).Info("Network policies deletion verification failed",
+			"polls", pollCount,
+			"error", err)
 		return fmt.Errorf("unable to delete Network policies for  %s : %v", nbMeta.Name, err)
 	}
 
-	// Verify Notebook HTTPRoute is deleted
+// Verify Notebook HTTPRoute is deleted
+	logger.V(1).Info("Verifying HTTPRoute deletion")
+	pollCount = 0
 	err = wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
+		pollCount++
 		_, err = tc.getNotebookHTTPRoute(nbMeta)
 		if err != nil {
 			if errors.IsNotFound(err) {
+				logger.V(1).Info("HTTPRoute successfully deleted",
+					"polls", pollCount)
 				return true, nil
 			}
-			log.Printf("Failed to get %s HTTPRoute", nbMeta.Name)
+			logger.V(1).Info("Error getting HTTPRoute (continuing to poll)",
+				"poll", pollCount,
+				"error", err)
 			return false, err
 		}
+		logger.V(1).Info("HTTPRoute still exists, continuing to poll",
+			"poll", pollCount)
 		return false, nil
 	})
 	if err != nil {
+		logger.V(1).Info("HTTPRoute deletion verification failed",
+			"polls", pollCount,
+			"error", err)
 		return fmt.Errorf("unable to delete HTTPRoute %s : %v", nbMeta.Name, err)
 	}
+
+	logger.Info("Notebook resources deletion verification completed successfully")
 
 	return nil
 }

--- a/components/odh-notebook-controller/run-e2e-test.sh
+++ b/components/odh-notebook-controller/run-e2e-test.sh
@@ -28,6 +28,9 @@ fi
 
 export K8S_NAMESPACE="${TEST_NAMESPACE}"
 
+# Enable debug logging by default in CI environment for better debugging
+export E2E_LOG_LEVEL="${E2E_LOG_LEVEL:-debug}"
+
 # From now on we want to be sure that undeploy and testing project deletion are called
 
 function cleanup() {


### PR DESCRIPTION
This introduce an extra logging for our E2E tests... waits until the #688 is merged.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added structured, per-area E2E logging and helpers with timestamps, durations and contextual fields.
  - Reworked culling verification to active, time-bounded monitoring and added a restart-all-culled-notebooks flow.
  - Enhanced creation, deletion, resource-cleanup and diagnostics with richer polling, per-step outcomes and final-state reporting.
  - Validated OAuth proxy sidecar CPU/memory against Notebook annotations.

- Documentation
  - Added E2E debug logging guidance and usage, including log-level controls and examples.

- Chores
  - Defaulted E2E log level to "debug" in CI and propagate E2E_LOG_LEVEL into test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->