### PR TITLE
fix: cleanup workbench-trusted-ca-bundle when odh-trusted-ca-bundle is removed

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -537,8 +537,22 @@ func (r *OpenshiftNotebookReconciler) CreateNotebookCertConfigMap(notebook *nbv1
 		configMap := &corev1.ConfigMap{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: notebook.Namespace, Name: configMapName}, configMap); err != nil {
 			// if configmap odh-trusted-ca-bundle is not found,
-			// no need to create the workbench-trusted-ca-bundle
+			// clean up the workbench-trusted-ca-bundle ConfigMap if it exists
 			if apierrs.IsNotFound(err) && configMapName == OdhConfigMapName {
+				workbenchConfigMap := &corev1.ConfigMap{}
+				err := r.Get(ctx, client.ObjectKey{
+					Namespace: notebook.Namespace,
+					Name:      "workbench-trusted-ca-bundle",
+				}, workbenchConfigMap)
+				if err == nil {
+					// ConfigMap exists, delete it
+					log.Info("Deleting workbench-trusted-ca-bundle ConfigMap as source CA bundle is not found")
+					if err := r.Delete(ctx, workbenchConfigMap); err != nil {
+						log.Error(err, "Unable to delete workbench-trusted-ca-bundle ConfigMap")
+						return err
+					}
+					log.Info("Deleted workbench-trusted-ca-bundle ConfigMap", "namespace", notebook.Namespace)
+				}
 				return nil
 			}
 			log.Info("Unable to fetch ConfigMap", "configMap", configMapName)

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -552,6 +552,8 @@ func (r *OpenshiftNotebookReconciler) CreateNotebookCertConfigMap(notebook *nbv1
 						return err
 					}
 					log.Info("Deleted workbench-trusted-ca-bundle ConfigMap", "namespace", notebook.Namespace)
+				} else if !apierrs.IsNotFound(err) {
+					log.Info("Unable to check workbench-trusted-ca-bundle ConfigMap existence, skipping cleanup", "error", err)
 				}
 				return nil
 			}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -798,8 +798,18 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					},
 				},
 				Data: map[string]string{
-					"ca-bundle.crt":     "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTMyMzI3MzdaFw0yNTExMTMy\nMzI3MzdaMAAwKjAFBgMrZXADIQDEMMlJ1P0gyxEV7A8PgpNosvKZgE4ttDDpu/w9\n35BHzjAFBgMrZXADQQDHT8ulalOcI6P5lGpoRcwLzpa4S/5pyqtbqw2zuj7dIJPI\ndNb1AkbARd82zc9bF+7yDkCNmLIHSlDORUYgTNEL\n-----END CERTIFICATE-----",
-					"odh-ca-bundle.crt": "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTMyMzI2NTlaFw0yNTExMTMy\nMzI2NTlaMAAwKjAFBgMrZXADIQB/v02zcoIIcuan/8bd7cvrBuCGTuVZBrYr1RdA\n0k58yzAFBgMrZXADQQBKsL1tkpOZ6NW+zEX3mD7bhmhxtODQHnANMXEXs0aljWrm\nAxDrLdmzsRRYFYxe23OdXhWqPs8SfO8EZWEvXoME\n-----END CERTIFICATE-----",
+					"ca-bundle.crt": "-----BEGIN CERTIFICATE-----\n" +
+						"MIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTMyMzI3MzdaFw0yNTExMTMy\n" +
+						"MzI3MzdaMAAwKjAFBgMrZXADIQDEMMlJ1P0gyxEV7A8PgpNosvKZgE4ttDDpu/w9\n" +
+						"35BHzjAFBgMrZXADQQDHT8ulalOcI6P5lGpoRcwLzpa4S/5pyqtbqw2zuj7dIJPI\n" +
+						"dNb1AkbARd82zc9bF+7yDkCNmLIHSlDORUYgTNEL\n" +
+						"-----END CERTIFICATE-----",
+					"odh-ca-bundle.crt": "-----BEGIN CERTIFICATE-----\n" +
+						"MIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTMyMzI2NTlaFw0yNTExMTMy\n" +
+						"MzI2NTlaMAAwKjAFBgMrZXADIQB/v02zcoIIcuan/8bd7cvrBuCGTuVZBrYr1RdA\n" +
+						"0k58yzAFBgMrZXADQQBKsL1tkpOZ6NW+zEX3mD7bhmhxtODQHnANMXEXs0aljWrm\n" +
+						"AxDrLdmzsRRYFYxe23OdXhWqPs8SfO8EZWEvXoME\n" +
+						"-----END CERTIFICATE-----",
 				},
 			}
 
