### PR TITLE
Remove configuration file for the wei/pull tool

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,8 +1,0 @@
-version: "1"
-rules:
-  - base: master
-    upstream: kubeflow:master
-    mergeMethod: none # don't automatically merge
-    mergeUnstable: false
-label: "do-not-merge/hold"
-conflictLabel: "needs-rebase"


### PR DESCRIPTION
We don't want any updates for master branch anymore so we don't want to be bothered by raised PRs by this tool.

[1] https://github.com/wei/pull

## Description
Example PR that this tool is creating:
* #703
* #725

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
