### PR TITLE
RHOAIENG-18582: add compatibility for KF_PIPELINES_SSL_SA_CERTS

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -431,7 +431,7 @@ func (r *OpenshiftNotebookReconciler) UnsetNotebookCertConfig(notebook *nbv1.Not
 	log := r.Log.WithValues("notebook", notebook.Name, "namespace", notebook.Namespace)
 
 	// Get the notebook object
-	envVars := []string{"PIP_CERT", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "PIPELINES_SSL_SA_CERTS", "GIT_SSL_CAINFO"}
+	envVars := []string{"PIP_CERT", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "PIPELINES_SSL_SA_CERTS", "GIT_SSL_CAINFO", "KF_PIPELINES_SSL_SA_CERTS"}
 	notebookSpecChanged := false
 	patch := client.MergeFrom(notebook.DeepCopy())
 	copyNotebook := notebook.DeepCopy()

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -668,11 +668,12 @@ func InjectCertConfig(notebook *nbv1.Notebook, configMapName string) error {
 	configMapMountKey := "ca-bundle.crt"
 	configMapMountValue := "ca-bundle.crt"
 	configEnvVars := map[string]string{
-		"PIP_CERT":               configMapMountPath,
-		"REQUESTS_CA_BUNDLE":     configMapMountPath,
-		"SSL_CERT_FILE":          configMapMountPath,
-		"PIPELINES_SSL_SA_CERTS": configMapMountPath,
-		"GIT_SSL_CAINFO":         configMapMountPath,
+		"PIP_CERT":                  configMapMountPath,
+		"REQUESTS_CA_BUNDLE":        configMapMountPath,
+		"SSL_CERT_FILE":             configMapMountPath,
+		"PIPELINES_SSL_SA_CERTS":    configMapMountPath,
+		"KF_PIPELINES_SSL_SA_CERTS": configMapMountPath,
+		"GIT_SSL_CAINFO":            configMapMountPath,
 	}
 
 	notebookContainers := &notebook.Spec.Template.Spec.Containers


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-18582

## Description
<!--- Describe your changes in detail -->

add compatibility for KF_PIPELINES_SSL_SA_CERTS
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
NA

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically injects Kubeflow Pipelines SSL service account certificates into notebook environments for improved pipeline integration.

- Bug Fixes
  - Ensures certificate-related settings are fully removed during environment cleanup to prevent leftover configuration and potential conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->