### PR TITLE
feat: Allow notebook to mount feast-store config

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_feast_config.go
+++ b/components/odh-notebook-controller/controllers/notebook_feast_config.go
@@ -16,12 +16,10 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
 	"fmt"
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -148,7 +146,7 @@ func unmountFeastConfig(notebook *nbv1.Notebook) {
 }
 
 // NewFeastConfig creates a new Feast config.
-func NewFeastConfig(ctx context.Context, cli client.Client, notebook *nbv1.Notebook) error {
+func NewFeastConfig(notebook *nbv1.Notebook) error {
 
 	feastConfigMapName := notebook.Name + feastConfigMapSuffix
 	// mount the Feast config volume

--- a/components/odh-notebook-controller/controllers/notebook_feast_config_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_feast_config_test.go
@@ -471,7 +471,7 @@ var _ = Describe("Feast Config Integration Tests", func() {
 
 			// Replicate webhook flow: Check label first
 			if isFeastEnabled(notebook) {
-				err := NewFeastConfig(ctx, cli, notebook)
+				err := NewFeastConfig(notebook)
 				Expect(err).ToNot(HaveOccurred())
 			} else {
 				Fail("Feast should be enabled but isFeastEnabled returned false")
@@ -534,7 +534,7 @@ var _ = Describe("Feast Config Integration Tests", func() {
 
 			// Replicate webhook flow: Check label first
 			if isFeastEnabled(notebook) {
-				err := NewFeastConfig(ctx, cli, notebook)
+				err := NewFeastConfig(notebook)
 				// Should not error - volume reference is added regardless of ConfigMap existence
 				Expect(err).ToNot(HaveOccurred())
 			} else {
@@ -639,7 +639,7 @@ var _ = Describe("Feast Config Integration Tests", func() {
 
 			// Step 1: Mount Feast config (label = true)
 			if isFeastEnabled(notebook) {
-				err := NewFeastConfig(ctx, cli, notebook)
+				err := NewFeastConfig(notebook)
 				Expect(err).ToNot(HaveOccurred())
 			}
 			Expect(isFeastMounted(notebook)).To(BeTrue(), "Feast should be mounted when label is true")

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -412,13 +412,15 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		// Handle Feast config mounting/unmounting based on label
 		if isFeastEnabled(notebook) {
 			// Label is enabled, mount the Feast config
-			err = NewFeastConfig(ctx, w.Client, notebook)
+			err = NewFeastConfig(notebook)
 			if err != nil {
 				log.Info("Unable to mount Feast config volume", "error", err)
+			} else {
+				log.Info("Successfully mounted Feast config volume")
 			}
 		} else if isFeastMounted(notebook) {
 			// Label is disabled but volume is still mounted, unmount it
-			log.Info("Feast label disabled, removing Feast config volume", "notebook", notebook.Name, "namespace", notebook.Namespace)
+			log.Info("Feast label disabled, removing Feast config volume")
 			unmountFeastConfig(notebook)
 		}
 	}


### PR DESCRIPTION
feat: Allow notebook to mount feast-store config
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


Related-to: https://issues.redhat.com/browse/RHOAIENG-39802
This feature enables mounting of configmap created by feast store and via setting the info through label on notebook CR.
```
metadata:
  labels:
    opendatahub.io/feast-integration: true
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
make test
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebooks detect a Feast enablement label and mount a read-only Feast configuration from a ConfigMap into the matching notebook container; automatic creation/attachment of the config is handled.

* **Bug Fixes**
  * Injection failures are logged non-fatally and do not block admission; clearer handling when the Feast config or target container is missing; config is removed when the label is disabled.

* **Tests**
  * Added comprehensive unit and integration tests covering label handling, mount/unmount flows, multi-container cases, state transitions, and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->