### PR TITLE
Fix the content of the params.env file for odh-nbc kustomize

### DIFF
--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,2 +1,4 @@
 odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:v1.10.0-5
-oauth-proxy-image=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5
+# Source: https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66#overview
+# We want to use our custom wrapper for the kube-rbac-proxy for ODH/RHOAI temporarily. More info: https://issues.redhat.com/browse/RHOAIENG-35698
+kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3


### PR DESCRIPTION
We were missing the recently added reference for kube-rbac-proxy in the params.env file. We were still referencing oauth-proxy which isn't relevant anymore.

This inconsistency probably roots from the merge CI actions that are ignoring this file when merging from main to stable.

* Latest main: https://github.com/opendatahub-io/kubeflow/blob/13a36ec22df4f9bf2038addd9957a988d65bcb50/components/odh-notebook-controller/config/base/params.env
* Latest release: https://github.com/opendatahub-io/kubeflow/blob/c42b08ea6d7b40935e6d21e91e01b0b52a8f2e10/components/odh-notebook-controller/config/base/params.env
* Current stable: https://github.com/opendatahub-io/kubeflow/blob/f53e54adec6a6703468f0c52152613f2533c0cba/components/odh-notebook-controller/config/base/params.env

The GHA in question: https://github.com/opendatahub-io/kubeflow/blob/13a36ec22df4f9bf2038addd9957a988d65bcb50/.github/workflows/sync-branches.yaml#L56-L69

## How Has This Been Tested?
no testing

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
