### PR TITLE
Bump the expected Go lang version also for the common module

### DIFF
--- a/components/common/go.mod
+++ b/components/common/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubeflow/kubeflow/components/common
 
-go 1.19
+go 1.25.3


### PR DESCRIPTION
This isn't strictly required as we're using this module in the
notebook-controller and odh-notebook-controller from these directly, but
formally, let's have all modules synced to the same Go version expected.

This would be a followup of the #724 - just to satisfy our internal build system, so this is still under discussion.

https://issues.redhat.com/browse/RHOAIENG-39634

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.25.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->