### PR TITLE
chore(gha): bump-go-directive: fix the file permissions before removal

### DIFF
--- a/.github/workflows/go-directive-updater.yaml
+++ b/.github/workflows/go-directive-updater.yaml
@@ -53,7 +53,7 @@ jobs:
           git checkout -B "${BRANCH}"
           git add --all
           git commit -m "${COMMIT_MSG}"
-          git push --force-with-lease --set-upstream origin "${BRANCH}"
+          git push --force --set-upstream origin "${BRANCH}"
 
           existing_pr_number="$(gh pr list --head "${BRANCH}" --base "${BASE_BRANCH}" --json number --jq '.[0].number // empty')"
           if [[ -n "${existing_pr_number}" ]]; then

--- a/ci/bump-go-mod-go-version.sh
+++ b/ci/bump-go-mod-go-version.sh
@@ -177,7 +177,7 @@ if [[ "${updated_any}" == "true" ]]; then
     (
       cd "${module_dir}"
       go_cache_root="$(mktemp -d)"
-      trap 'rm -rf "${go_cache_root}"' EXIT
+      trap 'chmod -R u+w "${go_cache_root}" 2>/dev/null; rm -rf "${go_cache_root}"' EXIT
       mkdir -p "${go_cache_root}/gopath" "${go_cache_root}/build-cache"
       export GOPATH="${go_cache_root}/gopath"
       export GOCACHE="${go_cache_root}/build-cache"


### PR DESCRIPTION
The GHA action failed on GH during the removal of the created cache on the machine. The cleanup is there in case the script runs on a local machine.

## Description

Example failure: https://github.com/opendatahub-io/kubeflow/actions/runs/23731561442/job/69126313021

## How Has This Been Tested?

Execution on my fork:
* https://github.com/jstourac/kubeflow/actions/runs/23740103878
* https://github.com/jstourac/kubeflow/pull/3

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability of temporary-directory cleanup during CI by restoring write permissions before removal to avoid leftover files.
  * Adjusted CI branch update behavior to use a direct force-push approach for branch updates, reducing push conflicts during automated branch syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->