### PR TITLE
Add a target for govulncheck to our component Makefiles, update CI

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -78,19 +78,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # latest govulncheck works with the latest stable go version
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          check-latest: true
+          go-version-file: ${{ matrix.component }}/go.mod
           cache-dependency-path: ${{ matrix.component }}/go.sum
 
       # https://go.googlesource.com/vuln
       - name: govulncheck
         if: "${{ !cancelled() }}"
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
           go mod tidy
-          $(go env GOPATH)/bin/govulncheck -show=verbose ./...
+          make govulncheck
         working-directory: ${{ matrix.component }}
 
   check-generated-code:
@@ -112,7 +111,7 @@ jobs:
               git diff
               exit 1
           fi
-          
+
   code-static-analysis:
     runs-on: ubuntu-latest
     steps:

--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -66,6 +66,18 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# Extract go version from go.mod (e.g., "1.23.6" from "go 1.23.6")
+GO_VERSION = $(shell grep '^go ' go.mod | awk '{print $$2}')
+.PHONY: govulncheck
+govulncheck: ## Run govulncheck against code. Uses the Go version specified in go.mod.
+	@if [ -z "$(GO_VERSION)" ]; then \
+		echo "Warning: No go version directive found in go.mod, using default Go version"; \
+		go run golang.org/x/vuln/cmd/govulncheck@latest -show=verbose ./...; \
+	else \
+		echo "Using Go version: $(GO_VERSION)"; \
+		GOVERSION=go$(GO_VERSION) go run golang.org/x/vuln/cmd/govulncheck@latest -show=verbose ./...; \
+	fi
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./... -coverprofile cover.out

--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -91,6 +91,18 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+# Extract go version from go.mod (e.g., "1.23.6" from "go 1.23.6")
+GO_VERSION = $(shell grep '^go ' go.mod | awk '{print $$2}')
+.PHONY: govulncheck
+govulncheck: ## Run govulncheck against code. Uses the Go version specified in go.mod.
+	@if [ -z "$(GO_VERSION)" ]; then \
+		echo "Warning: No go version directive found in go.mod, using default Go version"; \
+		go run golang.org/x/vuln/cmd/govulncheck@latest -show=verbose ./...; \
+	else \
+		echo "Using Go version: $(GO_VERSION)"; \
+		GOVERSION=go$(GO_VERSION) go run golang.org/x/vuln/cmd/govulncheck@latest -show=verbose ./...; \
+	fi
+
 .PHONY: test test-with-rbac-false test-with-rbac-true
 test: test-with-rbac-false test-with-rbac-true
 test-with-rbac-false: manifests generate fmt vet envtest ## Run tests.


### PR DESCRIPTION
This is for easier run for anyone without searching what to do.
And also updates our CI workflow to actually run with the go version we
use in our go.mod file!

## Description
This introduces new makefile targets to check the go vulnerabilities easily in a local environment. And also assures we use the correct Go version when running this check in our CI instead of using the latest go version available and as such masking CVEs present in our code as not present as it expected the latest Go lang is used for the builds.

## How Has This Been Tested?
```
cd components/notebook-controller
make govulncheck
cd -
cd components/odh-notebook-controller
make govulncheck
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated vulnerability scanning to the development workflow; the scanner now respects the module-specific Go toolchain version when available and is exposed as a reusable make target.
  * CI now invokes the make-based scanner and pins the Go setup to the module's go.mod version.

* **Tests**
  * Expanded test execution to include additional controller packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->