### PR TITLE
Update the go version to the latest patch version

### DIFF
--- a/components/common/go.mod
+++ b/components/common/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubeflow/kubeflow/components/common
 
-go 1.25.3
+go 1.25.7

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/kubeflow/components/notebook-controller
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/kubeflow/components/odh-notebook-controller
 
-go 1.25.3
+go 1.25.7
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
This assures that we're building with the latest golang patch release.

Related to the:
* https://issues.redhat.com/browse/RHOAIENG-44800
* https://issues.redhat.com/browse/RHOAIENG-44782
* https://issues.redhat.com/browse/RHOAIENG-48635
* https://issues.redhat.com/browse/RHOAIENG-48618

The go-toolset image in the dockerfile is updated automatically as it is set to tag.

In RHDS, we need to check the Dockerfile.konflux file. It is updated accordingly already for the main branch, but probably not for the rhoai-3.3 branch:
* https://github.com/red-hat-data-services/kubeflow/blob/main/components/odh-notebook-controller/Dockerfile.konflux#L5
* https://github.com/red-hat-data-services/kubeflow/blob/rhoai-3.3/components/odh-notebook-controller/Dockerfile.konflux#L5

Thus we should check there.
**UPDATE**: both are updated to the fixed base image - thus RHOAI 3.3 will be released build on the updated image. :heavy_check_mark: 

---

NOTE: Also, it looks that current images used in openshift-ci doesn't support 1.25.5 golang yet, thus we need to wait or find a different one that is updated already (this is reason for the CI failures).
**UPDATE**: images got updated and support 1.25.7 now :heavy_check_mark: 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
No specific testing included, just the standard CI that is run in the PR. Any extra testing will be done as a standard process once the changes propagates further to the product.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version across multiple components from 1.25.3 to 1.25.7. No behavioral or public API changes were introduced; builds and runtime behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->