### PR TITLE
Fix: Clean up auth-proxy sidecontainer when annotation is removed

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -132,6 +132,25 @@ func KubeRbacProxyInjectionIsEnabled(meta metav1.ObjectMeta) bool {
 	}
 }
 
+// PodTemplateHasKubeRbacProxy checks if the notebook pod template contains kube-rbac-proxy artifacts
+func PodTemplateHasKubeRbacProxy(notebook *nbv1.Notebook) bool {
+	// Check for kube-rbac-proxy container
+	for _, container := range notebook.Spec.Template.Spec.Containers {
+		if container.Name == "kube-rbac-proxy" {
+			return true
+		}
+	}
+
+	// Check for kube-rbac-proxy volumes
+	for _, volume := range notebook.Spec.Template.Spec.Volumes {
+		if volume.Name == "kube-rbac-proxy-config" || volume.Name == "kube-rbac-proxy-tls-certificates" {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ReconciliationLockIsEnabled returns true if the reconciliation lock
 // annotation is present in the notebook.
 func ReconciliationLockIsEnabled(meta metav1.ObjectMeta) bool {
@@ -475,20 +494,23 @@ func (r *OpenshiftNotebookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 
-		// Clean up any existing kube-rbac-proxy resources when switching away from auth mode
-		err = r.CleanupKubeRbacProxyClusterRoleBinding(notebook, ctx)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+		// Clean up any existing kube-rbac-proxy resources only if they exist in the pod template
+		// This ensures we only cleanup when transitioning from auth→off and the sidecar has been removed
+		if !PodTemplateHasKubeRbacProxy(notebook) {
+			err = r.CleanupKubeRbacProxyClusterRoleBinding(notebook, ctx)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 
-		err = r.CleanupKubeRbacProxyService(notebook, ctx)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+			err = r.CleanupKubeRbacProxyService(notebook, ctx)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 
-		err = r.CleanupKubeRbacProxyConfigMap(notebook, ctx)
-		if err != nil {
-			return ctrl.Result{}, err
+			err = r.CleanupKubeRbacProxyConfigMap(notebook, ctx)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 
 		// Call the regular HTTPRoute reconciler (see notebook_route.go file)

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -475,8 +475,18 @@ func (r *OpenshiftNotebookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return ctrl.Result{}, err
 		}
 
-		// Clean up any existing kube-rbac-proxy ClusterRoleBinding when switching away from auth mode
+		// Clean up any existing kube-rbac-proxy resources when switching away from auth mode
 		err = r.CleanupKubeRbacProxyClusterRoleBinding(notebook, ctx)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		err = r.CleanupKubeRbacProxyService(notebook, ctx)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		err = r.CleanupKubeRbacProxyConfigMap(notebook, ctx)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -1480,6 +1480,93 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("Cleaning up the test notebook")
 			Expect(cli.Delete(ctx, notebook)).Should(Succeed())
 		})
+
+		It("Should clean up all kube-rbac-proxy resources when annotation is removed", func() {
+			By("Creating a notebook with kube-rbac-proxy initially")
+			notebookName := Name + "-cleanup-all"
+			notebook := createNotebookWithKubeRbacProxy(notebookName, Namespace)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+
+			By("Verifying kube-rbac-proxy Service is created")
+			service := &corev1.Service{}
+			serviceKey := types.NamespacedName{Name: notebookName + KubeRbacProxyServiceSuffix, Namespace: Namespace}
+			Eventually(func() error {
+				return cli.Get(ctx, serviceKey, service)
+			}, duration, interval).Should(Succeed())
+
+			By("Verifying kube-rbac-proxy ConfigMap is created")
+			configMap := &corev1.ConfigMap{}
+			configMapKey := types.NamespacedName{Name: notebookName + KubeRbacProxyConfigSuffix, Namespace: Namespace}
+			Eventually(func() error {
+				return cli.Get(ctx, configMapKey, configMap)
+			}, duration, interval).Should(Succeed())
+
+			By("Verifying kube-rbac-proxy ClusterRoleBinding is created")
+			clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+			clusterRoleBindingName := fmt.Sprintf("%s-rbac-%s-auth-delegator", notebookName, Namespace)
+			clusterRoleBindingKey := types.NamespacedName{Name: clusterRoleBindingName}
+			Eventually(func() error {
+				return cli.Get(ctx, clusterRoleBindingKey, clusterRoleBinding)
+			}, duration, interval).Should(Succeed())
+
+			By("Verifying the notebook has kube-rbac-proxy sidecar container")
+			notebookKey := types.NamespacedName{Name: notebookName, Namespace: Namespace}
+			Eventually(func() (int, error) {
+				err := cli.Get(ctx, notebookKey, notebook)
+				if err != nil {
+					return 0, err
+				}
+				return len(notebook.Spec.Template.Spec.Containers), nil
+			}, duration, interval).Should(Equal(2))
+
+			By("Updating the notebook to remove the inject-auth annotation")
+			Expect(cli.Get(ctx, notebookKey, notebook)).Should(Succeed())
+			delete(notebook.Annotations, AnnotationInjectAuth)
+			Expect(cli.Update(ctx, notebook)).Should(Succeed())
+
+			By("Verifying the kube-rbac-proxy Service is deleted")
+			Eventually(func() bool {
+				err := cli.Get(ctx, serviceKey, service)
+				return apierrors.IsNotFound(err)
+			}, duration, interval).Should(BeTrue())
+
+			By("Verifying the kube-rbac-proxy ConfigMap is deleted")
+			Eventually(func() bool {
+				err := cli.Get(ctx, configMapKey, configMap)
+				return apierrors.IsNotFound(err)
+			}, duration, interval).Should(BeTrue())
+
+			By("Verifying the kube-rbac-proxy ClusterRoleBinding is deleted")
+			Eventually(func() bool {
+				err := cli.Get(ctx, clusterRoleBindingKey, clusterRoleBinding)
+				return apierrors.IsNotFound(err)
+			}, duration, interval).Should(BeTrue())
+
+			By("Verifying the kube-rbac-proxy sidecar container is removed")
+			Eventually(func() (int, error) {
+				err := cli.Get(ctx, notebookKey, notebook)
+				if err != nil {
+					return 0, err
+				}
+				return len(notebook.Spec.Template.Spec.Containers), nil
+			}, duration, interval).Should(Equal(1))
+
+			By("Verifying the kube-rbac-proxy volumes are removed")
+			Eventually(func() bool {
+				err := cli.Get(ctx, notebookKey, notebook)
+				if err != nil {
+					return false
+				}
+				volumeNames := make(map[string]bool)
+				for _, volume := range notebook.Spec.Template.Spec.Volumes {
+					volumeNames[volume.Name] = true
+				}
+				return !volumeNames[KubeRbacProxyConfigVolumeName] && !volumeNames[KubeRbacProxyTLSCertsVolumeName]
+			}, duration, interval).Should(BeTrue())
+
+			By("Cleaning up the test notebook")
+			Expect(cli.Delete(ctx, notebook)).Should(Succeed())
+		})
 	})
 
 	When("Creating a Notebook without kube-rbac-proxy proxy injection", func() {

--- a/components/odh-notebook-controller/controllers/notebook_kube_rbac_auth.go
+++ b/components/odh-notebook-controller/controllers/notebook_kube_rbac_auth.go
@@ -393,7 +393,10 @@ func (r *OpenshiftNotebookReconciler) CleanupKubeRbacProxyService(notebook *nbv1
 }
 
 // CleanupKubeRbacProxyConfigMap removes the kube-rbac-proxy ConfigMap when auth is disabled
-func (r *OpenshiftNotebookReconciler) CleanupKubeRbacProxyConfigMap(notebook *nbv1.Notebook, ctx context.Context) error {
+func (r *OpenshiftNotebookReconciler) CleanupKubeRbacProxyConfigMap(
+	notebook *nbv1.Notebook,
+	ctx context.Context,
+) error {
 	// Initialize logger format
 	log := r.Log.WithValues("notebook", notebook.Name, "namespace", notebook.Namespace)
 

--- a/components/odh-notebook-controller/controllers/notebook_kube_rbac_auth.go
+++ b/components/odh-notebook-controller/controllers/notebook_kube_rbac_auth.go
@@ -366,3 +366,53 @@ func (r *OpenshiftNotebookReconciler) CleanupKubeRbacProxyClusterRoleBinding(not
 	log.Info("Successfully deleted kube-rbac-proxy ClusterRoleBinding", "clusterRoleBinding", clusterRoleBindingName)
 	return nil
 }
+
+// CleanupKubeRbacProxyService removes the kube-rbac-proxy Service when auth is disabled
+func (r *OpenshiftNotebookReconciler) CleanupKubeRbacProxyService(notebook *nbv1.Notebook, ctx context.Context) error {
+	// Initialize logger format
+	log := r.Log.WithValues("notebook", notebook.Name, "namespace", notebook.Namespace)
+
+	serviceName := notebook.Name + KubeRbacProxyServiceSuffix
+	err := r.Delete(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: notebook.Namespace,
+		},
+	})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			log.Info("kube-rbac-proxy Service already deleted", "service", serviceName)
+			return nil
+		}
+		log.Error(err, "Unable to delete kube-rbac-proxy Service", "service", serviceName)
+		return err
+	}
+
+	log.Info("Successfully deleted kube-rbac-proxy Service", "service", serviceName)
+	return nil
+}
+
+// CleanupKubeRbacProxyConfigMap removes the kube-rbac-proxy ConfigMap when auth is disabled
+func (r *OpenshiftNotebookReconciler) CleanupKubeRbacProxyConfigMap(notebook *nbv1.Notebook, ctx context.Context) error {
+	// Initialize logger format
+	log := r.Log.WithValues("notebook", notebook.Name, "namespace", notebook.Namespace)
+
+	configMapName := notebook.Name + KubeRbacProxyConfigSuffix
+	err := r.Delete(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: notebook.Namespace,
+		},
+	})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			log.Info("kube-rbac-proxy ConfigMap already deleted", "configMap", configMapName)
+			return nil
+		}
+		log.Error(err, "Unable to delete kube-rbac-proxy ConfigMap", "configMap", configMapName)
+		return err
+	}
+
+	log.Info("Successfully deleted kube-rbac-proxy ConfigMap", "configMap", configMapName)
+	return nil
+}

