### PR TITLE
chore(go updater): fix the warning for missing cache when running GHA

### DIFF
--- a/.github/workflows/go-directive-updater.yaml
+++ b/.github/workflows/go-directive-updater.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           check-latest: true
           go-version-file: components/notebook-controller/go.mod
+          cache: false
 
       - name: Update go.mod go directives to latest patch
         id: update-go


### PR DESCRIPTION
Example warning when GHA runs:
```
Run actions/setup-go@v6
Setup go version spec 1.25.8
Attempting to resolve the latest version from the manifest...
matching 1.25.8...
Resolved as '1.25.8'
Found in cache @ /opt/hostedtoolcache/go/1.25.8/x64
Added go to the path
Successfully set up Go version 1.25.8
/opt/hostedtoolcache/go/1.25.8/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.25.8/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/kubeflow/kubeflow. Supported file pattern: go.mod
go version go1.25.8 linux/amd64
```

## Description
Set cache: false on the setup-go step. This eliminates the warning because:

The script uses isolated temp directories for GOPATH/GOMODCACHE (cleaned up after each tidy), so the default ~/go/pkg/mod never gets populated.
This workflow runs weekly at most, so caching provides negligible benefit anyway.
The Go toolchain itself is still cached by setup-go via hostedtoolcache regardless of this setting.

## How Has This Been Tested?
Running on my branch fork GHA - https://github.com/jstourac/kubeflow/actions/runs/24452395864/job/71444287879

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Go toolchain and module caching in the GitHub Actions workflow to ensure fresh builds with updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->