### PR TITLE
chore(konflux): use `main` tag for the push event images builds

### DIFF
--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -35,4 +35,4 @@ Key differences from the stable branch push pipelines:
 - Added pipeline timeouts (2h pipeline / 1h per task).
 - `pipeline-type` is set to `"kubeflow-main-build"` instead of the default `"push"`. This deliberately prevents the `trigger-operator-build` task from running, which would otherwise kick off downstream operator, operator-bundle, and FBC fragment CI builds. Those downstream triggers are not needed on the `main` branch.
 - `enable-group-testing` is set to `"true"` to run e2e tests after a successful build.
-- Push-built images use the `:odh-main` tag and do not expire.
+- Push-built images use the `:main` tag and do not expire.

--- a/.tekton/odh-kf-notebook-controller-push.yaml
+++ b/.tekton/odh-kf-notebook-controller-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kubeflow-notebook-controller:odh-main
+    value: quay.io/opendatahub/kubeflow-notebook-controller:main
   - name: dockerfile
     value: notebook-controller/Dockerfile
   - name: path-context

--- a/.tekton/odh-notebook-controller-push.yaml
+++ b/.tekton/odh-notebook-controller-push.yaml
@@ -31,7 +31,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-notebook-controller:odh-main
+    value: quay.io/opendatahub/odh-notebook-controller:main
   - name: dockerfile
     value: odh-notebook-controller/Dockerfile
   - name: path-context


### PR DESCRIPTION
We used the `odh-main` temporarily until we disabled the builds from openshift-ci completely.

This is a followup of the #790 and waits after this is merged first: openshift/release#76342.

https://issues.redhat.com/browse/RHOAIENG-52394

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image tags to standardize on `:main` instead of `:odh-main` across deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->