--- a/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
@@ -173,6 +173,42 @@ func parseAndValidateAuthSidecarResources(notebook *nbv1.Notebook) (*resourceCon
 	return config, nil
 }
 
+// RemoveKubeRbacProxy removes the kube-rbac-proxy sidecar container and associated volumes
+// from the Notebook spec when auth is disabled
+func RemoveKubeRbacProxy(notebook *nbv1.Notebook) {
+	// Remove the kube-rbac-proxy container
+	notebookContainers := &notebook.Spec.Template.Spec.Containers
+	for index, container := range *notebookContainers {
+		if container.Name == ContainerNameKubeRbacProxy {
+			*notebookContainers = append((*notebookContainers)[:index], (*notebookContainers)[index+1:]...)
+			break
+		}
+	}
+
+	// Remove the kube-rbac-proxy config volume
+	notebookVolumes := &notebook.Spec.Template.Spec.Volumes
+	for index, volume := range *notebookVolumes {
+		if volume.Name == KubeRbacProxyConfigVolumeName {
+			*notebookVolumes = append((*notebookVolumes)[:index], (*notebookVolumes)[index+1:]...)
+			break
+		}
+	}
+
+	// Remove the TLS certificates volume
+	for index, volume := range *notebookVolumes {
+		if volume.Name == KubeRbacProxyTLSCertsVolumeName {
+			*notebookVolumes = append((*notebookVolumes)[:index], (*notebookVolumes)[index+1:]...)
+			break
+		}
+	}
+
+	// Reset service account name to default if it was set to notebook name for kube-rbac-proxy
+	// Only reset if it matches the notebook name (which indicates it was set by kube-rbac-proxy)
+	if notebook.Spec.Template.Spec.ServiceAccountName == notebook.Name {
+		notebook.Spec.Template.Spec.ServiceAccountName = ""
+	}
+}
+
 // InjectKubeRbacProxy injects the kube-rbac-proxy proxy sidecar container in the Notebook
 // spec
 func InjectKubeRbacProxy(notebook *nbv1.Notebook, kubeRbacProxyConfig KubeRbacProxyConfig) error {
@@ -455,6 +491,9 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		if err != nil {
 			return admission.Errored(http.StatusInternalServerError, err)
 		}
+	} else {
+		// Remove kube-rbac-proxy sidecar and volumes if annotation is not present
+		RemoveKubeRbacProxy(notebook)
 	}
 
 	// If cluster-wide-proxy is enabled, and INJECT_CLUSTER_PROXY_ENV is set to true,

