### PR TITLE
[RHOAIENG-36963] fix the kube-rbac-proxy key in the generated config

### DIFF
--- a/components/odh-notebook-controller/README.md
+++ b/components/odh-notebook-controller/README.md
@@ -55,7 +55,7 @@ authorization:
     verb: get
     resource: notebooks
     apiGroup: kubeflow.org
-    resourceName: example
+    name: example
     namespace: opendatahub
 ```
 

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -901,7 +901,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
     verb: get
     resource: notebooks
     apiGroup: kubeflow.org
-    resourceName: %s
+    name: %s
     namespace: %s`, Name, Namespace),
 			},
 		}

--- a/components/odh-notebook-controller/controllers/notebook_kube_rbac_auth.go
+++ b/components/odh-notebook-controller/controllers/notebook_kube_rbac_auth.go
@@ -184,7 +184,7 @@ func NewNotebookKubeRbacProxyConfigMap(notebook *nbv1.Notebook) *corev1.ConfigMa
     verb: get
     resource: notebooks
     apiGroup: kubeflow.org
-    resourceName: %s
+    name: %s
     namespace: %s`, notebook.Name, notebook.Namespace)
 
 	return &corev1.ConfigMap{


### PR DESCRIPTION
We accidentally used a wrong key for the particular resource instance.

https://issues.redhat.com/browse/RHOAIENG-36963

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authorization configuration attributes in the notebook controller to use the correct resource identification field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->