### PR TITLE
use kube-auth-proxy image for the sidecar container

### DIFF
--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,2 +1,4 @@
 odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:v1.10.0-6
-oauth-proxy-image=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
+# Source: https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66#overview
+# We want to use our custom wrapper for the kube-rbac-proxy for ODH/RHOAI temporarily. More info: https://issues.redhat.com/browse/RHOAIENG-35698
+kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3


### PR DESCRIPTION
use kube-auth-proxy image for the sidecar container
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

use kube-auth-proxy image for the sidecar container
Follow-up of: https://github.com/opendatahub-io/kubeflow/pull/707
As param.env is skipped duirng sync-process , due to this: https://github.com/opendatahub-io/kubeflow/blob/121a467690d03514277a7d30c16c311815b1877f/.github/workflows/sync-branches.yaml#L58
this is important change.



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
cd components/odh-notebook-controller
kustomize build config/base 
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
