### PR TITLE
Fix kube-rbac-proxy injection for notebooks in kueue-managed namespaces

### DIFF
--- a/components/odh-notebook-controller/config/rbac/role.yaml
+++ b/components/odh-notebook-controller/config/rbac/role.yaml
@@ -19,6 +19,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews

--- a/components/odh-notebook-controller/controllers/auth_proxy_resources_test.go
+++ b/components/odh-notebook-controller/controllers/auth_proxy_resources_test.go
@@ -93,7 +93,7 @@ func TestInjectKubeRbacProxyWithResourceValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := InjectKubeRbacProxy(tt.notebook, kubeRbacProxyImage)
+			err := InjectKubeRbacProxy(tt.notebook, kubeRbacProxyImage, "")
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -96,6 +96,7 @@ type OpenshiftNotebookReconciler struct {
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services;serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies/finalizers,verbs=update;patch
@@ -112,8 +113,8 @@ type OpenshiftNotebookReconciler struct {
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.
 func CompareNotebooks(nb1 nbv1.Notebook, nb2 nbv1.Notebook) bool {
-	return reflect.DeepEqual(nb1.ObjectMeta.Labels, nb2.ObjectMeta.Labels) &&
-		reflect.DeepEqual(nb1.ObjectMeta.Annotations, nb2.ObjectMeta.Annotations) &&
+	return reflect.DeepEqual(nb1.Labels, nb2.Labels) &&
+		reflect.DeepEqual(nb1.Annotations, nb2.Annotations) &&
 		reflect.DeepEqual(nb1.Spec, nb2.Spec)
 }
 

--- a/components/odh-notebook-controller/controllers/notebook_kube_rbac_auth.go
+++ b/components/odh-notebook-controller/controllers/notebook_kube_rbac_auth.go
@@ -91,8 +91,18 @@ func (r *OpenshiftNotebookReconciler) ReconcileNotebookServiceAccount(notebook *
 	return nil
 }
 
-// NewNotebookKubeRbacProxyService defines the desired service object for kube-rbac-proxy
+// NewNotebookKubeRbacProxyService defines the desired service object for kube-rbac-proxy.
+// It reads the port name from the notebook annotation to support legacy oauth-proxy port names
+// in kueue-managed namespaces where port names are immutable.
 func NewNotebookKubeRbacProxyService(notebook *nbv1.Notebook) *corev1.Service {
+	// Get the port name from the annotation, defaulting to the standard name
+	portName := KubeRbacProxyServicePortName
+	if notebook.Annotations != nil {
+		if annotatedPortName, ok := notebook.Annotations[AnnotationProxyPortName]; ok && annotatedPortName != "" {
+			portName = annotatedPortName
+		}
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      notebook.Name + KubeRbacProxyServiceSuffix,
@@ -106,9 +116,9 @@ func NewNotebookKubeRbacProxyService(notebook *nbv1.Notebook) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:       KubeRbacProxyServicePortName,
+				Name:       portName,
 				Port:       KubeRbacProxyServicePort,
-				TargetPort: intstr.FromString(KubeRbacProxyServicePortName),
+				TargetPort: intstr.FromString(portName),
 				Protocol:   corev1.ProtocolTCP,
 			}},
 			Selector: map[string]string{

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -229,12 +229,6 @@ func InjectKubeRbacProxy(notebook *nbv1.Notebook, kubeRbacProxyConfig KubeRbacPr
 		portName = KubeRbacProxyServicePortName
 	}
 
-	// Store the port name as an annotation for service reconciliation
-	if notebook.Annotations == nil {
-		notebook.Annotations = make(map[string]string)
-	}
-	notebook.Annotations[AnnotationProxyPortName] = portName
-
 	// Convert config to ResourceRequirements
 	resourceRequirements := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -515,15 +509,16 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 			if isKueueManagedNamespace(ctx, w.Client, notebook.Namespace) {
 				log.Info("Notebook is in kueue-managed namespace, checking for existing proxy port name")
 				oldNotebook := &nbv1.Notebook{}
-				if err := w.Decoder.DecodeRaw(req.OldObject, oldNotebook); err == nil {
-					existingPortName := getExistingProxyPortName(oldNotebook)
-					if existingPortName != "" && existingPortName != KubeRbacProxyServicePortName {
-						log.Info("Preserving legacy proxy port name for kueue compatibility",
-							"existingPortName", existingPortName)
-						portName = existingPortName
-					}
-				} else {
-					log.Error(err, "Failed to decode old notebook object")
+				if err := w.Decoder.DecodeRaw(req.OldObject, oldNotebook); err != nil {
+					log.Error(err, "Failed to decode old notebook object in kueue-managed namespace")
+					return admission.Errored(http.StatusInternalServerError,
+						fmt.Errorf("failed to decode old notebook object: %w", err))
+				}
+				existingPortName := getExistingProxyPortName(oldNotebook)
+				if existingPortName != "" && existingPortName != KubeRbacProxyServicePortName {
+					log.Info("Preserving legacy proxy port name for kueue compatibility",
+						"existingPortName", existingPortName)
+					portName = existingPortName
 				}
 			}
 		}
@@ -565,6 +560,12 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 	if mutatedNotebook.Annotations == nil {
 		mutatedNotebook.Annotations = make(map[string]string)
 	}
+
+	// Set port name annotation based on final admitted spec to ensure sync with container spec
+	if finalPortName := getExistingProxyPortName(mutatedNotebook); finalPortName != "" {
+		mutatedNotebook.Annotations[AnnotationProxyPortName] = finalPortName
+	}
+
 	if needsRestart != NoPendingUpdates {
 		mutatedNotebook.Annotations[updatePendingAnnotation] = needsRestart.Reason
 	} else {

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -73,6 +73,10 @@ var getWebhookTracer func() trace.Tracer = sync.OnceValue(func() trace.Tracer {
 
 const (
 	ContainerNameKubeRbacProxy = "kube-rbac-proxy"
+	// LegacyContainerNameOAuthProxy is the old sidecar container name from before kube-rbac-proxy migration
+	LegacyContainerNameOAuthProxy = "oauth-proxy"
+	// LegacyOAuthProxyPortName is the old port name used by oauth-proxy sidecar
+	LegacyOAuthProxyPortName = "oauth-proxy"
 
 	KubeRbacProxyConfigVolumeName = "kube-rbac-proxy-config"
 	KubeRbacProxyConfigMountPath  = "/etc/kube-rbac-proxy"
@@ -93,6 +97,14 @@ const (
 	LastImageSelectionAnnotation      = "notebooks.opendatahub.io/last-image-selection"
 
 	KubeRbacProxyTLSCertVolumeSecretSuffix = "-kube-rbac-proxy-tls"
+
+	// KueueManagedNamespaceLabel is the label used by Kueue on OpenShift to mark a namespace as managed
+	KueueManagedNamespaceLabel = "kueue.openshift.io/managed"
+
+	// AnnotationProxyPortName stores the port name used by the auth proxy sidecar.
+	// This is used to preserve the legacy oauth-proxy port name in kueue-managed namespaces
+	// where container port names are immutable.
+	AnnotationProxyPortName = "notebooks.opendatahub.io/proxy-port-name"
 )
 
 // InjectReconciliationLock injects the kubeflow notebook controller culling
@@ -111,6 +123,36 @@ func InjectReconciliationLock(meta *metav1.ObjectMeta) error {
 		})
 	}
 	return nil
+}
+
+// isKueueManagedNamespace checks if the given namespace is managed by Kueue
+// by looking for the kueue.openshift.io/managed: 'true' label
+func isKueueManagedNamespace(ctx context.Context, c client.Client, namespace string) bool {
+	ns := &corev1.Namespace{}
+	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		return false
+	}
+	return ns.Labels[KueueManagedNamespaceLabel] == "true"
+}
+
+// getExistingProxyPortName extracts the port name from an existing auth sidecar container
+// in the old notebook. It checks for both kube-rbac-proxy and legacy oauth-proxy containers.
+// Returns the port name if found, or empty string if no sidecar exists.
+func getExistingProxyPortName(oldNotebook *nbv1.Notebook) string {
+	if oldNotebook == nil {
+		return ""
+	}
+
+	for _, container := range oldNotebook.Spec.Template.Spec.Containers {
+		if container.Name == ContainerNameKubeRbacProxy || container.Name == LegacyContainerNameOAuthProxy {
+			for _, port := range container.Ports {
+				if port.ContainerPort == NotebookKubeRbacProxyPort {
+					return port.Name
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // resourceConfig holds parsed and validated OAuth proxy resource configuration
@@ -173,13 +215,25 @@ func parseAndValidateAuthSidecarResources(notebook *nbv1.Notebook) (*resourceCon
 }
 
 // InjectKubeRbacProxy injects the kube-rbac-proxy proxy sidecar container in the Notebook
-// spec
-func InjectKubeRbacProxy(notebook *nbv1.Notebook, kubeRbacProxyConfig KubeRbacProxyConfig) error {
+// spec. The portName parameter allows preserving the legacy port name in kueue-managed
+// namespaces where port names are immutable. If empty, uses the default KubeRbacProxyServicePortName.
+func InjectKubeRbacProxy(notebook *nbv1.Notebook, kubeRbacProxyConfig KubeRbacProxyConfig, portName string) error {
 	// Parse and validate kube-rbac-proxy resource annotations
 	config, err := parseAndValidateAuthSidecarResources(notebook)
 	if err != nil {
 		return fmt.Errorf("invalid kube-rbac-proxy resource configuration: %w", err)
 	}
+
+	// Use default port name if not specified
+	if portName == "" {
+		portName = KubeRbacProxyServicePortName
+	}
+
+	// Store the port name as an annotation for service reconciliation
+	if notebook.Annotations == nil {
+		notebook.Annotations = make(map[string]string)
+	}
+	notebook.Annotations[AnnotationProxyPortName] = portName
 
 	// Convert config to ResourceRequirements
 	resourceRequirements := corev1.ResourceRequirements{
@@ -212,7 +266,7 @@ func InjectKubeRbacProxy(notebook *nbv1.Notebook, kubeRbacProxyConfig KubeRbacPr
 			"--auth-header-groups-field-name=X-Auth-Request-Groups",
 		},
 		Ports: []corev1.ContainerPort{{
-			Name:          KubeRbacProxyServicePortName,
+			Name:          portName,
 			ContainerPort: NotebookKubeRbacProxyPort,
 			Protocol:      corev1.ProtocolTCP,
 		}},
@@ -257,17 +311,24 @@ func InjectKubeRbacProxy(notebook *nbv1.Notebook, kubeRbacProxyConfig KubeRbacPr
 		},
 	}
 
-	// Add the sidecar container to the notebook
+	// Add or replace the sidecar container in the notebook.
+	// Also handles migration from legacy oauth-proxy to kube-rbac-proxy.
 	notebookContainers := &notebook.Spec.Template.Spec.Containers
-	proxyContainerExists := false
+	proxyContainerIndex := -1
+
+	// First, find any existing proxy container (either kube-rbac-proxy or legacy oauth-proxy)
 	for index, container := range *notebookContainers {
-		if container.Name == ContainerNameKubeRbacProxy {
-			(*notebookContainers)[index] = proxyContainer
-			proxyContainerExists = true
+		if container.Name == ContainerNameKubeRbacProxy || container.Name == LegacyContainerNameOAuthProxy {
+			proxyContainerIndex = index
 			break
 		}
 	}
-	if !proxyContainerExists {
+
+	if proxyContainerIndex >= 0 {
+		// Replace existing proxy container
+		(*notebookContainers)[proxyContainerIndex] = proxyContainer
+	} else {
+		// Append new proxy container
 		*notebookContainers = append(*notebookContainers, proxyContainer)
 	}
 
@@ -446,8 +507,29 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 
 	// Inject the kube-rbac-proxy if the annotation is present
 	if KubeRbacProxyInjectionIsEnabled(notebook.ObjectMeta) {
-		// Inject kube-rbac-proxy
-		err = InjectKubeRbacProxy(notebook, w.KubeRbacProxyConfig)
+		// Determine the port name to use.
+		// For UPDATE operations in kueue-managed namespaces, preserve the existing port name
+		// to avoid kueue admission webhook rejecting the change (ports are immutable).
+		portName := ""
+		if req.Operation == admissionv1.Update {
+			if isKueueManagedNamespace(ctx, w.Client, notebook.Namespace) {
+				log.Info("Notebook is in kueue-managed namespace, checking for existing proxy port name")
+				oldNotebook := &nbv1.Notebook{}
+				if err := w.Decoder.DecodeRaw(req.OldObject, oldNotebook); err == nil {
+					existingPortName := getExistingProxyPortName(oldNotebook)
+					if existingPortName != "" && existingPortName != KubeRbacProxyServicePortName {
+						log.Info("Preserving legacy proxy port name for kueue compatibility",
+							"existingPortName", existingPortName)
+						portName = existingPortName
+					}
+				} else {
+					log.Error(err, "Failed to decode old notebook object")
+				}
+			}
+		}
+
+		// Inject kube-rbac-proxy with the determined port name
+		err = InjectKubeRbacProxy(notebook, w.KubeRbacProxyConfig, portName)
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
@@ -484,9 +566,9 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		mutatedNotebook.Annotations = make(map[string]string)
 	}
 	if needsRestart != NoPendingUpdates {
-		mutatedNotebook.ObjectMeta.Annotations[updatePendingAnnotation] = needsRestart.Reason
+		mutatedNotebook.Annotations[updatePendingAnnotation] = needsRestart.Reason
 	} else {
-		delete(mutatedNotebook.ObjectMeta.Annotations, updatePendingAnnotation)
+		delete(mutatedNotebook.Annotations, updatePendingAnnotation)
 	}
 
 	// Create the mutated notebook object

--- a/components/odh-notebook-controller/controllers/notebook_webhook_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook_test.go
@@ -361,7 +361,7 @@ var _ = Describe("kube-rbac-proxy Resource Configuration Integration", func() {
 				ProxyImage: kubeRbacProxyImage,
 			}
 
-			err := InjectKubeRbacProxy(notebook, kubeRbacProxyConfig)
+			err := InjectKubeRbacProxy(notebook, kubeRbacProxyConfig, "")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify kube-rbac-proxy container injection
@@ -459,7 +459,7 @@ var _ = Describe("kube-rbac-proxy Resource Configuration Integration", func() {
 				ProxyImage: "test-kube-rbac-proxy-image",
 			}
 
-			err := InjectKubeRbacProxy(notebook, kubeRbacProxyConfig)
+			err := InjectKubeRbacProxy(notebook, kubeRbacProxyConfig, "")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify total container count (2 original + 1 kube-rbac-proxy)
@@ -533,7 +533,7 @@ var _ = Describe("kube-rbac-proxy Resource Configuration Integration", func() {
 				ProxyImage: "test-kube-rbac-proxy-image",
 			}
 
-			err := InjectKubeRbacProxy(notebook, kubeRbacProxyConfig)
+			err := InjectKubeRbacProxy(notebook, kubeRbacProxyConfig, "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid kube-rbac-proxy resource configuration"))
 
@@ -618,7 +618,7 @@ var _ = Describe("kube-rbac-proxy Resource Configuration Integration", func() {
 				ProxyImage: "new-rbac-image",
 			}
 
-			err := InjectKubeRbacProxy(notebook, kubeRbacProxyConfig)
+			err := InjectKubeRbacProxy(notebook, kubeRbacProxyConfig, "")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify container count remains the same (update, not add)


### PR DESCRIPTION
## Summary
- Preserve legacy proxy port name for existing notebooks in kueue-managed namespaces to avoid StatefulSet reconciliation failures
- Add namespace label check for kueue.openshift.io/managed: 'true'
- Store port name in annotation for Service reconciliation coordination

https://issues.redhat.com/browse/RHOAIENG-52201

## Description
### Problem

When the odh-notebook-controller injects the kube-rbac-proxy sidecar into notebooks that are in kueue-managed namespaces, the StatefulSet reconciliation fails with:
```admission webhook "vstatefulset.kb.io" denied the request: spec.template.spec.containers[1].ports: Invalid value: [{"name":"kube-rbac-proxy","containerPort":8443,"protocol":"TCP"}]: field is immutable```

This occurs because:

1. Existing notebooks may have the legacy oauth-proxy sidecar with port name oauth-proxy
2. The webhook changes the port name to kube-rbac-proxy
3. Kueue's admission webhook rejects changes to container port names as they are immutable

## Solution
For UPDATE operations on notebooks in kueue-managed namespaces:

1. Detect if the namespace has the kueue.openshift.io/managed: 'true' label
2. Extract the existing proxy port name from the old notebook object
3. Preserve the legacy port name instead of using the new kube-rbac-proxy name
4. Store the port name in the notebooks.opendatahub.io/proxy-port-name annotation
5. Use this annotation when creating/updating the kube-rbac-proxy Service to ensure the TargetPort matches

New notebooks and notebooks in non-kueue-managed namespaces continue to use the default kube-rbac-proxy port name.


Tested with following image: `quay.io/harshad16/odh-notebook-controller-live:kueue-flagged`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve legacy authentication-proxy port names during migrations.
  * Detect and handle special-managed namespaces to maintain proxy behavior.

* **Improvements**
  * Injection now respects and propagates proxy port name annotations.
  * RBAC expanded to allow namespace get/list/watch for smoother namespace operations.
  * Improved notebook update handling to more accurately compare labels and annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->