--- a/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
@@ -176,11 +176,14 @@ func parseAndValidateAuthSidecarResources(notebook *nbv1.Notebook) (*resourceCon
 // RemoveKubeRbacProxy removes the kube-rbac-proxy sidecar container and associated volumes
 // from the Notebook spec when auth is disabled
 func RemoveKubeRbacProxy(notebook *nbv1.Notebook) {
+	removedProxyArtifacts := false
+
 	// Remove the kube-rbac-proxy container
 	notebookContainers := &notebook.Spec.Template.Spec.Containers
 	for index, container := range *notebookContainers {
 		if container.Name == ContainerNameKubeRbacProxy {
 			*notebookContainers = append((*notebookContainers)[:index], (*notebookContainers)[index+1:]...)
+			removedProxyArtifacts = true
 			break
 		}
 	}
@@ -190,6 +193,7 @@ func RemoveKubeRbacProxy(notebook *nbv1.Notebook) {
 	for index, volume := range *notebookVolumes {
 		if volume.Name == KubeRbacProxyConfigVolumeName {
 			*notebookVolumes = append((*notebookVolumes)[:index], (*notebookVolumes)[index+1:]...)
+			removedProxyArtifacts = true
 			break
 		}
 	}
@@ -198,13 +202,14 @@ func RemoveKubeRbacProxy(notebook *nbv1.Notebook) {
 	for index, volume := range *notebookVolumes {
 		if volume.Name == KubeRbacProxyTLSCertsVolumeName {
 			*notebookVolumes = append((*notebookVolumes)[:index], (*notebookVolumes)[index+1:]...)
+			removedProxyArtifacts = true
 			break
 		}
 	}
 
 	// Reset service account name to default if it was set to notebook name for kube-rbac-proxy
-	// Only reset if it matches the notebook name (which indicates it was set by kube-rbac-proxy)
-	if notebook.Spec.Template.Spec.ServiceAccountName == notebook.Name {
+	// Only reset if we actually removed proxy artifacts and it matches the notebook name
+	if removedProxyArtifacts && notebook.Spec.Template.Spec.ServiceAccountName == notebook.Name {
 		notebook.Spec.Template.Spec.ServiceAccountName = ""
 	}
 }


### PR DESCRIPTION
## Summary
This PR fixes [RHOAIENG-39248](https://redhat.atlassian.net/browse/RHOAIENG-39248) by ensuring that all kube-rbac-proxy resources are properly cleaned up when the `notebooks.opendatahub.io/inject-auth` annotation is removed from a Notebook CR.

## Problem
When the `notebooks.opendatahub.io/inject-auth` annotation is removed from a Notebook CR, the kube-rbac-proxy sidecar container and its associated resources (Service, ConfigMap, TLS Secret, ClusterRoleBinding) were not being cleaned up. This caused orphaned resources and potential issues during upgrades from RHOAI 2.x to 3.x.

## Solution
Added comprehensive cleanup logic that removes all kube-rbac-proxy resources when auth is disabled:

### Controller Changes (`notebook_controller.go`)
- Added calls to cleanup functions when auth annotation is removed
- Ensures Service, ConfigMap, and ClusterRoleBinding are deleted

### Cleanup Functions (`notebook_kube_rbac_auth.go`)
- `CleanupKubeRbacProxyService`: Removes the kube-rbac-proxy Service
- `CleanupKubeRbacProxyConfigMap`: Removes the kube-rbac-proxy ConfigMap
- Existing `CleanupKubeRbacProxyClusterRoleBinding`: Already handles ClusterRoleBinding cleanup

### Webhook Changes (`notebook_mutating_webhook.go`)
- `RemoveKubeRbacProxy`: New function to remove sidecar container and volumes
- Removes kube-rbac-proxy container from pod spec
- Removes associated volumes (config and TLS certs)
- Resets service account name to default

### Test Coverage (`notebook_controller_test.go`)
- Added comprehensive test: "Should clean up all kube-rbac-proxy resources when annotation is removed"
- Verifies cleanup of Service, ConfigMap, ClusterRoleBinding, sidecar container, and volumes

## Test plan
- [x] Added unit test that verifies all resources are cleaned up
- [x] Test creates notebook with auth, then removes annotation and verifies cleanup
- [ ] Manual testing: Create workbench with auth enabled, then disable it
- [ ] Upgrade testing: Verify 2.x to 3.x migration removes oauth-proxy

## Related Issues
- Fixes [RHOAIENG-39248](https://redhat.atlassian.net/browse/RHOAIENG-39248)
- Related to [RHOAIENG-34310](https://redhat.atlassian.net/browse/RHOAIENG-34310)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebook admissions now proactively remove kube-rbac-proxy sidecar, volumes, and related service account entries when injection is disabled.

* **Bug Fixes**
  * Reconciler now conditionally cleans up kube-rbac-proxy resources (ClusterRoleBinding, Service, ConfigMap) only when pod templates lack proxy artifacts, preventing incomplete or premature deletions.

* **Tests**
  * Added end-to-end test validating full removal of kube-rbac-proxy components when auth injection is turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->