### PR TITLE
[RHOAIENG-48289] Don't reconcile labels we don't own

### DIFF
--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -106,19 +106,32 @@ func VirtualService(ctx context.Context, r client.Client, virtualServiceName, na
 // Returns true if the fields copied from don't match to.
 func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 	requireUpdate := false
-	for k, v := range to.Labels {
-		if from.Labels[k] != v {
+	// Reconcile only the labels provided by `from` (controller-owned).
+	// Preserve any extra labels already present on `to`.
+	for k, v := range from.Labels {
+		if to.Labels == nil || to.Labels[k] != v {
 			requireUpdate = true
 		}
 	}
-	to.Labels = from.Labels
+	if to.Labels == nil {
+		to.Labels = map[string]string{}
+	}
+	for k, v := range from.Labels {
+		to.Labels[k] = v
+	}
 
-	for k, v := range to.Annotations {
-		if from.Annotations[k] != v {
+	// Same approach for annotations: reconcile only controller-owned keys.
+	for k, v := range from.Annotations {
+		if to.Annotations == nil || to.Annotations[k] != v {
 			requireUpdate = true
 		}
 	}
-	to.Annotations = from.Annotations
+	if to.Annotations == nil {
+		to.Annotations = map[string]string{}
+	}
+	for k, v := range from.Annotations {
+		to.Annotations[k] = v
+	}
 
 	if *from.Spec.Replicas != *to.Spec.Replicas {
 		*to.Spec.Replicas = *from.Spec.Replicas
@@ -135,19 +148,29 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 
 func CopyDeploymentSetFields(from, to *appsv1.Deployment) bool {
 	requireUpdate := false
-	for k, v := range to.Labels {
-		if from.Labels[k] != v {
+	for k, v := range from.Labels {
+		if to.Labels == nil || to.Labels[k] != v {
 			requireUpdate = true
 		}
 	}
-	to.Labels = from.Labels
+	if to.Labels == nil {
+		to.Labels = map[string]string{}
+	}
+	for k, v := range from.Labels {
+		to.Labels[k] = v
+	}
 
-	for k, v := range to.Annotations {
-		if from.Annotations[k] != v {
+	for k, v := range from.Annotations {
+		if to.Annotations == nil || to.Annotations[k] != v {
 			requireUpdate = true
 		}
 	}
-	to.Annotations = from.Annotations
+	if to.Annotations == nil {
+		to.Annotations = map[string]string{}
+	}
+	for k, v := range from.Annotations {
+		to.Annotations[k] = v
+	}
 
 	if from.Spec.Replicas != to.Spec.Replicas {
 		to.Spec.Replicas = from.Spec.Replicas
@@ -165,19 +188,29 @@ func CopyDeploymentSetFields(from, to *appsv1.Deployment) bool {
 // CopyServiceFields copies the owned fields from one Service to another
 func CopyServiceFields(from, to *corev1.Service) bool {
 	requireUpdate := false
-	for k, v := range to.Labels {
-		if from.Labels[k] != v {
+	for k, v := range from.Labels {
+		if to.Labels == nil || to.Labels[k] != v {
 			requireUpdate = true
 		}
 	}
-	to.Labels = from.Labels
+	if to.Labels == nil {
+		to.Labels = map[string]string{}
+	}
+	for k, v := range from.Labels {
+		to.Labels[k] = v
+	}
 
-	for k, v := range to.Annotations {
-		if from.Annotations[k] != v {
+	for k, v := range from.Annotations {
+		if to.Annotations == nil || to.Annotations[k] != v {
 			requireUpdate = true
 		}
 	}
-	to.Annotations = from.Annotations
+	if to.Annotations == nil {
+		to.Annotations = map[string]string{}
+	}
+	for k, v := range from.Annotations {
+		to.Annotations[k] = v
+	}
 
 	// Don't copy the entire Spec, because we can't overwrite the clusterIp field
 

--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -102,36 +102,37 @@ func VirtualService(ctx context.Context, r client.Client, virtualServiceName, na
 
 // Reference: https://github.com/pwittrock/kubebuilder-workshop/blob/master/pkg/util/util.go
 
+// MergeManagedKeys merges keys from src into dst, preserving any extra keys
+// already present in dst. Returns the (possibly initialized) dst map and true
+// if any key was added or changed.
+func MergeManagedKeys(src, dst map[string]string) (map[string]string, bool) {
+	if len(src) == 0 {
+		return dst, false
+	}
+	changed := false
+	if dst == nil {
+		dst = make(map[string]string, len(src))
+	}
+	for k, v := range src {
+		if dst[k] != v {
+			changed = true
+		}
+		dst[k] = v
+	}
+	return dst, changed
+}
+
 // CopyStatefulSetFields copies the owned fields from one StatefulSet to another
 // Returns true if the fields copied from don't match to.
 func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 	requireUpdate := false
-	// Reconcile only the labels provided by `from` (controller-owned).
-	// Preserve any extra labels already present on `to`.
-	for k, v := range from.Labels {
-		if to.Labels == nil || to.Labels[k] != v {
-			requireUpdate = true
-		}
-	}
-	if to.Labels == nil {
-		to.Labels = map[string]string{}
-	}
-	for k, v := range from.Labels {
-		to.Labels[k] = v
-	}
+	var changed bool
 
-	// Same approach for annotations: reconcile only controller-owned keys.
-	for k, v := range from.Annotations {
-		if to.Annotations == nil || to.Annotations[k] != v {
-			requireUpdate = true
-		}
-	}
-	if to.Annotations == nil {
-		to.Annotations = map[string]string{}
-	}
-	for k, v := range from.Annotations {
-		to.Annotations[k] = v
-	}
+	to.Labels, changed = MergeManagedKeys(from.Labels, to.Labels)
+	requireUpdate = requireUpdate || changed
+
+	to.Annotations, changed = MergeManagedKeys(from.Annotations, to.Annotations)
+	requireUpdate = requireUpdate || changed
 
 	if *from.Spec.Replicas != *to.Spec.Replicas {
 		*to.Spec.Replicas = *from.Spec.Replicas
@@ -148,29 +149,13 @@ func CopyStatefulSetFields(from, to *appsv1.StatefulSet) bool {
 
 func CopyDeploymentSetFields(from, to *appsv1.Deployment) bool {
 	requireUpdate := false
-	for k, v := range from.Labels {
-		if to.Labels == nil || to.Labels[k] != v {
-			requireUpdate = true
-		}
-	}
-	if to.Labels == nil {
-		to.Labels = map[string]string{}
-	}
-	for k, v := range from.Labels {
-		to.Labels[k] = v
-	}
+	var changed bool
 
-	for k, v := range from.Annotations {
-		if to.Annotations == nil || to.Annotations[k] != v {
-			requireUpdate = true
-		}
-	}
-	if to.Annotations == nil {
-		to.Annotations = map[string]string{}
-	}
-	for k, v := range from.Annotations {
-		to.Annotations[k] = v
-	}
+	to.Labels, changed = MergeManagedKeys(from.Labels, to.Labels)
+	requireUpdate = requireUpdate || changed
+
+	to.Annotations, changed = MergeManagedKeys(from.Annotations, to.Annotations)
+	requireUpdate = requireUpdate || changed
 
 	if from.Spec.Replicas != to.Spec.Replicas {
 		to.Spec.Replicas = from.Spec.Replicas
@@ -188,29 +173,13 @@ func CopyDeploymentSetFields(from, to *appsv1.Deployment) bool {
 // CopyServiceFields copies the owned fields from one Service to another
 func CopyServiceFields(from, to *corev1.Service) bool {
 	requireUpdate := false
-	for k, v := range from.Labels {
-		if to.Labels == nil || to.Labels[k] != v {
-			requireUpdate = true
-		}
-	}
-	if to.Labels == nil {
-		to.Labels = map[string]string{}
-	}
-	for k, v := range from.Labels {
-		to.Labels[k] = v
-	}
+	var changed bool
 
-	for k, v := range from.Annotations {
-		if to.Annotations == nil || to.Annotations[k] != v {
-			requireUpdate = true
-		}
-	}
-	if to.Annotations == nil {
-		to.Annotations = map[string]string{}
-	}
-	for k, v := range from.Annotations {
-		to.Annotations[k] = v
-	}
+	to.Labels, changed = MergeManagedKeys(from.Labels, to.Labels)
+	requireUpdate = requireUpdate || changed
+
+	to.Annotations, changed = MergeManagedKeys(from.Annotations, to.Annotations)
+	requireUpdate = requireUpdate || changed
 
 	// Don't copy the entire Spec, because we can't overwrite the clusterIp field
 

--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -105,6 +105,13 @@ func VirtualService(ctx context.Context, r client.Client, virtualServiceName, na
 // MergeManagedKeys merges keys from src into dst, preserving any extra keys
 // already present in dst. Returns the (possibly initialized) dst map and true
 // if any key was added or changed.
+//
+// NOTE: this function is append-only — it never removes keys from dst that
+// are absent in src. This is intentional for the generic StatefulSet /
+// Deployment / Service reconcilers where all keys in src are controller-owned
+// and key removal across releases is not expected. For resources with an
+// explicit set of managed keys (HTTPRoute, ReferenceGrant, etc.) use a
+// dedicated reconcile helper that also handles stale-key cleanup.
 func MergeManagedKeys(src, dst map[string]string) (map[string]string, bool) {
 	if len(src) == 0 {
 		return dst, false

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -188,8 +188,22 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Copy the pod template labels, but reconciliation is not required
 	// exclusively based on the pod template labels
 	if ss.Spec.Replicas != nil && foundStateful.Spec.Replicas != nil && *ss.Spec.Replicas != *foundStateful.Spec.Replicas {
-		if !reflect.DeepEqual(foundStateful.Spec.Template.Labels, ss.Spec.Template.Labels) {
-			foundStateful.Spec.Template.Labels = ss.Spec.Template.Labels
+		// Reconcile only controller-owned labels (present on `ss`), preserve any
+		// extra labels on the existing StatefulSet pod template.
+		needsLabelUpdate := false
+		for k, v := range ss.Spec.Template.Labels {
+			if foundStateful.Spec.Template.Labels == nil || foundStateful.Spec.Template.Labels[k] != v {
+				needsLabelUpdate = true
+				break
+			}
+		}
+		if needsLabelUpdate {
+			if foundStateful.Spec.Template.Labels == nil {
+				foundStateful.Spec.Template.Labels = map[string]string{}
+			}
+			for k, v := range ss.Spec.Template.Labels {
+				foundStateful.Spec.Template.Labels[k] = v
+			}
 		}
 	}
 

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	reconcilehelper "github.com/kubeflow/kubeflow/components/common/reconcilehelper"
 	nbv1beta1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -288,6 +289,119 @@ func TestCreateNotebookStatus(t *testing.T) {
 		})
 	}
 
+}
+
+func TestCopyStatefulSetFieldsPreservesExtraLabels(t *testing.T) {
+	one := int32(1)
+
+	tests := []struct {
+		name           string
+		fromLabels     map[string]string
+		toLabels       map[string]string
+		wantLabels     map[string]string
+		wantUpdate     bool
+	}{
+		{
+			name:       "adds managed labels, preserves extra",
+			fromLabels: map[string]string{"managed": "val1"},
+			toLabels:   map[string]string{"extra": "keep"},
+			wantLabels: map[string]string{"managed": "val1", "extra": "keep"},
+			wantUpdate: true,
+		},
+		{
+			name:       "no update when labels already match",
+			fromLabels: map[string]string{"managed": "val1"},
+			toLabels:   map[string]string{"managed": "val1", "extra": "keep"},
+			wantLabels: map[string]string{"managed": "val1", "extra": "keep"},
+			wantUpdate: false,
+		},
+		{
+			name:       "updates changed managed label value",
+			fromLabels: map[string]string{"managed": "new"},
+			toLabels:   map[string]string{"managed": "old", "extra": "keep"},
+			wantLabels: map[string]string{"managed": "new", "extra": "keep"},
+			wantUpdate: true,
+		},
+		{
+			name:       "from labels nil, to labels preserved",
+			fromLabels: nil,
+			toLabels:   map[string]string{"extra": "keep"},
+			wantLabels: map[string]string{"extra": "keep"},
+			wantUpdate: false,
+		},
+		{
+			name:       "to labels nil, initialised from from",
+			fromLabels: map[string]string{"managed": "val1"},
+			toLabels:   nil,
+			wantLabels: map[string]string{"managed": "val1"},
+			wantUpdate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from := &appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{Labels: tt.fromLabels},
+				Spec:       appsv1.StatefulSetSpec{Replicas: &one, Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{}}},
+			}
+			to := &appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{Labels: tt.toLabels},
+				Spec:       appsv1.StatefulSetSpec{Replicas: &one, Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{}}},
+			}
+			got := reconcilehelper.CopyStatefulSetFields(from, to)
+			if got != tt.wantUpdate {
+				t.Errorf("CopyStatefulSetFields() = %v, want %v", got, tt.wantUpdate)
+			}
+			if !reflect.DeepEqual(to.Labels, tt.wantLabels) {
+				t.Errorf("Labels = %v, want %v", to.Labels, tt.wantLabels)
+			}
+		})
+	}
+}
+
+func TestPodTemplateLabelMergePreservesExtraLabels(t *testing.T) {
+	tests := []struct {
+		name         string
+		desiredPodLabels  map[string]string
+		existingPodLabels map[string]string
+		wantPodLabels     map[string]string
+	}{
+		{
+			name:              "merges managed, preserves extra",
+			desiredPodLabels:  map[string]string{"notebook-name": "nb1", "statefulset": "nb1"},
+			existingPodLabels: map[string]string{"notebook-name": "nb1", "statefulset": "nb1", "kueue-queue": "default"},
+			wantPodLabels:     map[string]string{"notebook-name": "nb1", "statefulset": "nb1", "kueue-queue": "default"},
+		},
+		{
+			name:              "corrects drifted managed label",
+			desiredPodLabels:  map[string]string{"notebook-name": "nb1"},
+			existingPodLabels: map[string]string{"notebook-name": "wrong", "kueue-queue": "default"},
+			wantPodLabels:     map[string]string{"notebook-name": "nb1", "kueue-queue": "default"},
+		},
+		{
+			name:              "handles nil existing labels",
+			desiredPodLabels:  map[string]string{"notebook-name": "nb1"},
+			existingPodLabels: nil,
+			wantPodLabels:     map[string]string{"notebook-name": "nb1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := tt.existingPodLabels
+			for k, v := range tt.desiredPodLabels {
+				if existing == nil || existing[k] != v {
+					if existing == nil {
+						existing = map[string]string{}
+					}
+					existing[k] = v
+				}
+			}
+			if !reflect.DeepEqual(existing, tt.wantPodLabels) {
+				t.Errorf("PodTemplate.Labels = %v, want %v", existing, tt.wantPodLabels)
+			}
+		})
+	}
 }
 
 func createMockReconciler() *NotebookReconciler {

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -123,8 +123,10 @@ type OpenshiftNotebookReconciler struct {
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.
 func CompareNotebooks(nb1 nbv1.Notebook, nb2 nbv1.Notebook) bool {
-	return reflect.DeepEqual(nb1.Labels, nb2.Labels) &&
-		reflect.DeepEqual(nb1.Annotations, nb2.Annotations) &&
+	// Do not treat all labels as controller-managed. Labels on Notebooks are often
+	// used by external automation (e.g., sharding / policy / ops tooling) and
+	// should not cause perpetual reconciliation.
+	return reflect.DeepEqual(nb1.Annotations, nb2.Annotations) &&
 		reflect.DeepEqual(nb1.Spec, nb2.Spec)
 }
 

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -124,8 +124,10 @@ type OpenshiftNotebookReconciler struct {
 
 // CompareNotebooks checks if two notebooks are equal, if not return false.
 func CompareNotebooks(nb1 nbv1.Notebook, nb2 nbv1.Notebook) bool {
-	return reflect.DeepEqual(nb1.Labels, nb2.Labels) &&
-		reflect.DeepEqual(nb1.Annotations, nb2.Annotations) &&
+	// Do not treat all labels as controller-managed. Labels on Notebooks are often
+	// used by external automation (e.g., sharding / policy / ops tooling) and
+	// should not cause perpetual reconciliation.
+	return reflect.DeepEqual(nb1.Annotations, nb2.Annotations) &&
 		reflect.DeepEqual(nb1.Spec, nb2.Spec)
 }
 

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -149,6 +149,104 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			Expect(*httpRoute).To(BeMatchingK8sResource(expectedHTTPRoute, CompareNotebookHTTPRoutes))
 		})
 
+		It("Should preserve extra labels (e.g., sharding) when reconciling HTTPRoute", func() {
+			const shardLabelKey = "route-shard"
+			const shardLabelValue = "blue"
+
+			By("By creating a new Notebook dedicated to this test")
+			shardedNotebookName := "test-notebook-shard-label"
+			shardedNotebook := createNotebook(shardedNotebookName, Namespace)
+			Expect(cli.Create(ctx, shardedNotebook)).Should(Succeed())
+
+			shardedHTTPRoute := &gatewayv1.HTTPRoute{}
+
+			By("By checking that the controller has created the HTTPRoute")
+			Eventually(func() error {
+				key := types.NamespacedName{Name: "nb-" + Namespace + "-" + shardedNotebookName, Namespace: odhNotebookControllerTestNamespace}
+				return cli.Get(ctx, key, shardedHTTPRoute)
+			}, duration, interval).Should(Succeed())
+
+			shardedHTTPRouteName := "nb-" + Namespace + "-" + shardedNotebookName
+			expectedShardedHTTPRoute := gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shardedHTTPRouteName,
+					Namespace: odhNotebookControllerTestNamespace, // Central namespace
+					Labels: map[string]string{
+						"notebook-name":      shardedNotebookName,
+						"notebook-namespace": Namespace,
+					},
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Group:     func() *gatewayv1.Group { g := gatewayv1.Group("gateway.networking.k8s.io"); return &g }(),
+								Kind:      func() *gatewayv1.Kind { k := gatewayv1.Kind("Gateway"); return &k }(),
+								Name:      gatewayv1.ObjectName("data-science-gateway"),
+								Namespace: func() *gatewayv1.Namespace { ns := gatewayv1.Namespace("openshift-ingress"); return &ns }(),
+							},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1.HTTPRouteMatch{
+								{
+									Path: &gatewayv1.HTTPPathMatch{
+										Type:  &pathPrefix,
+										Value: (*string)(&[]string{"/notebook/" + Namespace + "/" + shardedNotebookName}[0]),
+									},
+								},
+							},
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Group:     func() *gatewayv1.Group { g := gatewayv1.Group(""); return &g }(),
+											Kind:      func() *gatewayv1.Kind { k := gatewayv1.Kind("Service"); return &k }(),
+											Name:      gatewayv1.ObjectName(shardedNotebookName),
+											Namespace: func() *gatewayv1.Namespace { ns := gatewayv1.Namespace(Namespace); return &ns }(),
+											Port:      (*gatewayv1.PortNumber)(&[]gatewayv1.PortNumber{8888}[0]),
+										},
+										Weight: func() *int32 { w := int32(1); return &w }(),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			By("By simulating a manual HTTPRoute spec modification and adding a shard label")
+			patch := client.RawPatch(types.MergePatchType, []byte(`{"metadata":{"labels":{"`+shardLabelKey+`":"`+shardLabelValue+`"}},"spec":{"rules":[{"backendRefs":[{"name":"foo","port":8888}]}]}}`))
+			Expect(cli.Patch(ctx, shardedHTTPRoute, patch)).Should(Succeed())
+
+			By("By checking that the controller restored the spec while preserving the shard label")
+			Eventually(func() error {
+				key := types.NamespacedName{Name: "nb-" + Namespace + "-" + shardedNotebookName, Namespace: odhNotebookControllerTestNamespace}
+				err := cli.Get(ctx, key, shardedHTTPRoute)
+				if err != nil {
+					return err
+				}
+				backendName := ""
+				if len(shardedHTTPRoute.Spec.Rules) > 0 && len(shardedHTTPRoute.Spec.Rules[0].BackendRefs) > 0 {
+					backendName = string(shardedHTTPRoute.Spec.Rules[0].BackendRefs[0].BackendRef.BackendObjectReference.Name)
+				}
+				if backendName != shardedNotebookName {
+					return fmt.Errorf("expected backend name %q, got %q", shardedNotebookName, backendName)
+				}
+				if shardedHTTPRoute.Labels[shardLabelKey] != shardLabelValue {
+					return fmt.Errorf("expected %s=%q, got %q", shardLabelKey, shardLabelValue, shardedHTTPRoute.Labels[shardLabelKey])
+				}
+				return nil
+			}, duration, interval).Should(Succeed())
+
+			Expect(shardedHTTPRoute.GetLabels()).To(HaveKeyWithValue(shardLabelKey, shardLabelValue))
+			Expect(*shardedHTTPRoute).To(BeMatchingK8sResource(expectedShardedHTTPRoute, CompareNotebookHTTPRoutes))
+
+			By("By deleting the Notebook created for this test")
+			Expect(cli.Delete(ctx, shardedNotebook)).Should(Succeed())
+		})
+
 		It("Should recreate the HTTPRoute when deleted", func() {
 			By("By deleting the notebook HTTPRoute")
 			Expect(cli.Delete(ctx, httpRoute)).Should(Succeed())
@@ -258,7 +356,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				return cli.Update(ctx, referenceGrant)
 			}, duration, interval).Should(Succeed())
 
-			By("By checking that the controller has restored the ReferenceGrant labels")
+			By("By checking that the controller has restored the managed ReferenceGrant labels (without removing extra labels)")
 			Eventually(func() map[string]string {
 				if err := cli.Get(ctx, referenceGrantKey, referenceGrant); err != nil {
 					return nil
@@ -267,6 +365,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			}, duration, interval).Should(And(
 				HaveKeyWithValue("app.kubernetes.io/managed-by", "odh-notebook-controller"),
 				HaveKeyWithValue("opendatahub.io/component", "notebook-controller"),
+				HaveKeyWithValue("wrong-label", "wrong-value"),
 			))
 		})
 

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -157,6 +157,9 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			shardedNotebookName := "test-notebook-shard-label"
 			shardedNotebook := createNotebook(shardedNotebookName, Namespace)
 			Expect(cli.Create(ctx, shardedNotebook)).Should(Succeed())
+			defer func() {
+				_ = cli.Delete(ctx, shardedNotebook)
+			}()
 
 			shardedHTTPRoute := &gatewayv1.HTTPRoute{}
 
@@ -180,10 +183,10 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
 						ParentRefs: []gatewayv1.ParentReference{
 							{
-								Group:     func() *gatewayv1.Group { g := gatewayv1.Group("gateway.networking.k8s.io"); return &g }(),
-								Kind:      func() *gatewayv1.Kind { k := gatewayv1.Kind("Gateway"); return &k }(),
+								Group:     ptr.To(gatewayv1.Group("gateway.networking.k8s.io")),
+								Kind:      ptr.To(gatewayv1.Kind("Gateway")),
 								Name:      gatewayv1.ObjectName("data-science-gateway"),
-								Namespace: func() *gatewayv1.Namespace { ns := gatewayv1.Namespace("openshift-ingress"); return &ns }(),
+								Namespace: ptr.To(gatewayv1.Namespace("openshift-ingress")),
 							},
 						},
 					},
@@ -193,7 +196,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 								{
 									Path: &gatewayv1.HTTPPathMatch{
 										Type:  &pathPrefix,
-										Value: (*string)(&[]string{"/notebook/" + Namespace + "/" + shardedNotebookName}[0]),
+										Value: ptr.To("/notebook/" + Namespace + "/" + shardedNotebookName),
 									},
 								},
 							},
@@ -201,13 +204,13 @@ var _ = Describe("The Openshift Notebook controller", func() {
 								{
 									BackendRef: gatewayv1.BackendRef{
 										BackendObjectReference: gatewayv1.BackendObjectReference{
-											Group:     func() *gatewayv1.Group { g := gatewayv1.Group(""); return &g }(),
-											Kind:      func() *gatewayv1.Kind { k := gatewayv1.Kind("Service"); return &k }(),
+											Group:     ptr.To(gatewayv1.Group("")),
+											Kind:      ptr.To(gatewayv1.Kind("Service")),
 											Name:      gatewayv1.ObjectName(shardedNotebookName),
-											Namespace: func() *gatewayv1.Namespace { ns := gatewayv1.Namespace(Namespace); return &ns }(),
-											Port:      (*gatewayv1.PortNumber)(&[]gatewayv1.PortNumber{8888}[0]),
+											Namespace: ptr.To(gatewayv1.Namespace(Namespace)),
+											Port:      ptr.To(gatewayv1.PortNumber(8888)),
 										},
-										Weight: func() *int32 { w := int32(1); return &w }(),
+										Weight: ptr.To(int32(1)),
 									},
 								},
 							},
@@ -242,9 +245,6 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			Expect(shardedHTTPRoute.GetLabels()).To(HaveKeyWithValue(shardLabelKey, shardLabelValue))
 			Expect(*shardedHTTPRoute).To(BeMatchingK8sResource(expectedShardedHTTPRoute, CompareNotebookHTTPRoutes))
-
-			By("By deleting the Notebook created for this test")
-			Expect(cli.Delete(ctx, shardedNotebook)).Should(Succeed())
 		})
 
 		It("Should recreate the HTTPRoute when deleted", func() {

--- a/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
@@ -357,8 +357,12 @@ func SyncElyraRuntimeConfigSecret(ctx context.Context, cli client.Client, notebo
 
 	if requiresUpdate {
 		log.Info("Updating existing Elyra runtime config secret", "name", elyraRuntimeSecretName)
-		// Set correct label and data
-		existingSecret.Labels = desiredSecret.Labels
+		// Set controller-managed label and data. Preserve any other labels that
+		// may have been added by external tooling.
+		if existingSecret.Labels == nil {
+			existingSecret.Labels = map[string]string{}
+		}
+		existingSecret.Labels[managedByKey] = managedByValue
 		existingSecret.Data = desiredSecret.Data
 
 		if err := cli.Update(ctx, existingSecret); err != nil {

--- a/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
@@ -385,8 +385,12 @@ func SyncElyraRuntimeConfigSecret(ctx context.Context, cli client.Client, notebo
 
 	if requiresUpdate {
 		log.Info("Updating existing Elyra runtime config secret", "name", elyraRuntimeSecretName)
-		// Set correct label and data
-		existingSecret.Labels = desiredSecret.Labels
+		// Set controller-managed label and data. Preserve any other labels that
+		// may have been added by external tooling.
+		if existingSecret.Labels == nil {
+			existingSecret.Labels = map[string]string{}
+		}
+		existingSecret.Labels[managedByKey] = managedByValue
 		existingSecret.Data = desiredSecret.Data
 
 		if err := cli.Update(ctx, existingSecret); err != nil {

--- a/components/odh-notebook-controller/controllers/notebook_network.go
+++ b/components/odh-notebook-controller/controllers/notebook_network.go
@@ -107,9 +107,9 @@ func (r *OpenshiftNotebookReconciler) reconcileNetworkPolicy(desiredNetworkPolic
 			}, foundNetworkPolicy); err != nil {
 				return err
 			}
-			// Reconcile labels and spec field
+			// Reconcile spec only. Preserve any existing labels that may be used by
+			// other automation (e.g., network sharding / policy tooling).
 			foundNetworkPolicy.Spec = desiredNetworkPolicy.Spec
-			foundNetworkPolicy.Labels = desiredNetworkPolicy.Labels
 			return r.Update(ctx, foundNetworkPolicy)
 		})
 		if err != nil {
@@ -123,9 +123,9 @@ func (r *OpenshiftNotebookReconciler) reconcileNetworkPolicy(desiredNetworkPolic
 
 // CompareNotebookNetworkPolicies checks if two services are equal, if not return false
 func CompareNotebookNetworkPolicies(np1 netv1.NetworkPolicy, np2 netv1.NetworkPolicy) bool {
-	// Two network policies will be equal if the labels and specs are identical
-	return reflect.DeepEqual(np1.Labels, np2.Labels) &&
-		reflect.DeepEqual(np1.Spec, np2.Spec)
+	// Only compare spec. Labels are not treated as fully controller-managed to
+	// avoid clobbering external labels used for sharding/policy/ops tooling.
+	return reflect.DeepEqual(np1.Spec, np2.Spec)
 }
 
 // NewNotebookNetworkPolicy defines the desired network policy for Notebook port

--- a/components/odh-notebook-controller/controllers/notebook_referencegrant.go
+++ b/components/odh-notebook-controller/controllers/notebook_referencegrant.go
@@ -70,9 +70,21 @@ func NewNotebookReferenceGrant(namespace string, centralNamespace string) *gatew
 
 // CompareNotebookReferenceGrants checks if two ReferenceGrants are equal, if not return false
 func CompareNotebookReferenceGrants(rg1 gatewayv1beta1.ReferenceGrant, rg2 gatewayv1beta1.ReferenceGrant) bool {
-	// Two ReferenceGrants will be equal if the labels and specs are identical
-	return reflect.DeepEqual(rg1.Labels, rg2.Labels) &&
-		reflect.DeepEqual(rg1.Spec, rg2.Spec)
+	// Only compare controller-managed labels. Extra labels (e.g., added for
+	// sharding / policy / ops tooling) should not cause perpetual reconciliation.
+	managedLabelKeys := []string{
+		"app.kubernetes.io/managed-by",
+		"opendatahub.io/component",
+	}
+	for _, k := range managedLabelKeys {
+		v1, ok1 := rg1.Labels[k]
+		v2, ok2 := rg2.Labels[k]
+		if ok1 != ok2 || v1 != v2 {
+			return false
+		}
+	}
+
+	return reflect.DeepEqual(rg1.Spec, rg2.Spec)
 }
 
 // ReconcileReferenceGrant ensures a ReferenceGrant exists in the Notebook's namespace
@@ -112,7 +124,19 @@ func (r *OpenshiftNotebookReconciler) ReconcileReferenceGrant(notebook *nbv1.Not
 		if !CompareNotebookReferenceGrants(*desiredRefGrant, *foundRefGrant) {
 			log.Info("Updating ReferenceGrant to match desired spec and labels")
 			foundRefGrant.Spec = desiredRefGrant.Spec
-			foundRefGrant.Labels = desiredRefGrant.Labels
+
+			if foundRefGrant.Labels == nil {
+				foundRefGrant.Labels = map[string]string{}
+			}
+			// Only reconcile controller-managed labels; preserve any others.
+			for _, k := range []string{"app.kubernetes.io/managed-by", "opendatahub.io/component"} {
+				if desiredRefGrant.Labels != nil {
+					if v, ok := desiredRefGrant.Labels[k]; ok {
+						foundRefGrant.Labels[k] = v
+					}
+				}
+			}
+
 			err = r.Update(ctx, foundRefGrant)
 			if err != nil {
 				log.Error(err, "Unable to update ReferenceGrant")

--- a/components/odh-notebook-controller/controllers/notebook_referencegrant.go
+++ b/components/odh-notebook-controller/controllers/notebook_referencegrant.go
@@ -33,6 +33,14 @@ const (
 	ReferenceGrantName = "notebook-httproute-access"
 )
 
+// referenceGrantManagedLabelKeys lists the label keys that the controller owns
+// on ReferenceGrant resources. Used for both comparison and reconciliation to
+// keep the two paths in sync.
+var referenceGrantManagedLabelKeys = []string{
+	"app.kubernetes.io/managed-by",
+	"opendatahub.io/component",
+}
+
 // NewNotebookReferenceGrant creates a ReferenceGrant that allows HTTPRoutes from the
 // central application namespace to reference Services in the user's namespace where
 // Notebooks are created.
@@ -72,11 +80,7 @@ func NewNotebookReferenceGrant(namespace string, centralNamespace string) *gatew
 func CompareNotebookReferenceGrants(rg1 gatewayv1beta1.ReferenceGrant, rg2 gatewayv1beta1.ReferenceGrant) bool {
 	// Only compare controller-managed labels. Extra labels (e.g., added for
 	// sharding / policy / ops tooling) should not cause perpetual reconciliation.
-	managedLabelKeys := []string{
-		"app.kubernetes.io/managed-by",
-		"opendatahub.io/component",
-	}
-	for _, k := range managedLabelKeys {
+	for _, k := range referenceGrantManagedLabelKeys {
 		v1, ok1 := rg1.Labels[k]
 		v2, ok2 := rg2.Labels[k]
 		if ok1 != ok2 || v1 != v2 {
@@ -129,7 +133,7 @@ func (r *OpenshiftNotebookReconciler) ReconcileReferenceGrant(notebook *nbv1.Not
 				foundRefGrant.Labels = map[string]string{}
 			}
 			// Only reconcile controller-managed labels; preserve any others.
-			for _, k := range []string{"app.kubernetes.io/managed-by", "opendatahub.io/component"} {
+			for _, k := range referenceGrantManagedLabelKeys {
 				if desiredRefGrant.Labels != nil {
 					if v, ok := desiredRefGrant.Labels[k]; ok {
 						foundRefGrant.Labels[k] = v

--- a/components/odh-notebook-controller/controllers/notebook_route.go
+++ b/components/odh-notebook-controller/controllers/notebook_route.go
@@ -133,9 +133,23 @@ func NewNotebookHTTPRoute(notebook *nbv1.Notebook, centralNamespace string) *gat
 
 // CompareNotebookHTTPRoutes checks if two HTTPRoutes are equal, if not return false
 func CompareNotebookHTTPRoutes(r1 gatewayv1.HTTPRoute, r2 gatewayv1.HTTPRoute) bool {
-	// Two HTTPRoutes will be equal if the labels and spec are identical
-	return reflect.DeepEqual(r1.Labels, r2.Labels) &&
-		reflect.DeepEqual(r1.Spec, r2.Spec)
+	// Only compare labels that are managed by this controller.
+	// Extra labels (e.g., added for sharding / policy / ops tooling) should not
+	// cause perpetual reconciliation.
+	managedLabelKeys := []string{
+		"notebook-name",
+		"notebook-namespace",
+	}
+
+	for _, k := range managedLabelKeys {
+		v1, ok1 := r1.Labels[k]
+		v2, ok2 := r2.Labels[k]
+		if ok1 != ok2 || v1 != v2 {
+			return false
+		}
+	}
+
+	return reflect.DeepEqual(r1.Spec, r2.Spec)
 }
 
 // reconcileHTTPRoute will manage the creation, update and deletion of the HTTPRoute returned
@@ -204,9 +218,17 @@ func (r *OpenshiftNotebookReconciler) reconcileHTTPRoute(notebook *nbv1.Notebook
 			}, foundHTTPRoute); err != nil {
 				return err
 			}
-			// Reconcile labels and spec field
+			// Reconcile spec and ONLY the controller-managed labels.
+			// Preserve any other labels (e.g., used for ingress sharding).
 			foundHTTPRoute.Spec = desiredHTTPRoute.Spec
-			foundHTTPRoute.Labels = desiredHTTPRoute.Labels
+
+			if foundHTTPRoute.Labels == nil {
+				foundHTTPRoute.Labels = map[string]string{}
+			}
+			for k, v := range desiredHTTPRoute.Labels {
+				foundHTTPRoute.Labels[k] = v
+			}
+
 			return r.Update(ctx, foundHTTPRoute)
 		})
 		if err != nil {

--- a/components/odh-notebook-controller/controllers/notebook_route_compare_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_route_compare_test.go
@@ -1,0 +1,61 @@
+package controllers
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestCompareNotebookHTTPRoutes_IgnoresExtraLabels(t *testing.T) {
+	r1 := gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"notebook-name":      "nb",
+				"notebook-namespace": "ns",
+				"route-shard":        "blue",
+			},
+		},
+		Spec: gatewayv1.HTTPRouteSpec{},
+	}
+
+	r2 := gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"notebook-name":      "nb",
+				"notebook-namespace": "ns",
+			},
+		},
+		Spec: gatewayv1.HTTPRouteSpec{},
+	}
+
+	if !CompareNotebookHTTPRoutes(r1, r2) {
+		t.Fatalf("expected routes to match even with extra labels")
+	}
+}
+
+func TestCompareNotebookHTTPRoutes_DetectsManagedLabelDrift(t *testing.T) {
+	r1 := gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"notebook-name":      "nb",
+				"notebook-namespace": "ns",
+			},
+		},
+		Spec: gatewayv1.HTTPRouteSpec{},
+	}
+
+	r2 := gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"notebook-name":      "nb2",
+				"notebook-namespace": "ns",
+			},
+		},
+		Spec: gatewayv1.HTTPRouteSpec{},
+	}
+
+	if CompareNotebookHTTPRoutes(r1, r2) {
+		t.Fatalf("expected routes to not match when managed label differs")
+	}
+}


### PR DESCRIPTION
For the CRs we managed we should reconcile only those labels that we're managing. Other labels may be added/removed by other parties and we may thus break their functionality.

https://redhat.atlassian.net/browse/RHOAIENG-48289

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation to preserve user-added metadata by merging controller-managed labels/annotations instead of replacing full maps across Deployments, StatefulSets, Services, ConfigMaps, Secrets, NetworkPolicies, ReferenceGrants, and HTTPRoutes.
  * Updated reconciliation/equality logic for notebooks, ReferenceGrants, and HTTPRoutes to ignore non-managed label changes, reducing unnecessary updates.
  * Ensured label updates for StatefulSet pod templates only adjust managed keys, preserving extra labels.

* **Tests**
  * Added unit tests for HTTPRoute comparison and managed-label merge behavior, plus expanded StatefulSet/pod-template label merge coverage (including extra labels preservation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->