@@ -817,7 +827,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			Expect(cli.Create(ctx, serviceCACertBundle)).Should(Succeed())
 
 			By("By creating a new Notebook")
-			notebook := createNotebook(Name, Namespace)
+			cleanupTestName := "test-notebook-cleanup-cert"
+			notebook := createNotebook(cleanupTestName, Namespace)
 			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
 			By("By verifying workbench-trusted-ca-bundle is created")
@@ -851,7 +862,14 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				}
 
 				// Check that cert-related env variables are removed
-				certEnvVars := []string{"PIP_CERT", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "PIPELINES_SSL_SA_CERTS", "GIT_SSL_CAINFO", "KF_PIPELINES_SSL_SA_CERTS"}
+				certEnvVars := []string{
+					"PIP_CERT",
+					"REQUESTS_CA_BUNDLE",
+					"SSL_CERT_FILE",
+					"PIPELINES_SSL_SA_CERTS",
+					"GIT_SSL_CAINFO",
+					"KF_PIPELINES_SSL_SA_CERTS",
+				}
 				for _, container := range updatedNotebook.Spec.Template.Spec.Containers {
 					if container.Name == notebook.Name {
 						for _, env := range container.Env {
@@ -875,6 +893,9 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			}, duration, interval).Should(BeTrue())
 
 			// Clean up
+			if err := cli.Delete(ctx, notebook); err != nil {
+				logger.Info("Error occurred during deletion of Notebook", "error", err)
+			}
 			if err := cli.Delete(ctx, serviceCACertBundle); err != nil {
 				logger.Info("Error occurred during deletion of ConfigMap", "error", err)
 			}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -819,7 +819,14 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					Namespace: "default",
 				},
 				Data: map[string]string{
-					"service-ca.crt": "-----BEGIN CERTIFICATE-----\nMIIBATCBtKADAgECAgEBMAUGAytlcDAAMB4XDTI1MDYxNjE2MTg0MVoXDTI2MDYx\nNjE2MTg0MVowADAqMAUGAytlcAMhAP7g8UxhoFPZXQiy4sSbOsLrlXq2RgFTzQOD\nj8O8e9qmo1MwUTAdBgNVHQ4EFgQUTCWpJDtMDVadBlVpkVTiLnCihqMwHwYDVR0j\nBBgwFoAUTCWpJDtMDVadBlVpkVTiLnCihqMwDwYDVR0TAQH/BAUwAwEB/zAFBgMr\nZXADQQDKpiapbn7ub7/hT7Whad9wbvIY8wXrWojgZXXbWaMQFV8i8GW7QN4w/C1p\nB8i0efvecoLP/mqmXNyl7KgTnC4D\n-----END CERTIFICATE-----",
+					"service-ca.crt": "-----BEGIN CERTIFICATE-----\n" +
+						"MIIBATCBtKADAgECAgEBMAUGAytlcDAAMB4XDTI1MDYxNjE2MTg0MVoXDTI2MDYx\n" +
+						"NjE2MTg0MVowADAqMAUGAytlcAMhAP7g8UxhoFPZXQiy4sSbOsLrlXq2RgFTzQOD\n" +
+						"j8O8e9qmo1MwUTAdBgNVHQ4EFgQUTCWpJDtMDVadBlVpkVTiLnCihqMwHwYDVR0j\n" +
+						"BBgwFoAUTCWpJDtMDVadBlVpkVTiLnCihqMwDwYDVR0TAQH/BAUwAwEB/zAFBgMr\n" +
+						"ZXADQQDKpiapbn7ub7/hT7Whad9wbvIY8wXrWojgZXXbWaMQFV8i8GW7QN4w/C1p\n" +
+						"B8i0efvecoLP/mqmXNyl7KgTnC4D\n" +
+						"-----END CERTIFICATE-----",
 				},
 			}
 

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -784,6 +784,101 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				return checkCertConfigMapWithError(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 3)
 			}, duration, interval).Should(Succeed())
 		})
