### PR TITLE
ci: use docker-build-no-test in integration test workflows

### DIFF
--- a/.github/workflows/notebook_controller_integration_test.yaml
+++ b/.github/workflows/notebook_controller_integration_test.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Build Notebook Controller Image
         run: |
           cd components/notebook-controller
-          make docker-build
+          make docker-build-no-test
         env:
           CACHE_IMAGE: ghcr.io/${{ github.repository }}/components/notebook-controller/build-cache
 

--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Build Notebook Controller Image
         run: |
           cd components/notebook-controller
-          make docker-build
+          make docker-build-no-test
         env:
           IMG: notebook-controller
           CACHE_IMAGE: ghcr.io/${{ github.repository }}/components/notebook-controller/build-cache
@@ -69,7 +69,7 @@ jobs:
       - name: Build ODH Notebook Controller Image
         run: |
           cd components/odh-notebook-controller
-          make docker-build
+          make docker-build-no-test
         env:
           IMG: odh-notebook-controller
           CACHE_IMAGE: ghcr.io/${{ github.repository }}/components/odh-notebook-controller/build-cache


### PR DESCRIPTION
The integration test workflows were running unit tests as part of `make docker-build` before building the container image. These unit tests are redundant since dedicated unit test workflows (notebook_controller_unit_test, odh_notebook_controller_unit_test) already run on the same triggers.

Switch to `make docker-build-no-test` to skip the duplicate test execution and reduce CI time.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
