### PR TITLE
set the scheme based on DSPA externalStorgae.scheme

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
@@ -108,7 +108,13 @@ func extractElyraRuntimeConfigInfo(ctx context.Context, gatewayInstance map[stri
 	if host == "" {
 		return nil, fmt.Errorf("invalid DSPA CR: missing or invalid 'host'")
 	}
-	cosEndpoint := fmt.Sprintf("https://%s", host)
+
+	// Use scheme from DSPA CR, default to "https" if not specified
+	scheme := externalStorage.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+	cosEndpoint := fmt.Sprintf("%s://%s", scheme, host)
 
 	cosBucket := externalStorage.Bucket
 	if cosBucket == "" {


### PR DESCRIPTION
set the scheme based on DSPA externalStorgae.scheme
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

set the scheme based on DSPA externalStorgae.scheme
<img width="1458" height="466" alt="Screenshot from 2026-01-07 19-31-11" src="https://github.com/user-attachments/assets/6e05ee6e-217d-4e1e-86e2-d3b10231981d" />

Fixes: https://issues.redhat.com/browse/RHOAIENG-2472

The current setup, irrespective of cluster, the scheme is hard-coded to `https`
in term of insecure cluster , it still sets `https`.

With this change, the scheme would be set as per DSPA, so it would fix the issue.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


In PSI cluster, which insecure , 
include a minio s3, https://github.com/harshad16/quick-minio
set that s3 connection DPSA 
and test the changes, by creating a notebook and verify if the url of s3 change in elyra runtime-configuration.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage endpoint URL construction to respect custom schemes when configured, with HTTPS as the default fallback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->