+
+		It("Should cleanup workbench-trusted-ca-bundle when odh-trusted-ca-bundle is removed", func() {
+			logger := logr.Discard()
+
+			By("By creating odh-trusted-ca-bundle ConfigMap")
+			trustedCACertBundle := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "odh-trusted-ca-bundle",
+					Namespace: "default",
+					Labels: map[string]string{
+						"config.openshift.io/inject-trusted-cabundle": "true",
+					},
+				},
+				Data: map[string]string{
+					"ca-bundle.crt":     "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTMyMzI3MzdaFw0yNTExMTMy\nMzI3MzdaMAAwKjAFBgMrZXADIQDEMMlJ1P0gyxEV7A8PgpNosvKZgE4ttDDpu/w9\n35BHzjAFBgMrZXADQQDHT8ulalOcI6P5lGpoRcwLzpa4S/5pyqtbqw2zuj7dIJPI\ndNb1AkbARd82zc9bF+7yDkCNmLIHSlDORUYgTNEL\n-----END CERTIFICATE-----",
+					"odh-ca-bundle.crt": "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTMyMzI2NTlaFw0yNTExMTMy\nMzI2NTlaMAAwKjAFBgMrZXADIQB/v02zcoIIcuan/8bd7cvrBuCGTuVZBrYr1RdA\n0k58yzAFBgMrZXADQQBKsL1tkpOZ6NW+zEX3mD7bhmhxtODQHnANMXEXs0aljWrm\nAxDrLdmzsRRYFYxe23OdXhWqPs8SfO8EZWEvXoME\n-----END CERTIFICATE-----",
+				},
+			}
+
+			serviceCACertBundle := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openshift-service-ca.crt",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"service-ca.crt": "-----BEGIN CERTIFICATE-----\nMIIBATCBtKADAgECAgEBMAUGAytlcDAAMB4XDTI1MDYxNjE2MTg0MVoXDTI2MDYx\nNjE2MTg0MVowADAqMAUGAytlcAMhAP7g8UxhoFPZXQiy4sSbOsLrlXq2RgFTzQOD\nj8O8e9qmo1MwUTAdBgNVHQ4EFgQUTCWpJDtMDVadBlVpkVTiLnCihqMwHwYDVR0j\nBBgwFoAUTCWpJDtMDVadBlVpkVTiLnCihqMwDwYDVR0TAQH/BAUwAwEB/zAFBgMr\nZXADQQDKpiapbn7ub7/hT7Whad9wbvIY8wXrWojgZXXbWaMQFV8i8GW7QN4w/C1p\nB8i0efvecoLP/mqmXNyl7KgTnC4D\n-----END CERTIFICATE-----",
+				},
+			}
+
+			Expect(cli.Create(ctx, trustedCACertBundle)).Should(Succeed())
+			Expect(cli.Create(ctx, serviceCACertBundle)).Should(Succeed())
+
+			By("By creating a new Notebook")
+			notebook := createNotebook(Name, Namespace)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+
+			By("By verifying workbench-trusted-ca-bundle is created")
+			configMapName := "workbench-trusted-ca-bundle"
+			Eventually(func() error {
+				return checkCertConfigMapWithError(ctx, notebook.Namespace, configMapName, "ca-bundle.crt", 3)
+			}, duration, interval).Should(Succeed())
+
+			By("By deleting odh-trusted-ca-bundle ConfigMap")
+			Expect(cli.Delete(ctx, trustedCACertBundle)).Should(Succeed())
+
+			By("By verifying workbench-trusted-ca-bundle is deleted")
+			Eventually(func() bool {
+				workbenchConfigMap := &corev1.ConfigMap{}
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      configMapName,
+					Namespace: notebook.Namespace,
+				}, workbenchConfigMap)
+				return apierrors.IsNotFound(err)
+			}, duration, interval).Should(BeTrue())
+
+			By("By verifying notebook has cert env variables and volumes removed")
+			Eventually(func() bool {
+				updatedNotebook := &nbv1.Notebook{}
+				err := cli.Get(ctx, types.NamespacedName{
+					Name:      notebook.Name,
+					Namespace: notebook.Namespace,
+				}, updatedNotebook)
+				if err != nil {
+					return false
+				}
+
+				// Check that cert-related env variables are removed
+				certEnvVars := []string{"PIP_CERT", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "PIPELINES_SSL_SA_CERTS", "GIT_SSL_CAINFO", "KF_PIPELINES_SSL_SA_CERTS"}
+				for _, container := range updatedNotebook.Spec.Template.Spec.Containers {
+					if container.Name == notebook.Name {
+						for _, env := range container.Env {
+							for _, certEnvVar := range certEnvVars {
+								if env.Name == certEnvVar {
+									return false
+								}
+							}
+						}
+					}
+				}
+
+				// Check that trusted-ca volume is removed
+				for _, volume := range updatedNotebook.Spec.Template.Spec.Volumes {
+					if volume.Name == "trusted-ca" {
+						return false
+					}
+				}
+
+				return true
+			}, duration, interval).Should(BeTrue())
+
+			// Clean up
+			if err := cli.Delete(ctx, serviceCACertBundle); err != nil {
+				logger.Info("Error occurred during deletion of ConfigMap", "error", err)
+			}
+		})
 	})
 
 	When("Creating a Notebook, test Networkpolicies", func() {


### PR DESCRIPTION
## Summary
Fixes [RHOAIENG-12327](https://redhat.atlassian.net/browse/RHOAIENG-12327) where removing the certificates key from DSCi or setting the cert component to Removed was not properly reflected in workbenches.

## Problem
When the `odh-trusted-ca-bundle` ConfigMap is removed (by setting the cert component to Removed in DSCi), the controller's `CreateNotebookCertConfigMap()` would return early without deleting the corresponding `workbench-trusted-ca-bundle` ConfigMap, leaving stale certificate data in notebook pods.

## Solution
- Added cleanup logic to delete `workbench-trusted-ca-bundle` when the source `odh-trusted-ca-bundle` is not found
- The existing `UnsetNotebookCertConfig` function then removes certificate environment variables and volumes from the notebook
- Added comprehensive test coverage to verify the cleanup behavior

## Test Plan
- [x] Added new test case: "Should cleanup workbench-trusted-ca-bundle when odh-trusted-ca-bundle is removed"
- [x] Test verifies:
  - `workbench-trusted-ca-bundle` is created when `odh-trusted-ca-bundle` exists
  - `workbench-trusted-ca-bundle` is deleted when `odh-trusted-ca-bundle` is removed
  - Certificate-related environment variables and volumes are removed from notebooks
- [x] Tests compile successfully

## Files Modified
- `components/odh-notebook-controller/controllers/notebook_controller.go` - Added cleanup logic
- `components/odh-notebook-controller/controllers/notebook_controller_test.go` - Added test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Controller now cleans up lingering workbench certificate bundles when the source certificate bundle is missing, preventing stale certificates and ensuring notebooks run with consistent trust configuration.

* **Tests**
  * Added an end-to-end test that verifies workbench certificate bundles are removed and that notebook environment and volumes are updated when the source bundle is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->