### PR TITLE
Bump go-toolset images from golang 1.25 to 1.26

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           args: --timeout=5m
-          version: v2.8.0
+          version: v2.12.2
           only-new-issues: true
           working-directory: ${{ matrix.component }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         name: golangci-lint (notebook-controller)
         entry: bash -c 'cd components/notebook-controller && golangci-lint run --timeout=5m ./...'
         language: golang
-        additional_dependencies: ['github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0']
+        additional_dependencies: ['github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2']
         files: ^components/notebook-controller/.*\.go$
         pass_filenames: false
         types: [go]
@@ -24,7 +24,7 @@ repos:
         name: golangci-lint (odh-notebook-controller)
         entry: bash -c 'cd components/odh-notebook-controller && golangci-lint run --timeout=5m ./...'
         language: golang
-        additional_dependencies: ['github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0']
+        additional_dependencies: ['github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2']
         files: ^components/odh-notebook-controller/.*\.go$
         pass_filenames: false
         types: [go]

--- a/components/common/go.mod
+++ b/components/common/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubeflow/kubeflow/components/common
 
-go 1.25.9
+go 1.26.2

--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -7,7 +7,7 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.25
+ARG GOLANG_VERSION=1.26
 
 # Use ubi9/go-toolset as base image
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/kubeflow/components/notebook-controller
 
-go 1.25.9
+go 1.26.2
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/components/odh-notebook-controller/Dockerfile
+++ b/components/odh-notebook-controller/Dockerfile
@@ -7,7 +7,7 @@
 
 # Build arguments
 ARG SOURCE_CODE=.
-ARG GOLANG_VERSION=1.25
+ARG GOLANG_VERSION=1.26
 
 # Use ubi9/go-toolset as base image
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690

--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/kubeflow/components/odh-notebook-controller
 
-go 1.25.9
+go 1.26.2
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Also update the golangci-lint to the latest version that supports 1.26 GoLang already.

GoLang 1.26 was released this February - full changelog: https://go.dev/doc/go1.26

## Description
https://redhat.atlassian.net/browse/RHOAIENG-65206

## How Has This Been Tested?
Just the integrated CI

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated golangci-lint to v2.12.2 in CI and pre-commit hooks.
  * Bumped Go toolchain to 1.26.2 across components.
  * Adjusted build container defaults to use Go 1.26 for image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->