### PR TITLE
fix(security): bump Go to 1.25.5 for CVE remediation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ bin/
 vendor/
 
 .vscode/
+.cursor/
+.reports/
 
 # Compiled python files.
 *.pyc

--- a/components/common/go.mod
+++ b/components/common/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubeflow/kubeflow/components/common
 
-go 1.25.3
+go 1.25.5

--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -7,7 +7,7 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.25
+ARG GOLANG_VERSION=1.25.5
 
 # Use ubi9/go-toolset as base image
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690

--- a/components/notebook-controller/Dockerfile.ci
+++ b/components/notebook-controller/Dockerfile.ci
@@ -6,7 +6,7 @@
 #
 # This is necessary because the Jupyter controller now depends on
 # components/common
-ARG GOLANG_VERSION=1.15
+ARG GOLANG_VERSION=1.25.5
 FROM golang:${GOLANG_VERSION} as builder
 
 WORKDIR /workspace

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/kubeflow/components/notebook-controller
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -7,7 +7,7 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.25
+ARG GOLANG_VERSION=1.25.5
 
 # Use ubi9/go-toolset as base image
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/kubeflow/components/odh-notebook-controller
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Description

- Bump Go to 1.25.5 in common, notebook-controller, and odh-notebook-controller
- Update Dockerfiles to use GOLANG_VERSION=1.25.5
- Add .cursor/ and .reports/ to .gitignore

## How Has This Been Tested?

The images were built and the tests were run. Everything normal.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


@jstourac @harshad16 this is a test. In theory this should solve all the CVEs, and can be backported. Again, this is a test, we can discard it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.25.3 to 1.25.5 across multiple component modules
  * Updated Docker build configurations to use Go version 1.25.5
  * Added .cursor/ and .reports/ directories to version control exclusions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->