### PR TITLE
chore(tests): Bump version of k8s used by envtest from 1.28 to 1.32

### DIFF
--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -13,8 +13,8 @@ CONTAINER_ENGINE ?= podman
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 # We should try to use the kubernetes version that is used in the oldest OpenShift we support: https://access.redhat.com/solutions/4870701
-# Right now we target the OCP 4.15 as the oldest one: https://access.redhat.com/articles/rhoai-supported-configs
-ENVTEST_K8S_VERSION = 1.28
+# Right now we target the OCP 4.19 as the oldest one: https://access.redhat.com/articles/rhoai-supported-configs
+ENVTEST_K8S_VERSION = 1.32
 
 # Kubernetes configuration
 K8S_NAMESPACE ?= odh-notebook-controller-system


### PR DESCRIPTION
With the code now approaching to the ODH/RHOAI 3.0 release, we're aiming to support OpenShift 4.19+ only. OCP4.19 is build on top of kubernetes 1.32, so let's get aligned.

## How Has This Been Tested?
```
make test
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the test environment to align with the current platform baseline (Kubernetes 1.32 / OCP 4.19), improving test fidelity and ensuring compatibility with supported clusters.
  - No functional or behavioral changes to the application.
- **Chores**
  - Refreshed internal comments to reflect the updated minimum supported platform version for clarity and consistency across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->