### PR TITLE
fix(manifests): update nbc images references

### DIFF
--- a/components/notebook-controller/config/overlays/openshift/params.env
+++ b/components/notebook-controller/config/overlays/openshift/params.env
@@ -1,1 +1,1 @@
-odh-kf-notebook-controller-image=quay.io/opendatahub/kubeflow-notebook-controller:v1.10.0-10
+odh-kf-notebook-controller-image=quay.io/opendatahub/kubeflow-notebook-controller:odh-stable

--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,4 +1,4 @@
-odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:v1.10.0-10
+odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:odh-stable
 # Source: https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66#overview
 # We want to use our custom wrapper for the kube-rbac-proxy for ODH/RHOAI temporarily. More info: https://issues.redhat.com/browse/RHOAIENG-35698
 kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3

--- a/components/odh-notebook-controller/makefile-vars.mk
+++ b/components/odh-notebook-controller/makefile-vars.mk
@@ -1,1 +1,1 @@
-KF_TAG ?= v1.10.0-10
+KF_TAG ?= odh-stable


### PR DESCRIPTION
We decided to use the `odh-stable` tag for our nbc images in the `stable` branch. This tag is being build by konflux already from the latest code on this branch.

## Description
This is a followup of the #763.

The referenced images build by konflux:
* https://quay.io/repository/opendatahub/odh-notebook-controller?tab=tags ([konflux tekton pipeline](https://github.com/opendatahub-io/kubeflow/blob/88e4f8962ed613eee486def9969996c3b7f3cde1/.tekton/odh-notebook-controller-push.yaml#L26))
* https://quay.io/repository/opendatahub/kubeflow-notebook-controller?tab=tags ([konflux tekton pipeline](https://github.com/opendatahub-io/kubeflow/blob/88e4f8962ed613eee486def9969996c3b7f3cde1/.tekton/odh-kf-notebook-controller-push.yaml#L27))

## How Has This Been Tested?
none

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
