### PR TITLE
[RHOAIENG-34310] reverts changes to matchers_test.go done recently

### DIFF
--- a/components/odh-notebook-controller/controllers/matchers_test.go
+++ b/components/odh-notebook-controller/controllers/matchers_test.go
@@ -378,7 +378,7 @@ func Test_BeMatchingK8sResource_MismatchedStructs(t *testing.T) {
 		},
 	}
 	matcher := BeMatchingK8sResource(someOtherRoute, func(r1 routev1.Route, r2 routev1.Route) bool {
-		return r1.ObjectMeta.Name == r2.ObjectMeta.Name
+		return r1.Name == r2.Name
 	})
 	res, err := matcher.Match(someRoute)
 	assert.NoError(t, err)


### PR DESCRIPTION
This is a revert of changes to the matchers_test.go file done in the bf6b20b5a4cf689c0c3fa06f99dfbdcf6674d51f commit. In the end the original implementation seemed to work better. Let's have it back then.

https://issues.redhat.com/browse/RHOAIENG-34310

## Description
An example of a failure message for the same problem.
Before:
```
    Expected
    {TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:nb-default-test-notebook GenerateName: Namespace:redhat-ods-applications SelfLink: UID:4724d0ec-5374-4c10-b0f8-7459aa09b49e ResourceVersion:233 Generation:1 CreationTimestamp:2025-11-19 16:07:19 +0100 CET DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[notebook-name:test-notebook notebook-namespace:default] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[{Manager:controllers.test Operation:Update APIVersion:gateway.networking.k8s.io/v1 Time:2025-11-19 16:07:19 +0100 CET FieldsType:FieldsV1 FieldsV1:{"f:metadata":{"f:labels":{".":{},"f:notebook-name":{},"f:notebook-namespace":{}}},"f:spec":{".":{},"f:parentRefs":{},"f:rules":{}}} Subresource:}]} Spec:{CommonRouteSpec:{ParentRefs:[{Group:0xc00072d1f0 Kind:0xc00072d200 Namespace:0xc00072d210 Name:data-science-gateway SectionName:<nil> Port:<nil>}]} Hostnames:[] Rules:[{Name:<nil> Matches:[{Path:0xc00072d250 Headers:[] QueryParams:[] Method:<nil>}] Filters:[] BackendRefs:[{BackendRef:{BackendObjectReference:{Group:0xc00072d220 Kind:0xc00072d230 Name:test-notebook Namespace:0xc00072d240 Port:0xc000b377d0} Weight:0xc000b377d4} Filters:[]}] Timeouts:<nil> Retry:<nil> SessionPersistence:<nil>}]} Status:{RouteStatus:{Parents:[]}}}
    to match
    {TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:nb-default-test-notebook GenerateName: Namespace:redhat-ods-applications SelfLink: UID: ResourceVersion: Generation:0 CreationTimestamp:0001-01-01 00:00:00 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[notebook-name:test-notebook-test notebook-namespace:default-test] Annotations:map[] OwnerReferences:[] Finalizers:[] ManagedFields:[]} Spec:{CommonRouteSpec:{ParentRefs:[{Group:0xc00027efd0 Kind:0xc00027eff0 Namespace:0xc00027f000 Name:data-science-gateway SectionName:<nil> Port:<nil>}]} Hostnames:[] Rules:[{Name:<nil> Matches:[{Path:0xc00027f040 Headers:[] QueryParams:[] Method:<nil>}] Filters:[] BackendRefs:[{BackendRef:{BackendObjectReference:{Group:0xc00027f010 Kind:0xc00027f020 Name:test-notebook Namespace:0xc00027f030 Port:0xc00011aefc} Weight:0xc00011aef8} Filters:[]}] Timeouts:<nil> Retry:<nil> SessionPersistence:<nil>}]} Status:{RouteStatus:{Parents:[]}}}
    
    Full diff (-actual +expected):
      v1.HTTPRoute{
      	TypeMeta: {},
      	ObjectMeta: v1.ObjectMeta{
      		... // 2 identical fields
      		Namespace:                  "redhat-ods-applications",
      		SelfLink:                   "",
    - 		UID:                        "4724d0ec-5374-4c10-b0f8-7459aa09b49e",
    + 		UID:                        "",
    - 		ResourceVersion:            "233",
    + 		ResourceVersion:            "",
    - 		Generation:                 1,
    + 		Generation:                 0,
    - 		CreationTimestamp:          v1.Time{Time: s"2025-11-19 16:07:19 +0100 CET"},
    + 		CreationTimestamp:          v1.Time{},
      		DeletionTimestamp:          nil,
      		DeletionGracePeriodSeconds: nil,
      		Labels: map[string]string{
    - 			"notebook-name":      "test-notebook",
    + 			"notebook-name":      "test-notebook-test",
    - 			"notebook-namespace": "default",
    + 			"notebook-namespace": "default-test",
      		},
      		Annotations:     nil,
      		OwnerReferences: nil,
      		Finalizers:      nil,
    - 		ManagedFields: []v1.ManagedFieldsEntry{
    - 			{
    - 				Manager:    "controllers.test",
    - 				Operation:  "Update",
    - 				APIVersion: "gateway.networking.k8s.io/v1",
    - 				Time:       s"2025-11-19 16:07:19 +0100 CET",
    - 				FieldsType: "FieldsV1",
    - 				FieldsV1:   s`{"f:metadata":{"f:labels":{".":{},"f:notebook-name":{},"f:notebo`...,
    - 			},
    - 		},
    + 		ManagedFields: nil,
      	},
      	Spec:   {CommonRouteSpec: {ParentRefs: {{Group: &"gateway.networking.k8s.io", Kind: &"Gateway", Namespace: &"openshift-ingress", Name: "data-science-gateway", ...}}}, Rules: {{Matches: {{Path: &{Type: &"PathPrefix", Value: &"/notebook/default/test-notebook"}}}, BackendRefs: {{BackendRef: {BackendObjectReference: {Group: &"", Kind: &"Service", Name: "test-notebook", Namespace: &"default", ...}, Weight: &1}}}}}},
      	Status: {},
      }
    
    
    Minimal diff (-actual +expected):
      v1.HTTPRoute{
      	TypeMeta: {},
      	ObjectMeta: v1.ObjectMeta{
      		... // 2 identical fields
      		Namespace:                  "redhat-ods-applications",
      		SelfLink:                   "",
    - 		UID:                        "4724d0ec-5374-4c10-b0f8-7459aa09b49e",
    + 		UID:                        "",
    - 		ResourceVersion:            "233",
    + 		ResourceVersion:            "",
    - 		Generation:                 1,
    + 		Generation:                 0,
    - 		CreationTimestamp:          v1.Time{Time: s"2025-11-19 16:07:19 +0100 CET"},
    + 		CreationTimestamp:          v1.Time{},
      		DeletionTimestamp:          nil,
      		DeletionGracePeriodSeconds: nil,
      		Labels: map[string]string{
    - 			"notebook-name":      "test-notebook",
    + 			"notebook-name":      "test-notebook-test",
    - 			"notebook-namespace": "default",
    + 			"notebook-namespace": "default-test",
      		},
      		Annotations:     nil,
      		OwnerReferences: nil,
      		Finalizers:      nil,
    - 		ManagedFields: []v1.ManagedFieldsEntry{
    - 			{
    - 				Manager:    "controllers.test",
    - 				Operation:  "Update",
    - 				APIVersion: "gateway.networking.k8s.io/v1",
    - 				Time:       s"2025-11-19 16:07:19 +0100 CET",
    - 				FieldsType: "FieldsV1",
    - 				FieldsV1:   s`{"f:metadata":{"f:labels":{".":{},"f:notebook-name":{},"f:notebo`...,
    - 			},
    - 		},
    + 		ManagedFields: nil,
      	},
      	Spec:   {CommonRouteSpec: {ParentRefs: {{Group: &"gateway.networking.k8s.io", Kind: &"Gateway", Namespace: &"openshift-ingress", Name: "data-science-gateway", ...}}}, Rules: {{Matches: {{Path: &{Type: &"PathPrefix", Value: &"/notebook/default/test-notebook"}}}, BackendRefs: {{BackendRef: {BackendObjectReference: {Group: &"", Kind: &"Service", Name: "test-notebook", Namespace: &"default", ...}, Weight: &1}}}}}},
      	Status: {},
      }
