### PR TITLE
RHOAIENG-35625: rename AI Pipeline to Pipeline in kubeflow

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
@@ -139,7 +139,7 @@ func extractElyraRuntimeConfigInfo(ctx context.Context, dashboardInstance map[st
 	// Construct Elyra-compatible config
 	metadata := map[string]interface{}{
 		"tags":          []string{},
-		"display_name":  "AI Pipeline",
+		"display_name":  "Pipeline",
 		"engine":        "Argo",
 		"runtime_type":  "KUBEFLOW_PIPELINES",
 		"auth_type":     "KUBERNETES_SERVICE_ACCOUNT_TOKEN",
@@ -166,7 +166,7 @@ func extractElyraRuntimeConfigInfo(ctx context.Context, dashboardInstance map[st
 
 	// Return the full runtime config
 	return map[string]interface{}{
-		"display_name": "AI Pipeline",
+		"display_name": "Pipeline",
 		"schema_name":  "kfp",
 		"metadata":     metadata,
 	}, nil


### PR DESCRIPTION
This PR renames `AI Pipelines` (originally `Data Science Pipelines`) to `Pipelines` in places that will appear on the UI. It is a follow-up to #687, as the requirements have changed again.

To test this, I opened a terminal in my rosa cluster and ran the following commands:
- `elyra-metadata list runtimes` - print filepath to available `odh_dsp.json` metadata file
- `cat <path/to/odh_dsp.json>` - prints file contents, shows where `AI Pipeline` occurs (the same places I changed in the PR)
- using the `vi` tool, I edited `odh_dsp.json` to say `Pipeline` instead of `AI Pipeline`
- The changes from before and after are shown below in the screenshots.

JIRA: https://issues.redhat.com/browse/RHOAIENG-35625
Relevant changes in Elyra plugin: https://github.com/opendatahub-io/elyra/pull/138

Before: 
<img width="2561" height="668" alt="Screenshot From 2025-10-07 14-44-56" src="https://github.com/user-attachments/assets/6ba6e589-160e-4444-bf13-51f7cc4d51fc" />

After:
<img width="2561" height="668" alt="Screenshot From 2025-10-07 14-47-09" src="https://github.com/user-attachments/assets/4421e67e-d11f-493a-9e86-ab6fee9d50eb" />
