### PR TITLE
[RHOAIENG-45876] Replace dynamic Kubernetes clients with typed clients in ODH Notebook Controller

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -397,7 +397,7 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		// Ensure the pipeline-runtime-images ConfigMap exists before trying to mount it.
 		// This fixes the race condition (RHOAIENG-24545) where the first notebook in a namespace
 		// would not have the runtime images mounted because the ConfigMap didn't exist yet.
-		err = SyncRuntimeImagesConfigMap(ctx, w.Client, log, notebook.Namespace, w.Namespace, w.Config)
+		err = SyncRuntimeImagesConfigMap(ctx, w.Client, log, notebook.Namespace, w.Namespace)
 		if err != nil {
 			log.Error(err, "Failed to sync runtime images ConfigMap")
 			// Don't fail the webhook on sync error - continue and try to mount if ConfigMap exists
@@ -414,7 +414,7 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 			// Ensure the ds-pipeline-config Secret exists before trying to mount it.
 			// This fixes the race condition (RHOAIENG-24545) where the first notebook in a
 			// namespace would not have the secret mounted because it didn't exist yet.
-			err = SyncElyraRuntimeConfigSecret(ctx, w.Client, w.Config, notebook, log)
+			err = SyncElyraRuntimeConfigSecret(ctx, w.Client, notebook, log)
 			if err != nil {
 				log.Error(err, "Failed to sync Elyra runtime config secret")
 				// Don't fail the webhook on sync error - continue and try to mount if secret exists


### PR DESCRIPTION
Use strongly-typed Gateway API and ImageStream clients instead of
dynamic.Interface to improve type safety, reduce boilerplate, and
enable better IDE support. Remove rest.Config from function signatures
that no longer need to create dynamic clients.

Also updated the variable naming format from `image_url` to `imageUrl`
to match standard golang conventions.

https://issues.redhat.com/browse/RHOAIENG-45876

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
No testing performed except the attached CI runs in this PR.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Controller now uses typed Gateway and ImageStream APIs for more reliable hostname, route and image metadata resolution.
  * Runtime image discovery and Elyra config extraction rely on structured fields and stronger nil-checks, improving correctness and error handling.
  * Sync flows simplified to use the controller client directly.

* **Tests**
  * Tests updated to exercise Gateway CRD objects and typed image metadata scenarios, aligning expectations with structured inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->