### PR TITLE
Bump go-toolset images from golang 1.24 to 1.25

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           args: --timeout=5m
-          version: v2.1.6
+          version: v2.6.2
           only-new-issues: true
           working-directory: ${{ matrix.component }}
 

--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -7,7 +7,7 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.24
+ARG GOLANG_VERSION=1.25
 
 # Use ubi9/go-toolset as base image
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -1,8 +1,6 @@
 module github.com/kubeflow/kubeflow/components/notebook-controller
 
-go 1.24.3
-
-toolchain go1.24.5
+go 1.25.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -7,7 +7,7 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.24
+ARG GOLANG_VERSION=1.25
 
 # Use ubi9/go-toolset as base image
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -1,8 +1,6 @@
 module github.com/opendatahub-io/kubeflow/components/odh-notebook-controller
 
-go 1.24.3
-
-toolchain go1.24.5
+go 1.25.3
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Also update the golangci-lint to the latest 2.6.2 version that supports 1.25 GoLang already.

https://issues.redhat.com/browse/RHOAIENG-39634

Waiting for openshift/release#71833 - done

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis tooling to the latest version
  * Upgraded Go toolchain version from 1.24 to 1.25 across build configurations and module dependencies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->