### PR TITLE
fix(odh-notebook-controller): watch DSPA changes to keep Elyra secret in sync

### DIFF
--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -126,6 +126,8 @@ jobs:
                 served: true
                 storage: true
           EOF
+          # install DSPA CRD (required by the DSPA watch in the controller)
+          kubectl apply -f components/odh-notebook-controller/config/crd/external/opendatahub.io_dspa.yaml
           # install gateway-api
           kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
 

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/go-logr/logr"
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
 	"github.com/kubeflow/kubeflow/components/notebook-controller/pkg/culler"
+	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -719,6 +720,39 @@ func (r *OpenshiftNotebookReconciler) UnsetNotebookCertConfig(notebook *nbv1.Not
 	return nil
 }
 
+// notebooksForDSPA maps a DSPA change to reconcile requests for all notebooks
+// in the same namespace. This triggers Elyra secret reconciliation when DSPA
+// configuration changes (e.g., credential rotation, storage update, deletion).
+// Fix for RHOAIENG-4531.
+func (r *OpenshiftNotebookReconciler) notebooksForDSPA(ctx context.Context, o client.Object) []reconcile.Request {
+	// Only trigger if Elyra secret sync is enabled
+	if strings.ToLower(strings.TrimSpace(os.Getenv("SET_PIPELINE_SECRET"))) != "true" {
+		return []reconcile.Request{}
+	}
+
+	log := r.Log.WithValues("namespace", o.GetNamespace(), "dspa", o.GetName())
+
+	var nbList nbv1.NotebookList
+	if err := r.List(ctx, &nbList, client.InNamespace(o.GetNamespace())); err != nil {
+		log.Error(err, "Unable to list Notebooks when handling DSPA change")
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, len(nbList.Items))
+	for i, nb := range nbList.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      nb.Name,
+				Namespace: nb.Namespace,
+			},
+		}
+	}
+	if len(requests) > 0 {
+		log.Info("Triggering notebook reconciliation due to DSPA change", "notebookCount", len(requests))
+	}
+	return requests
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *OpenshiftNotebookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
@@ -798,6 +832,15 @@ func (r *OpenshiftNotebookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 				return []reconcile.Request{}
 			}),
+		).
+
+		// Watch for DSPA changes to keep the Elyra runtime config secret in sync.
+		// When a DSPA is created, updated, or deleted, reconcile all notebooks in
+		// the same namespace so the ds-pipeline-config secret is updated.
+		// Fix for RHOAIENG-4531: without this Watch, credential rotations and
+		// external DSPA deletions are not detected.
+		Watches(&dspav1.DataSciencePipelinesApplication{},
+			handler.EnqueueRequestsFromMapFunc(r.notebooksForDSPA),
 		).
 
 		// Watch for all the required ConfigMaps

