### PR TITLE
[RHOAIENG-33609] fix route search to work also for generated routes

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -139,12 +139,11 @@ func ReconciliationLockIsEnabled(meta metav1.ObjectMeta) bool {
 func (r *OpenshiftNotebookReconciler) RemoveReconciliationLock(notebook *nbv1.Notebook,
 	ctx context.Context) error {
 	// Wait until the image pull secret is mounted in the notebook service
-	// account, but proceed anyway if it takes too long (for test environments
-	// or cases where ImagePullSecrets aren't needed)
+	// account
 	retry.OnError(wait.Backoff{
 		Steps:    3,
 		Duration: 1 * time.Second,
-		Factor:   2.0, // Reduced factor for faster timeout
+		Factor:   5.0,
 	}, func(error) bool { return true },
 		func() error {
 			serviceAccount := &corev1.ServiceAccount{}

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -139,11 +139,12 @@ func ReconciliationLockIsEnabled(meta metav1.ObjectMeta) bool {
 func (r *OpenshiftNotebookReconciler) RemoveReconciliationLock(notebook *nbv1.Notebook,
 	ctx context.Context) error {
 	// Wait until the image pull secret is mounted in the notebook service
-	// account
+	// account, but proceed anyway if it takes too long (for test environments
+	// or cases where ImagePullSecrets aren't needed)
 	retry.OnError(wait.Backoff{
 		Steps:    3,
 		Duration: 1 * time.Second,
-		Factor:   5.0,
+		Factor:   2.0, // Reduced factor for faster timeout
 	}, func(error) bool { return true },
 		func() error {
 			serviceAccount := &corev1.ServiceAccount{}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -452,6 +452,56 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			}, duration, interval).Should(HaveOccurred())
 		})
 
+		It("Should handle OAuth client creation with generated route names", func() {
+			By("Creating a new notebook with OAuth enabled and name that triggers route generateName")
+			// Use a name that triggers route generateName but doesn't exceed label limits
+			// Route threshold: name + namespace > 63 chars
+			// "test-notebook-with-a-very-long-name-thats-48char" (48) + "default" (7) = 55 < 63
+			// Adding "-0123456789" (11) = 66 > 63, triggers generateName for routes
+			longName := Name + "-0123456789"
+			oauthNotebook := createNotebook(longName, Namespace)
+			oauthNotebook.SetAnnotations(map[string]string{
+				"notebooks.opendatahub.io/inject-oauth": "true",
+			})
+			Expect(cli.Create(ctx, oauthNotebook)).Should(Succeed())
+			defer cli.Delete(ctx, oauthNotebook)
+
+			By("Waiting for the OAuth route to be created with generateName")
+			var oauthRoute *routev1.Route
+			Eventually(func() error {
+				foundRoute, err := getRouteFromList(&routev1.Route{}, oauthNotebook, longName, Namespace)
+				if foundRoute == nil {
+					return err
+				}
+				oauthRoute = foundRoute
+				return nil
+			}, duration, interval).Should(Succeed())
+
+			By("Waiting for the controller to create the OAuth client secret")
+			secret := &corev1.Secret{}
+			Eventually(func() error {
+				key := types.NamespacedName{Name: longName + "-oauth-client", Namespace: Namespace}
+				return cli.Get(ctx, key, secret)
+			}, duration, interval).Should(Succeed())
+
+			By("Verifying the route has a generated name but correct labels")
+			Expect(oauthRoute.Name).Should(HavePrefix("nb-"))
+			Expect(oauthRoute.Name).ShouldNot(Equal(longName))
+			Expect(oauthRoute.Labels["notebook-name"]).Should(Equal(longName))
+
+			By("Testing OAuth client creation with generated route name")
+			reconciler := &OpenshiftNotebookReconciler{
+				Client: cli,
+				Scheme: cli.Scheme(),
+				Log:    logr.Discard(),
+			}
+
+			err := reconciler.createOAuthClient(oauthNotebook, ctx)
+
+			By("Verifying OAuth client creation succeeds despite generated route name")
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
 	})
 
 	// New test case for notebook update

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -365,13 +365,31 @@ func (r *OpenshiftNotebookReconciler) createOAuthClient(notebook *nbv1.Notebook,
 
 	// Get the route that will be used in the OAuthClient
 	oauthClientRoute := &routev1.Route{}
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      notebook.Name,
-		Namespace: notebook.Namespace,
-	}, oauthClientRoute)
+	routeList := &routev1.RouteList{}
+
+	// List the routes in the notebook namespace with the notebook name label
+	opts := []client.ListOption{
+		client.InNamespace(notebook.Namespace),
+		client.MatchingLabels{"notebook-name": notebook.Name},
+	}
+
+	err := r.List(ctx, routeList, opts...)
 	if err != nil {
-		log.Error(err, "Unable to retrieve route", "route", notebook.Name)
+		log.Error(err, "Unable to list routes for OAuth client")
 		return err
+	}
+
+	// Get the route from the list
+	for _, nRoute := range routeList.Items {
+		if metav1.IsControlledBy(&nRoute, notebook) {
+			oauthClientRoute = &nRoute
+			break
+		}
+	}
+
+	if oauthClientRoute.Name == "" {
+		log.Error(err, "Unable to find route for OAuth client", "notebook", notebook.Name)
+		return fmt.Errorf("route not found for notebook %s", notebook.Name)
 	}
 
 	// Get the secret that will be used in the OAuthClient

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -43,6 +43,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/go-logr/logr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -199,6 +200,16 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
+	// Setup test helper to add ImagePullSecrets to service accounts
+	// This simulates the behavior of real OpenShift environments where
+	// ImagePullSecrets are automatically mounted on service accounts
+	err = (&TestServiceAccountReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("test-serviceaccount-helper"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred())
+
 	// Setup notebook mutating webhook
 	hookServer := mgr.GetWebhookServer()
 	notebookWebhook := &webhook.Admission{
@@ -248,6 +259,45 @@ var _ = BeforeSuite(func() {
 	}
 
 }, 60)
+
+// TestServiceAccountReconciler is a test-only controller that automatically
+// adds ImagePullSecrets to service accounts to simulate real OpenShift behavior
+type TestServiceAccountReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+func (r *TestServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	serviceAccount := &v1.ServiceAccount{}
+	if err := r.Get(ctx, req.NamespacedName, serviceAccount); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Skip if it already has ImagePullSecrets or if it's not a notebook-related service account
+	if len(serviceAccount.ImagePullSecrets) > 0 || serviceAccount.Labels["notebook-name"] == "" {
+		return ctrl.Result{}, nil
+	}
+
+	// Add a test ImagePullSecret to simulate real OpenShift behavior
+	serviceAccount.ImagePullSecrets = []v1.LocalObjectReference{
+		{Name: "test-pull-secret"},
+	}
+
+	if err := r.Update(ctx, serviceAccount); err != nil {
+		r.Log.Error(err, "Failed to add ImagePullSecrets to service account")
+		return ctrl.Result{}, err
+	}
+
+	r.Log.Info("Added test ImagePullSecrets to service account", "serviceAccount", serviceAccount.Name)
+	return ctrl.Result{}, nil
+}
+
+func (r *TestServiceAccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.ServiceAccount{}).
+		Complete(r)
+}
 
 var _ = AfterSuite(func() {
 	By("Stopping the manager")

--- a/components/odh-notebook-controller/e2e/helper_test.go
+++ b/components/odh-notebook-controller/e2e/helper_test.go
@@ -326,9 +326,8 @@ func setupThothMinimalOAuthNotebook() notebookContext {
 
 // Add spec and metadata for Notebook objects with custom OAuth proxy resources
 func setupThothOAuthCustomResourcesNotebook() notebookContext {
-	// Too long name - shall be resolved via https://issues.redhat.com/browse/RHOAIENG-33609
-	// testNotebookName := "thoth-oauth-custom-resources-notebook"
-	testNotebookName := "thoth-custom-resources-notebook"
+	// Let's use long name to test the generated route name https://issues.redhat.com/browse/RHOAIENG-33609
+	testNotebookName := "thoth-oauth-custom-resources-notebook"
 
 	testNotebook := &nbv1.Notebook{
 		TypeMeta: metav1.TypeMeta{},

--- a/components/odh-notebook-controller/e2e/helper_test.go
+++ b/components/odh-notebook-controller/e2e/helper_test.go
@@ -135,17 +135,30 @@ func (tc *testContext) rolloutDeployment(depMeta metav1.ObjectMeta) error {
 func (tc *testContext) waitForStatefulSet(nbMeta *metav1.ObjectMeta, availableReplicas int32, readyReplicas int32) error {
 	// Verify StatefulSet is running expected number of replicas
 	err := wait.PollUntilContextTimeout(tc.ctx, tc.resourceRetryInterval, tc.resourceCreationTimeout, false, func(ctx context.Context) (done bool, err error) {
-		notebookStatefulSet, err1 := tc.kubeClient.AppsV1().StatefulSets(tc.testNamespace).Get(ctx,
-			nbMeta.Name, metav1.GetOptions{})
-
+		// Find StatefulSet by looking for one that has a selector matching "statefulset": notebook.Name
+		// This works for both regular names and generated names (when notebook name is too long)
+		namespacedStatefulSets := &appsv1.StatefulSetList{}
+		err1 := tc.customClient.List(ctx, namespacedStatefulSets, client.InNamespace(tc.testNamespace))
 		if err1 != nil {
-			if errors.IsNotFound(err1) {
-				return false, nil
-			} else {
-				log.Printf("Failed to get %s statefulset", nbMeta.Name)
-				return false, err1
+			log.Printf("Failed to list StatefulSets in namespace %s", tc.testNamespace)
+			return false, err1
+		}
+
+		// Find the StatefulSet that has a selector for "statefulset": nbMeta.Name
+		var notebookStatefulSet *appsv1.StatefulSet
+		for _, sts := range namespacedStatefulSets.Items {
+			if sts.Spec.Selector != nil && sts.Spec.Selector.MatchLabels != nil {
+				if statefulsetLabel, exists := sts.Spec.Selector.MatchLabels["statefulset"]; exists && statefulsetLabel == nbMeta.Name {
+					notebookStatefulSet = &sts
+					break
+				}
 			}
 		}
+
+		if notebookStatefulSet == nil {
+			return false, nil // StatefulSet not found yet
+		}
+
 		if notebookStatefulSet.Status.AvailableReplicas == availableReplicas &&
 			notebookStatefulSet.Status.ReadyReplicas == readyReplicas {
 			return true, nil


### PR DESCRIPTION
In the `createOAuthClient` function, the search for the appropriate
route for the workbench didn't work when the generated route was created
before. We're now searching based on the appropriate labels as is used
for other resources in this case when generated name is used instead of
the regular one.

This is a followup of the #539 (https://issues.redhat.com/browse/RHOAIENG-4148).

https://issues.redhat.com/browse/RHOAIENG-33609

## Description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