```
and after this change:
```
    Expected
    	v1.HTTPRoute{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"nb-default-test-notebook", GenerateName:"", Namespace:"redhat-ods-applications", SelfLink:"", UID:"0f17fe66-f80f-443c-9a0c-1132b4729223", ResourceVersion:"233", Generation:1, CreationTimestamp:time.Date(2025, time.November, 19, 16, 43, 15, 0, time.Local), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"notebook-name":"test-notebook", "notebook-namespace":"default"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"controllers.test", Operation:"Update", APIVersion:"gateway.networking.k8s.io/v1", Time:time.Date(2025, time.November, 19, 16, 43, 15, 0, time.Local), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0xc000695ad0), Subresource:""}}}, Spec:v1.HTTPRouteSpec{CommonRouteSpec:v1.CommonRouteSpec{ParentRefs:[]v1.ParentReference{v1.ParentReference{Group:(*v1.Group)(0xc0008c7e80), Kind:(*v1.Kind)(0xc0008c7e90), Namespace:(*v1.Namespace)(0xc0008c7ea0), Name:"data-science-gateway", SectionName:(*v1.SectionName)(nil), Port:(*v1.PortNumber)(nil)}}}, Hostnames:[]v1.Hostname(nil), Rules:[]v1.HTTPRouteRule{v1.HTTPRouteRule{Name:(*v1.SectionName)(nil), Matches:[]v1.HTTPRouteMatch{v1.HTTPRouteMatch{Path:(*v1.HTTPPathMatch)(0xc0008c7ee0), Headers:[]v1.HTTPHeaderMatch(nil), QueryParams:[]v1.HTTPQueryParamMatch(nil), Method:(*v1.HTTPMethod)(nil)}}, Filters:[]v1.HTTPRouteFilter(nil), BackendRefs:[]v1.HTTPBackendRef{v1.HTTPBackendRef{BackendRef:v1.BackendRef{BackendObjectReference:v1.BackendObjectReference{Group:(*v1.Group)(0xc0008c7eb0), Kind:(*v1.Kind)(0xc0008c7ec0), Name:"test-notebook", Namespace:(*v1.Namespace)(0xc0008c7ed0), Port:(*v1.PortNumber)(0xc000d15d20)}, Weight:(*int32)(0xc000d15d24)}, Filters:[]v1.HTTPRouteFilter(nil)}}, Timeouts:(*v1.HTTPRouteTimeouts)(nil), Retry:(*v1.HTTPRouteRetry)(nil), SessionPersistence:(*v1.SessionPersistence)(nil)}}}, Status:v1.HTTPRouteStatus{RouteStatus:v1.RouteStatus{Parents:[]v1.RouteParentStatus(nil)}}}
    to match
    	v1.HTTPRoute{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"nb-default-test-notebook", GenerateName:"", Namespace:"redhat-ods-applications", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"notebook-name":"test-notebook-test", "notebook-namespace":"default-test"}, Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1.HTTPRouteSpec{CommonRouteSpec:v1.CommonRouteSpec{ParentRefs:[]v1.ParentReference{v1.ParentReference{Group:(*v1.Group)(0xc000323520), Kind:(*v1.Kind)(0xc000323530), Namespace:(*v1.Namespace)(0xc000323550), Name:"data-science-gateway", SectionName:(*v1.SectionName)(nil), Port:(*v1.PortNumber)(nil)}}}, Hostnames:[]v1.Hostname(nil), Rules:[]v1.HTTPRouteRule{v1.HTTPRouteRule{Name:(*v1.SectionName)(nil), Matches:[]v1.HTTPRouteMatch{v1.HTTPRouteMatch{Path:(*v1.HTTPPathMatch)(0xc000323590), Headers:[]v1.HTTPHeaderMatch(nil), QueryParams:[]v1.HTTPQueryParamMatch(nil), Method:(*v1.HTTPMethod)(nil)}}, Filters:[]v1.HTTPRouteFilter(nil), BackendRefs:[]v1.HTTPBackendRef{v1.HTTPBackendRef{BackendRef:v1.BackendRef{BackendObjectReference:v1.BackendObjectReference{Group:(*v1.Group)(0xc000323560), Kind:(*v1.Kind)(0xc000323570), Name:"test-notebook", Namespace:(*v1.Namespace)(0xc000323580), Port:(*v1.PortNumber)(0xc0000144ac)}, Weight:(*int32)(0xc0000144a8)}, Filters:[]v1.HTTPRouteFilter(nil)}}, Timeouts:(*v1.HTTPRouteTimeouts)(nil), Retry:(*v1.HTTPRouteRetry)(nil), SessionPersistence:(*v1.SessionPersistence)(nil)}}}, Status:v1.HTTPRouteStatus{RouteStatus:v1.RouteStatus{Parents:[]v1.RouteParentStatus(nil)}}}
    Full diff (-actual +expected):
      v1.HTTPRoute{
      	TypeMeta: {},
      	ObjectMeta: v1.ObjectMeta{
      		... // 2 identical fields
      		Namespace:                  "redhat-ods-applications",
      		SelfLink:                   "",
    - 		UID:                        "0f17fe66-f80f-443c-9a0c-1132b4729223",
    + 		UID:                        "",
    - 		ResourceVersion:            "233",
    + 		ResourceVersion:            "",
    - 		Generation:                 1,
    + 		Generation:                 0,
    - 		CreationTimestamp:          v1.Time{Time: s"2025-11-19 16:43:15 +0100 CET"},
    + 		CreationTimestamp:          v1.Time{},
      		DeletionTimestamp:          nil,
      		DeletionGracePeriodSeconds: nil,
      		Labels: map[string]string{
    - 			"notebook-name":      "test-notebook",
    + 			"notebook-name":      "test-notebook-test",
    - 			"notebook-namespace": "default",
    + 			"notebook-namespace": "default-test",
      		},
      		Annotations:     nil,
      		OwnerReferences: nil,
      		Finalizers:      nil,
    - 		ManagedFields: []v1.ManagedFieldsEntry{
    - 			{
    - 				Manager:    "controllers.test",
    - 				Operation:  "Update",
    - 				APIVersion: "gateway.networking.k8s.io/v1",
    - 				Time:       s"2025-11-19 16:43:15 +0100 CET",
    - 				FieldsType: "FieldsV1",
    - 				FieldsV1:   s`{"f:metadata":{"f:labels":{".":{},"f:notebook-name":{},"f:notebo`...,
    - 			},
    - 		},
    + 		ManagedFields: nil,
      	},
      	Spec:   {CommonRouteSpec: {ParentRefs: {{Group: &"gateway.networking.k8s.io", Kind: &"Gateway", Namespace: &"openshift-ingress", Name: "data-science-gateway", ...}}}, Rules: {{Matches: {{Path: &{Type: &"PathPrefix", Value: &"/notebook/default/test-notebook"}}}, BackendRefs: {{BackendRef: {BackendObjectReference: {Group: &"", Kind: &"Service", Name: "test-notebook", Namespace: &"default", ...}, Weight: &1}}}}}},
      	Status: {},
      }
    
    Minimized diff (-actual +expected):
      v1.HTTPRoute{
      	TypeMeta: {},
      	ObjectMeta: v1.ObjectMeta{
      		... // 8 identical fields
      		DeletionTimestamp:          nil,
      		DeletionGracePeriodSeconds: nil,
      		Labels: map[string]string{
    - 			"notebook-name":      "test-notebook",
    + 			"notebook-name":      "test-notebook-test",
    - 			"notebook-namespace": "default",
    + 			"notebook-namespace": "default-test",
      		},
      		Annotations:     nil,
      		OwnerReferences: nil,
      		... // 2 identical fields
      	},
      	Spec:   {CommonRouteSpec: {ParentRefs: {{Group: &"gateway.networking.k8s.io", Kind: &"Gateway", Namespace: &"openshift-ingress", Name: "data-science-gateway", ...}}}, Rules: {{Matches: {{Path: &{Type: &"PathPrefix", Value: &"/notebook/default/test-notebook"}}}, BackendRefs: {{BackendRef: {BackendObjectReference: {Group: &"", Kind: &"Service", Name: "test-notebook", Namespace: &"default", ...}, Weight: &1}}}}}},
      	Status: {},
      }
```

## How Has This Been Tested?
```
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded matcher tests for clearer failure diagnostics, covering map/slice cases and comparator panic scenarios; validates minimized diffs for host/path and metadata variations.

* **Refactor**
  * Matcher logic now generically supports multiple Kubernetes resource types and enforces deep-copy semantics to improve comparison accuracy and error reporting.

* **Documentation**
  * Added explanatory comments describing the diff-minimization approach and usage caveats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->