--- a/components/odh-notebook-controller/controllers/notebook_dspa_watch_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_watch_test.go
@@ -17,7 +17,6 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
@@ -88,6 +87,17 @@ func TestNotebooksForDSPA_RHOAIENG4531(t *testing.T) {
 			wantCount:         0,
 		},
 		{
+			name:              "handles SET_PIPELINE_SECRET with whitespace and mixed case",
+			setPipelineSecret: "  True  ",
+			dspaNamespace:     "test-ns",
+			notebooks: []nbv1.Notebook{
+				newTestNotebook("nb1", "test-ns"),
+			},
+			wantCount:      1,
+			wantNamespaces: []string{"test-ns"},
+			wantNames:      []string{"nb1"},
+		},
+		{
 			name:              "only returns notebooks from DSPA namespace, not other namespaces",
 			setPipelineSecret: "true",
 			dspaNamespace:     "target-ns",
@@ -103,13 +113,10 @@ func TestNotebooksForDSPA_RHOAIENG4531(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set env var
-			if tt.setPipelineSecret == "" {
-				os.Unsetenv("SET_PIPELINE_SECRET")
-			} else {
-				os.Setenv("SET_PIPELINE_SECRET", tt.setPipelineSecret)
+			// Set env var — t.Setenv automatically restores on subtest cleanup
+			if tt.setPipelineSecret != "" {
+				t.Setenv("SET_PIPELINE_SECRET", tt.setPipelineSecret)
 			}
-			defer os.Unsetenv("SET_PIPELINE_SECRET")
 
 			// Build fake client with notebooks
 			objs := make([]runtime.Object, len(tt.notebooks))
@@ -142,13 +149,13 @@ func TestNotebooksForDSPA_RHOAIENG4531(t *testing.T) {
 
 			for i, req := range requests {
 				if i < len(tt.wantNames) {
-					if req.NamespacedName.Name != tt.wantNames[i] {
-						t.Errorf("request[%d].Name = %q, want %q", i, req.NamespacedName.Name, tt.wantNames[i])
+					if req.Name != tt.wantNames[i] {
+						t.Errorf("request[%d].Name = %q, want %q", i, req.Name, tt.wantNames[i])
 					}
 				}
 				if i < len(tt.wantNamespaces) {
-					if req.NamespacedName.Namespace != tt.wantNamespaces[i] {
-						t.Errorf("request[%d].Namespace = %q, want %q", i, req.NamespacedName.Namespace, tt.wantNamespaces[i])
+					if req.Namespace != tt.wantNamespaces[i] {
+						t.Errorf("request[%d].Namespace = %q, want %q", i, req.Namespace, tt.wantNamespaces[i])
 					}
 				}
 			}

--- a/components/odh-notebook-controller/controllers/notebook_dspa_watch_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_watch_test.go
@@ -1,0 +1,176 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	nbv1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1"
+	dspav1 "github.com/opendatahub-io/data-science-pipelines-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestNotebooksForDSPA_RHOAIENG4531 verifies the DSPA Watch mapper function
+// that was added to fix RHOAIENG-4531. When a DSPA changes, the mapper should
+// return reconcile requests for all notebooks in the same namespace.
+func TestNotebooksForDSPA_RHOAIENG4531(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := nbv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add notebook scheme: %v", err)
+	}
+	if err := dspav1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add dspa scheme: %v", err)
+	}
+
+	tests := []struct {
+		name              string
+		setPipelineSecret string
+		dspaNamespace     string
+		notebooks         []nbv1.Notebook
+		wantCount         int
+		wantNamespaces    []string
+		wantNames         []string
+	}{
+		{
+			name:              "returns reconcile requests for all notebooks in DSPA namespace",
+			setPipelineSecret: "true",
+			dspaNamespace:     "test-ns",
+			notebooks: []nbv1.Notebook{
+				newTestNotebook("nb1", "test-ns"),
+				newTestNotebook("nb2", "test-ns"),
+			},
+			wantCount:      2,
+			wantNamespaces: []string{"test-ns", "test-ns"},
+			wantNames:      []string{"nb1", "nb2"},
+		},
+		{
+			name:              "returns empty when SET_PIPELINE_SECRET is not true",
+			setPipelineSecret: "false",
+			dspaNamespace:     "test-ns",
+			notebooks: []nbv1.Notebook{
+				newTestNotebook("nb1", "test-ns"),
+			},
+			wantCount: 0,
+		},
+		{
+			name:              "returns empty when SET_PIPELINE_SECRET is unset",
+			setPipelineSecret: "",
+			dspaNamespace:     "test-ns",
+			notebooks: []nbv1.Notebook{
+				newTestNotebook("nb1", "test-ns"),
+			},
+			wantCount: 0,
+		},
+		{
+			name:              "returns empty when no notebooks exist in namespace",
+			setPipelineSecret: "true",
+			dspaNamespace:     "empty-ns",
+			notebooks:         []nbv1.Notebook{},
+			wantCount:         0,
+		},
+		{
+			name:              "only returns notebooks from DSPA namespace, not other namespaces",
+			setPipelineSecret: "true",
+			dspaNamespace:     "target-ns",
+			notebooks: []nbv1.Notebook{
+				newTestNotebook("nb-target", "target-ns"),
+				newTestNotebook("nb-other", "other-ns"),
+			},
+			wantCount:      1,
+			wantNamespaces: []string{"target-ns"},
+			wantNames:      []string{"nb-target"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set env var
+			if tt.setPipelineSecret == "" {
+				os.Unsetenv("SET_PIPELINE_SECRET")
+			} else {
+				os.Setenv("SET_PIPELINE_SECRET", tt.setPipelineSecret)
+			}
+			defer os.Unsetenv("SET_PIPELINE_SECRET")
+
+			// Build fake client with notebooks
+			objs := make([]runtime.Object, len(tt.notebooks))
+			for i := range tt.notebooks {
+				objs[i] = &tt.notebooks[i]
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(objs...).
+				Build()
+
+			reconciler := &OpenshiftNotebookReconciler{
+				Client: fakeClient,
+				Log:    ctrl.Log.WithName("test"),
+			}
+
+			// Create a DSPA object as the trigger
+			dspa := &dspav1.DataSciencePipelinesApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dspa",
+					Namespace: tt.dspaNamespace,
+				},
+			}
+
+			requests := reconciler.notebooksForDSPA(context.Background(), dspa)
+
+			if len(requests) != tt.wantCount {
+				t.Errorf("notebooksForDSPA() returned %d requests, want %d", len(requests), tt.wantCount)
+			}
+
+			for i, req := range requests {
+				if i < len(tt.wantNames) {
+					if req.NamespacedName.Name != tt.wantNames[i] {
+						t.Errorf("request[%d].Name = %q, want %q", i, req.NamespacedName.Name, tt.wantNames[i])
+					}
+				}
+				if i < len(tt.wantNamespaces) {
+					if req.NamespacedName.Namespace != tt.wantNamespaces[i] {
+						t.Errorf("request[%d].Namespace = %q, want %q", i, req.NamespacedName.Namespace, tt.wantNamespaces[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func newTestNotebook(name, namespace string) nbv1.Notebook {
+	return nbv1.Notebook{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: nbv1.NotebookSpec{
+			Template: nbv1.NotebookTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  name,
+						Image: "registry.redhat.io/ubi9/ubi:latest",
+					}},
+				},
+			},
+		},
+	}
+}

--- a/components/odh-notebook-controller/run-e2e-test.sh
+++ b/components/odh-notebook-controller/run-e2e-test.sh
@@ -53,6 +53,10 @@ oc delete --wait=true --ignore-not-found=true project "${TEST_NAMESPACE}" || ech
 # setup and deploy the controller
 oc new-project "${TEST_NAMESPACE}"
 
+# Install the DSPA CRD required by the controller's DSPA Watch (SET_PIPELINE_SECRET=true).
+# On full RHOAI clusters the CRD already exists via DSP Operator, so this is a no-op.
+oc apply -f config/crd/external/opendatahub.io_dspa.yaml
+
 # deploy and run e2e tests
 make deploy
 make e2e-test


### PR DESCRIPTION
## Summary

The Elyra runtime config secret (`ds-pipeline-config`) was only reconciled when a Notebook CR event triggered the controller. If a DSPA was modified (e.g., S3 credentials rotated) or deleted externally, the secret became stale.

- Add `notebooksForDSPA()` mapper method on `OpenshiftNotebookReconciler`
- Add DSPA Watch in `SetupWithManager()` using `EnqueueRequestsFromMapFunc`
- Add 5 unit tests for the mapper function

Fixes: https://issues.redhat.com/browse/RHOAIENG-4531

## Details

When a `DataSciencePipelinesApplication` is created, updated, or deleted, all notebooks in the same namespace are enqueued for reconciliation, causing `SyncElyraRuntimeConfigSecret` to update the `ds-pipeline-config` secret.

The watch is feature-gated behind the existing `SET_PIPELINE_SECRET` env var and follows the same `EnqueueRequestsFromMapFunc` pattern used for ConfigMap and ReferenceGrant watches in the same controller.

## Test plan

- [x] Unit tests pass: `go test ./controllers/... -run TestNotebooksForDSPA -v` (5/5 pass)
- [x] All standalone tests pass (33/33, zero regressions)
- [x] `go build`, `gofmt`, `go vet` all clean
- [ ] Full envtest suite passes in CI
- [ ] DSPA update (e.g., bucket change) triggers secret update
- [ ] DSPA deletion cleans up secret via owner reference GC
- [ ] No impact when `SET_PIPELINE_SECRET` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebooks now synchronize when a DataSciencePipelines Application is created/updated/deleted in the same namespace; this behavior is controlled by the pipeline-secret environment flag.

* **Tests**
  * Added unit tests validating synchronization behavior across namespaces and for different pipeline-secret settings (including case/whitespace and no-notebook scenarios).

* **Chores**
  * Integration and e2e test flows updated to ensure the DSPA custom resource is installed before running tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->