### PR TITLE
misc(Makefile): introduce a docker build without test execution

### DIFF
--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -104,23 +104,23 @@ run-culling: generate fmt vet manifests
 ##@ Build
 .PHONY: docker-build-no-test
 docker-build-no-test: ## Build docker image with the manager (without running tests).
-	cd .. && ${CONTAINER_ENGINE} build . --platform="${ARCH}" -t ${IMG}:${TAG} -f ./notebook-controller/Dockerfile
+	cd .. && "${CONTAINER_ENGINE}" build . --platform="${ARCH}" -t "${IMG}:${TAG}" -f ./notebook-controller/Dockerfile
 
 .PHONY: docker-build
 docker-build: test docker-build-no-test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	${CONTAINER_ENGINE} push ${IMG}:${TAG}
+	"${CONTAINER_ENGINE}" push "${IMG}:${TAG}"
 
 .PHONY: docker-build-multi-arch
 docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
-	cd .. && docker buildx build --load --platform ${ARCH} --tag ${IMG}:${TAG} -f ./notebook-controller/Dockerfile .
+	cd .. && docker buildx build --load --platform "${ARCH}" --tag "${IMG}:${TAG}" -f ./notebook-controller/Dockerfile .
 
 
 .PHONY: docker-build-push-multi-arch
 docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry
-	cd .. && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push -f ./notebook-controller/Dockerfile .
+	cd .. && docker buildx build --platform "${ARCH}" --tag "${IMG}:${TAG}" --push -f ./notebook-controller/Dockerfile .
 
 
 .PHONY: image

--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -102,9 +102,12 @@ run-culling: generate fmt vet manifests
 	go run ./main.go
 
 ##@ Build
-.PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+.PHONY: docker-build-no-test
+docker-build-no-test: ## Build docker image with the manager (without running tests).
 	cd .. && ${CONTAINER_ENGINE} build . --platform="${ARCH}" -t ${IMG}:${TAG} -f ./notebook-controller/Dockerfile
+
+.PHONY: docker-build
+docker-build: test docker-build-no-test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -128,14 +128,14 @@ run: manifests generate fmt vet certificates ktunnel ## Run a controller from yo
 
 .PHONY: docker-build-no-test
 docker-build-no-test: ## Build docker image with the manager (without running tests).
-	cd ../ && ${CONTAINER_ENGINE} build . --platform="${ARCH}" -t ${IMG}:${TAG} -f odh-notebook-controller/Dockerfile
+	cd ../ && "${CONTAINER_ENGINE}" build . --platform="${ARCH}" -t "${IMG}:${TAG}" -f odh-notebook-controller/Dockerfile
 
 .PHONY: docker-build
 docker-build: test docker-build-no-test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	${CONTAINER_ENGINE} push ${IMG}:${TAG}
+	"${CONTAINER_ENGINE}" push "${IMG}:${TAG}"
 
 .PHONY: image
 image: docker-build docker-push ## Build and push docker image with the manager.

--- a/components/odh-notebook-controller/Makefile
+++ b/components/odh-notebook-controller/Makefile
@@ -126,9 +126,12 @@ run: manifests generate fmt vet certificates ktunnel ## Run a controller from yo
 		$(WEBHOOK_PORT) --eject=false --namespace $(K8S_NAMESPACE) &
 	go run ./main.go
 
-.PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+.PHONY: docker-build-no-test
+docker-build-no-test: ## Build docker image with the manager (without running tests).
 	cd ../ && ${CONTAINER_ENGINE} build . --platform="${ARCH}" -t ${IMG}:${TAG} -f odh-notebook-controller/Dockerfile
+
+.PHONY: docker-build
+docker-build: test docker-build-no-test ## Build docker image with the manager.
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
In some cases we want to build an OCI image without running the component tests. Let's have a separate Makefile target for that.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split test and image-build steps in notebook controller build configuration to allow more flexible workflows.
  * Added an option to build container images without running tests while preserving test gating for normal builds.
  * Improved handling of image/tag/platform/engine arguments during Docker build/push for more robust CLI usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->