### PR TITLE
update version of the golangci-lint tool to the latest one

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           args: --timeout=5m
-          version: v2.6.2
+          version: v2.8.0
           only-new-issues: true
           working-directory: ${{ matrix.component }}
 


### PR DESCRIPTION
## How Has This Been Tested?
Locally executed:
```
go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
cd components/notebook-controller
golangci-lint run
cd -
cd components/odh-notebook-controller
golangci-lint run
```

There are multiple issues reported:
#### notebook-controller (we don't want to do unnecessary changes to this code as we don't want to divert from upstream much, and anyway - this part isn't developed in the upstream actively anymore)
```
controllers/culling_controller.go:251:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
controllers/culling_controller_test.go:254:14: Error return value of `os.Setenv` is not checked (errcheck)
				os.Setenv(envVar, val)
				         ^
controllers/culling_controller_test.go:256:18: Error return value is not checked (errcheck)
			initGlobalVars()
			              ^
pkg/culler/culler.go:193:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
pkg/culler/culler.go:213:23: Error return value of `resp.Body.Close` is not checked (errcheck)
	defer resp.Body.Close()
	                     ^
controllers/culling_controller.go:359:5: S1009: should omit nil check; len() for nil slices is defined as zero (staticcheck)
	if kernels == nil || len(kernels) == 0 {
	   ^
controllers/culling_controller.go:380:11: S1039: unnecessary use of fmt.Sprintf (staticcheck)
	log.Info(fmt.Sprintf("Comparing api/kernels last_activity time to current notebook annotation time"))
	         ^
controllers/notebook_controller.go:99:2: S1021: should merge variable declaration with assignment on next line (staticcheck)
	var getEventErr error
	^
controllers/notebook_controller.go:191:53: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
		if !reflect.DeepEqual(foundStateful.Spec.Template.ObjectMeta.Labels, ss.Spec.Template.ObjectMeta.Labels) {
		                                                  ^
controllers/notebook_controller.go:192:32: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
			foundStateful.Spec.Template.ObjectMeta.Labels = ss.Spec.Template.ObjectMeta.Labels
			                            ^
controllers/notebook_controller.go:480:25: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
	l := &ss.Spec.Template.ObjectMeta.Labels
	                       ^
controllers/notebook_controller.go:592:15: ST1005: error strings should not be capitalized (staticcheck)
		return nil, fmt.Errorf("Set .spec.hosts error: %v", err)
		            ^
pkg/culler/culler.go:137:3: S1033: unnecessary guard around call to delete (staticcheck)
		if _, ok := meta.GetAnnotations()["notebooks.kubeflow.org/last_activity"]; ok {
		^
pkg/culler/culler.go:266:62: SA5011: possible nil pointer dereference (staticcheck)
	log := log.WithValues("notebook", getNamespacedNameFromMeta(*meta))
	                                                            ^
pkg/culler/culler.go:267:5: SA5011(related information): this check suggests that the pointer can be nil (staticcheck)
	if meta == nil {
	   ^
pkg/culler/culler.go:325:5: S1009: should omit nil check; len() for nil slices is defined as zero (staticcheck)
	if kernels == nil || len(kernels) == 0 {
	   ^
pkg/culler/culler.go:346:11: S1039: unnecessary use of fmt.Sprintf (staticcheck)
	log.Info(fmt.Sprintf("Comparing api/kernels last_activity time to current notebook annotation time"))
	         ^
pkg/culler/culler.go:362:5: S1009: should omit nil check; len() for nil slices is defined as zero (staticcheck)
	if terminals == nil || len(terminals) == 0 {
	   ^
pkg/culler/culler.go:373:11: S1039: unnecessary use of fmt.Sprintf (staticcheck)
	log.Info(fmt.Sprintf("Comparing api/terminals last_activity time to current notebook annotation time"))
	         ^
api/v1beta1/notebook_webhook.go:24:5: var notebooklog is unused (unused)
var notebooklog = logf.Log.WithName("notebook-resource")
    ^
20 issues:
* errcheck: 5
* staticcheck: 14
* unused: 1
```
#### odh-notebook-controller - this is fully under our control and we can/shall diminish most/all of these
```
WARN [runner/nolint_filter] Found unknown linters in //nolint directives: qf1008 
controllers/notebook_controller.go:147:15: Error return value of `retry.OnError` is not checked (errcheck)
	retry.OnError(wait.Backoff{
	             ^
controllers/suite_test.go:244:13: Error return value of `conn.Close` is not checked (errcheck)
		conn.Close()
		          ^
controllers/notebook_controller.go:115:31: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
	return reflect.DeepEqual(nb1.ObjectMeta.Labels, nb2.ObjectMeta.Labels) &&
	                             ^
controllers/notebook_controller.go:116:25: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
		reflect.DeepEqual(nb1.ObjectMeta.Annotations, nb2.ObjectMeta.Annotations) &&
		                      ^
controllers/notebook_network.go:112:23: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
			foundNetworkPolicy.ObjectMeta.Labels = desiredNetworkPolicy.ObjectMeta.Labels
			                   ^
controllers/notebook_webhook.go:844:24: QF1008: could remove embedded field "Time" from selector (staticcheck)
										return iTime.Time.After(jTime.Time) //nolint:QF1008 // Reason: We are comparing metav1.Time // Lexicographical comparison of RFC3339 timestamps
										             ^
e2e/helper_test.go:97:24: func (*testContext).curlNotebookEndpoint is unused (unused)
func (tc *testContext) curlNotebookEndpoint(nbMeta metav1.ObjectMeta) (*http.Response, error) {
                       ^
e2e/notebook_creation_test.go:593:6: func errorWithBody is unused (unused)
func errorWithBody(resp *http.Response) error {
     ^
8 issues:
* errcheck: 2
* staticcheck: 4
* unused: 2
```

There is a tracker issue to get rid of the linter failures: https://issues.redhat.com/browse/RHOAIENG-12107

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality tooling dependencies to latest versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->