### PR TITLE
RHOAIENG-36936: support deletion of oauthclient finalizer

### DIFF
--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -126,6 +126,17 @@ rules:
   - patch
   - update
 - apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -1,0 +1,96 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// Finalizer to handle OAuthClient cleanup since it's cluster-scoped and can't use owner references
+	NotebookOAuthClientFinalizer = "notebook-oauth-client-finalizer.opendatahub.io"
+)
+
+// removeOAuthClientFinalizer removes the OAuth client finalizer from the notebook
+func (r *OpenshiftNotebookReconciler) removeOAuthClientFinalizer(notebook *nbv1.Notebook, ctx context.Context) error {
+	log := logf.FromContext(ctx)
+
+	// Check if finalizer exists before attempting removal
+	if !controllerutil.ContainsFinalizer(notebook, NotebookOAuthClientFinalizer) {
+		log.Info("OAuth client finalizer not present, nothing to remove")
+		return nil
+	}
+
+	// Remove the finalizer using the standard controller-runtime helper
+	controllerutil.RemoveFinalizer(notebook, NotebookOAuthClientFinalizer)
+	err := r.Update(ctx, notebook)
+	if err != nil {
+		log.Error(err, "Unable to remove OAuth client finalizer from notebook")
+		return err
+	}
+
+	log.Info("Removed OAuth client finalizer from notebook")
+	return nil
+}
+
+// hasOAuthClientFinalizer checks if the notebook has the OAuth client finalizer
+func (r *OpenshiftNotebookReconciler) hasOAuthClientFinalizer(notebook *nbv1.Notebook) bool {
+	for _, finalizer := range notebook.Finalizers {
+		if finalizer == NotebookOAuthClientFinalizer {
+			return true
+		}
+	}
+	return false
+}
+
+// deleteOAuthClient deletes the OAuthClient associated with the notebook
+func (r *OpenshiftNotebookReconciler) deleteOAuthClient(notebook *nbv1.Notebook, ctx context.Context) error {
+	log := logf.FromContext(ctx)
+
+	oauthClientName := notebook.Name + "-" + notebook.Namespace + "-oauth-client"
+	oauthClient := &oauthv1.OAuthClient{}
+
+	err := r.Get(ctx, types.NamespacedName{Name: oauthClientName}, oauthClient)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			log.Info("OAuthClient not found, nothing to delete", "oauthClient", oauthClientName)
+			return nil
+		}
+		log.Error(err, "Unable to fetch OAuthClient for deletion", "oauthClient", oauthClientName)
+		return err
+	}
+
+	err = r.Delete(ctx, oauthClient)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			log.Info("OAuthClient already deleted", "oauthClient", oauthClientName)
+			return nil
+		}
+		log.Error(err, "Unable to delete OAuthClient", "oauthClient", oauthClientName)
+		return err
+	} else {
+		log.Info("Successfully deleted OAuthClient", "oauthClient", oauthClientName)
+	}
+
+	return nil
+}

--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -33,6 +33,7 @@ import (
 	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	imagev1 "github.com/openshift/api/image/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,6 +62,7 @@ func init() {
 	utilruntime.Must(configv1.AddToScheme(scheme))
 	utilruntime.Must(imagev1.AddToScheme(scheme))
 	utilruntime.Must(dspav1.AddToScheme(scheme))
+	utilruntime.Must(oauthv1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
support deletion of oauthclient finalizer
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED


https://issues.redhat.com/browse/RHOAIENG-36936

## Description
<!--- Describe your changes in detail -->

On upgrade to 3.0 ODH, the auth method is changing and no longer would use oauth-proxy, so removal of oauth-client would be difficult , as that part of code-base is changed with new changes.
Bring back the deletion of oauthclient for more clear delete

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TBA


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notebook deletion now reliably removes associated OpenShift OAuth clients and related finalizers, preventing orphaned credentials and stuck resources.
  * Controller permissions and runtime support for OpenShift OAuth objects were updated so OAuth client removal during cleanup succeeds and deletions complete reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->