### PR TITLE
[RHOAIENG-34310] use kube-auth-proxy image instead of kube-rbac-proxy

### DIFF
--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,3 +1,4 @@
 odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:main
 # Source: https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66#overview
-kube-rbac-proxy=registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:784c4667a867abdbec6d31a4bbde52676a0f37f8e448eaae37568a46fcdeace7
+# We want to use our custom wrapper for the kube-rbac-proxy for ODH/RHOAI temporarily. More info: https://issues.redhat.com/browse/RHOAIENG-35698
+kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3


### PR DESCRIPTION
We want to use our own wrapper of the kube-rbac-proxy temporarily as there is some functionality missing in the original kube-rbac-proxy image. Once that functionality is implemented in the official image, we'll switch back to the kube-rbac-proxy.

More details in: https://issues.redhat.com/browse/RHOAIENG-35698

https://issues.redhat.com/browse/RHOAIENG-34310

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image reference to a custom wrapper version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->