### PR TITLE
[RHOAIENG-12107] fix some linter issues in odh-nbc component

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_network.go
+++ b/components/odh-notebook-controller/controllers/notebook_network.go
@@ -109,7 +109,7 @@ func (r *OpenshiftNotebookReconciler) reconcileNetworkPolicy(desiredNetworkPolic
 			}
 			// Reconcile labels and spec field
 			foundNetworkPolicy.Spec = desiredNetworkPolicy.Spec
-			foundNetworkPolicy.ObjectMeta.Labels = desiredNetworkPolicy.ObjectMeta.Labels
+			foundNetworkPolicy.Labels = desiredNetworkPolicy.Labels
 			return r.Update(ctx, foundNetworkPolicy)
 		})
 		if err != nil {
@@ -124,7 +124,7 @@ func (r *OpenshiftNotebookReconciler) reconcileNetworkPolicy(desiredNetworkPolic
 // CompareNotebookNetworkPolicies checks if two services are equal, if not return false
 func CompareNotebookNetworkPolicies(np1 netv1.NetworkPolicy, np2 netv1.NetworkPolicy) bool {
 	// Two network policies will be equal if the labels and specs are identical
-	return reflect.DeepEqual(np1.ObjectMeta.Labels, np2.ObjectMeta.Labels) &&
+	return reflect.DeepEqual(np1.Labels, np2.Labels) &&
 		reflect.DeepEqual(np1.Spec, np2.Spec)
 }
 

--- a/components/odh-notebook-controller/controllers/notebook_route.go
+++ b/components/odh-notebook-controller/controllers/notebook_route.go
@@ -133,7 +133,7 @@ func NewNotebookHTTPRoute(notebook *nbv1.Notebook, centralNamespace string) *gat
 // CompareNotebookHTTPRoutes checks if two HTTPRoutes are equal, if not return false
 func CompareNotebookHTTPRoutes(r1 gatewayv1.HTTPRoute, r2 gatewayv1.HTTPRoute) bool {
 	// Two HTTPRoutes will be equal if the labels and spec are identical
-	return reflect.DeepEqual(r1.ObjectMeta.Labels, r2.ObjectMeta.Labels) &&
+	return reflect.DeepEqual(r1.Labels, r2.Labels) &&
 		reflect.DeepEqual(r1.Spec, r2.Spec)
 }
 

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -484,9 +484,9 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		mutatedNotebook.Annotations = make(map[string]string)
 	}
 	if needsRestart != NoPendingUpdates {
-		mutatedNotebook.ObjectMeta.Annotations[updatePendingAnnotation] = needsRestart.Reason
+		mutatedNotebook.Annotations[updatePendingAnnotation] = needsRestart.Reason
 	} else {
-		delete(mutatedNotebook.ObjectMeta.Annotations, updatePendingAnnotation)
+		delete(mutatedNotebook.Annotations, updatePendingAnnotation)
 	}
 
 	// Create the mutated notebook object

--- a/components/odh-notebook-controller/controllers/suite_test.go
+++ b/components/odh-notebook-controller/controllers/suite_test.go
@@ -241,7 +241,7 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
-		conn.Close()
+		_ = conn.Close()
 		return nil
 	}).Should(Succeed())
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://issues.redhat.com/browse/RHOAIENG-12107

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
```
go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@2.10.1
cd components/odh-notebook-controller
golangci-lint run
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image pull secret verification is now non-blocking during notebook reconciliation; failures are logged but no longer prevent reconciliation.
  * Label and annotation comparisons now use top-level fields, improving detection of label/annotation differences for notebooks, network policies, and routes.
  * Webhook handling of the update-pending annotation now reads/updates annotations consistently at the top level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->