### PR TITLE
fix: stabilize CI unit tests by reducing reconciler blocking time

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -26,7 +26,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
 
 	netv1 "k8s.io/api/networking/v1"
 
@@ -40,7 +39,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
+
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
@@ -150,36 +149,23 @@ func ReconciliationLockIsEnabled(meta metav1.ObjectMeta) bool {
 	}
 }
 
-// RemoveReconciliationLock waits until the image pull secret is mounted in the
-// notebook service account to remove the reconciliation lock annotation.
+// RemoveReconciliationLock removes the reconciliation lock annotation from the
+// notebook. It first checks whether the image pull secret is mounted in the
+// notebook service account; if not, it logs a warning but proceeds with lock
+// removal anyway (best-effort, matching the original contract). This is a
+// single non-blocking check rather than a synchronous retry loop, so the
+// reconciler worker is never stalled waiting for the pull secret.
 func (r *OpenshiftNotebookReconciler) RemoveReconciliationLock(notebook *nbv1.Notebook,
 	ctx context.Context) error {
-	// Wait until the image pull secret is mounted in the notebook service
-	// account
-	if err := retry.OnError(wait.Backoff{
-		Steps:    3,
-		Duration: 1 * time.Second,
-		Factor:   5.0,
-	}, func(error) bool { return true },
-		func() error {
-			serviceAccount := &corev1.ServiceAccount{}
-			if err := r.Get(ctx, types.NamespacedName{
-				Name:      notebook.Name,
-				Namespace: notebook.Namespace,
-			}, serviceAccount); err != nil {
-				return err
-			}
-			if len(serviceAccount.ImagePullSecrets) == 0 {
-				return errors.New("pull secret not mounted")
-			}
-			return nil
-		},
-	); err != nil {
-		// Log the error but don't fail - the lock removal is best-effort
-		r.Log.Info("Failed to wait for image pull secret", "error", err)
+	serviceAccount := &corev1.ServiceAccount{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      notebook.Name,
+		Namespace: notebook.Namespace,
+	}, serviceAccount)
+	if err != nil || len(serviceAccount.ImagePullSecrets) == 0 {
+		r.Log.Info("Image pull secret not yet available, proceeding with lock removal")
 	}
 
-	// Remove the reconciliation lock annotation
 	patch := client.RawPatch(types.MergePatchType,
 		[]byte(`{"metadata":{"annotations":{"`+culler.STOP_ANNOTATION+`":null}}}`))
 	return r.Patch(ctx, notebook, patch)

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -159,7 +159,7 @@ func (r *OpenshiftNotebookReconciler) RemoveReconciliationLock(notebook *nbv1.No
 	if err := retry.OnError(wait.Backoff{
 		Steps:    3,
 		Duration: 1 * time.Second,
-		Factor:   1.0,
+		Factor:   5.0,
 	}, func(error) bool { return true },
 		func() error {
 			serviceAccount := &corev1.ServiceAccount{}

--- a/components/odh-notebook-controller/controllers/notebook_controller.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller.go
@@ -159,7 +159,7 @@ func (r *OpenshiftNotebookReconciler) RemoveReconciliationLock(notebook *nbv1.No
 	if err := retry.OnError(wait.Backoff{
 		Steps:    3,
 		Duration: 1 * time.Second,
-		Factor:   5.0,
+		Factor:   1.0,
 	}, func(error) bool { return true },
 		func() error {
 			serviceAccount := &corev1.ServiceAccount{}

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -119,7 +119,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create an HTTPRoute to expose the traffic externally", func() {
 			By("By creating a new Notebook")
-			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook)
 
 			By("By checking that the controller has created the HTTPRoute")
 			Eventually(func() error {
@@ -190,7 +190,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create a ReferenceGrant when creating a Notebook", func() {
 			By("By creating a new Notebook")
-			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook)
 
 			By("By checking that the controller has created the ReferenceGrant")
 			Eventually(func() error {
@@ -273,7 +273,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should keep ReferenceGrant when deleting notebook if other notebooks exist", func() {
 			By("By creating a second notebook in the same namespace")
 			notebook2 := createNotebook(Name+"-second", Namespace)
-			Expect(cli.Create(ctx, notebook2)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook2)
 
 			// Wait for second notebook to be reconciled
 			time.Sleep(interval)
@@ -309,7 +309,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should share one ReferenceGrant across multiple notebooks", func() {
 			By("By creating first notebook")
 			notebook1 := createNotebook(Name1, Namespace)
-			Expect(cli.Create(ctx, notebook1)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook1)
 
 			By("By verifying ReferenceGrant exists or is created")
 			referenceGrant := &gatewayv1beta1.ReferenceGrant{}
@@ -322,8 +322,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("By creating second and third notebooks")
 			notebook2 := createNotebook(Name2, Namespace)
 			notebook3 := createNotebook(Name3, Namespace)
-			Expect(cli.Create(ctx, notebook2)).Should(Succeed())
-			Expect(cli.Create(ctx, notebook3)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook2)
+			createNotebookWithSA(ctx, cli, notebook3)
 
 			// Wait for reconciliation
 			time.Sleep(interval)
@@ -621,7 +621,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create an HTTPRoute to expose the traffic externally", func() {
 			By("By creating a new Notebook")
-			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook)
 			time.Sleep(interval)
 
 			By("By checking that the controller has created the HTTPRoute")
@@ -918,7 +918,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create network policies to restrict undesired traffic", func() {
 			By("By creating a new Notebook")
-			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook)
 
 			By("By checking that the controller has created Network policy to allow only controller traffic")
 			Eventually(func() error {
@@ -1404,7 +1404,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should clean up unauthenticated HTTPRoutes when enabling kube-rbac-proxy", func() {
 			By("Creating a notebook without kube-rbac-proxy initially")
 			notebook := createNotebook(Name, Namespace)
-			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook)
 
 			By("Verifying an unauthenticated HTTPRoute is created")
 			unauthenticatedRoute := &gatewayv1.HTTPRoute{}
@@ -1530,7 +1530,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create a Notebook without kube-rbac-proxy proxy", func() {
 			By("By creating a new Notebook without inject-auth annotation")
-			Expect(cli.Create(ctx, notebook)).Should(Succeed())
+			createNotebookWithSA(ctx, cli, notebook)
 
 			By("By checking that no kube-rbac-proxy proxy container was injected")
 			Eventually(func() error {
@@ -1676,7 +1676,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("Creating Notebook")
 			notebook := createNotebook(notebookName, Namespace)
-			Expect(cli.Create(ctx, notebook)).To(Succeed())
+			createNotebookWithSA(ctx, cli, notebook)
 
 			By("Waiting for ds-pipeline-config Secret to be created")
 			Eventually(func() error {
@@ -1859,6 +1859,28 @@ func createExpectedServiceAccount(name, namespace string) corev1.ServiceAccount 
 			},
 		},
 	}
+}
+
+// createNotebookWithSA pre-creates a ServiceAccount with a dummy ImagePullSecret
+// before creating the notebook, so that RemoveReconciliationLock returns immediately
+// instead of blocking the single reconciler worker with retries (the SA never gets
+// real pull secrets in envtest). Use this for non-kube-rbac-proxy notebooks only;
+// kube-rbac-proxy tests rely on the reconciler creating the SA with ownerReferences.
+func createNotebookWithSA(ctx context.Context, cli client.Client, notebook *nbv1.Notebook) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      notebook.Name,
+			Namespace: notebook.Namespace,
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "default-dockercfg-dummy"},
+		},
+	}
+	err := cli.Create(ctx, sa)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+	Expect(cli.Create(ctx, notebook)).Should(Succeed())
 }
 
 // CompareNotebookServiceAccounts compares two ServiceAccount objects for testing

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -119,7 +119,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create an HTTPRoute to expose the traffic externally", func() {
 			By("By creating a new Notebook")
-			createNotebookWithSA(ctx, cli, notebook)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
 			By("By checking that the controller has created the HTTPRoute")
 			Eventually(func() error {
@@ -190,7 +190,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create a ReferenceGrant when creating a Notebook", func() {
 			By("By creating a new Notebook")
-			createNotebookWithSA(ctx, cli, notebook)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
 			By("By checking that the controller has created the ReferenceGrant")
 			Eventually(func() error {
@@ -273,7 +273,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should keep ReferenceGrant when deleting notebook if other notebooks exist", func() {
 			By("By creating a second notebook in the same namespace")
 			notebook2 := createNotebook(Name+"-second", Namespace)
-			createNotebookWithSA(ctx, cli, notebook2)
+			Expect(cli.Create(ctx, notebook2)).Should(Succeed())
 
 			// Wait for second notebook to be reconciled
 			time.Sleep(interval)
@@ -309,7 +309,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should share one ReferenceGrant across multiple notebooks", func() {
 			By("By creating first notebook")
 			notebook1 := createNotebook(Name1, Namespace)
-			createNotebookWithSA(ctx, cli, notebook1)
+			Expect(cli.Create(ctx, notebook1)).Should(Succeed())
 
 			By("By verifying ReferenceGrant exists or is created")
 			referenceGrant := &gatewayv1beta1.ReferenceGrant{}
@@ -322,8 +322,8 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			By("By creating second and third notebooks")
 			notebook2 := createNotebook(Name2, Namespace)
 			notebook3 := createNotebook(Name3, Namespace)
-			createNotebookWithSA(ctx, cli, notebook2)
-			createNotebookWithSA(ctx, cli, notebook3)
+			Expect(cli.Create(ctx, notebook2)).Should(Succeed())
+			Expect(cli.Create(ctx, notebook3)).Should(Succeed())
 
 			// Wait for reconciliation
 			time.Sleep(interval)
@@ -382,11 +382,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		})
 
 		It("Should create a RoleBinding when the referenced Role exists", func() {
-			By("Creating a Notebook and ensuring the Role exists")
-			Expect(cli.Create(ctx, notebook)).Should(Succeed())
-			time.Sleep(interval)
-
-			// Simulate the Role required by RoleBinding
+			By("Creating the Role before the Notebook so the reconciler finds it")
 			role := &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      roleRefName,
@@ -399,6 +395,9 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					GinkgoT().Logf("Failed to delete Role: %v", err)
 				}
 			}()
+
+			By("Creating the Notebook")
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
 			By("Checking that the RoleBinding is created")
 			roleBinding := &rbacv1.RoleBinding{}
@@ -621,7 +620,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create an HTTPRoute to expose the traffic externally", func() {
 			By("By creating a new Notebook")
-			createNotebookWithSA(ctx, cli, notebook)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 			time.Sleep(interval)
 
 			By("By checking that the controller has created the HTTPRoute")
@@ -731,8 +730,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("When notebook CR is updated, should mount a trusted-ca if it exists on the given namespace", func() {
 			logger := logr.Discard()
 
-			By("By simulating the existence of odh-trusted-ca-bundle ConfigMap")
-			// Create a ConfigMap similar to odh-trusted-ca-bundle for simulation
+			By("By simulating the existence of odh-trusted-ca-bundle and service-ca ConfigMaps")
 			workbenchTrustedCACertBundle := WorkbenchTrustedCABundleName
 			trustedCACertBundle := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -747,23 +745,51 @@ var _ = Describe("The Openshift Notebook controller", func() {
 					OdhCABundleCertKey: "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTMyMzI4NDJaFw0yNTExMTMy\nMzI4NDJaMAAwKjAFBgMrZXADIQAw01381TUVSxaCvjQckcw3RTcg+bsVMgNZU8eF\nXa/f3jAFBgMrZXADQQBeJZHSiMOYqa/tXUrQTfNIcklHuvieGyBRVSrX3bVUV2uM\nDBkZLsZt65rCk1A8NG+xkA6j3eIMAA9vBKJ0ht8F\n-----END CERTIFICATE-----",
 				},
 			}
-			// Create the ConfigMap
+			serviceCACertBundle := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openshift-service-ca.crt",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"service-ca.crt": "-----BEGIN CERTIFICATE-----\nMIIBATCBtKADAgECAgEBMAUGAytlcDAAMB4XDTI1MDYxNjE2MTg0MVoXDTI2MDYx\nNjE2MTg0MVowADAqMAUGAytlcAMhAP7g8UxhoFPZXQiy4sSbOsLrlXq2RgFTzQOD\nj8O8e9qmo1MwUTAdBgNVHQ4EFgQUTCWpJDtMDVadBlVpkVTiLnCihqMwHwYDVR0j\nBBgwFoAUTCWpJDtMDVadBlVpkVTiLnCihqMwDwYDVR0TAQH/BAUwAwEB/zAFBgMr\nZXADQQDKpiapbn7ub7/hT7Whad9wbvIY8wXrWojgZXXbWaMQFV8i8GW7QN4w/C1p\nB8i0efvecoLP/mqmXNyl7KgTnC4D\n-----END CERTIFICATE-----",
+				},
+			}
 			Expect(cli.Create(ctx, trustedCACertBundle)).Should(Succeed())
+			err := cli.Create(ctx, serviceCACertBundle)
+			if err != nil && !apierrors.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
 			defer func() {
-				// Clean up the ConfigMap after the test
 				if err := cli.Delete(ctx, trustedCACertBundle); err != nil {
-					// Log the error without failing the test
+					logger.Info("Error occurred during deletion of ConfigMap", "error", err)
+				}
+				if err := cli.Delete(ctx, serviceCACertBundle); err != nil {
 					logger.Info("Error occurred during deletion of ConfigMap", "error", err)
 				}
 			}()
 
-			By("By updating the Notebook's image")
+			By("By stopping the notebook so the webhook allows pod-template mutations")
 			key := types.NamespacedName{Name: Name, Namespace: Namespace}
-			Expect(cli.Get(ctx, key, notebook)).Should(Succeed())
+			Eventually(func() error {
+				if err := cli.Get(ctx, key, notebook); err != nil {
+					return err
+				}
+				if notebook.Annotations == nil {
+					notebook.Annotations = make(map[string]string)
+				}
+				notebook.Annotations[culler.STOP_ANNOTATION] = "true"
+				return cli.Update(ctx, notebook)
+			}, duration, interval).Should(Succeed())
 
+			By("By updating the Notebook's image")
 			updatedImage := "registry.redhat.io/ubi9/ubi:updated"
-			notebook.Spec.Template.Spec.Containers[0].Image = updatedImage
-			Expect(cli.Update(ctx, notebook)).Should(Succeed())
+			Eventually(func() error {
+				if err := cli.Get(ctx, key, notebook); err != nil {
+					return err
+				}
+				notebook.Spec.Template.Spec.Containers[0].Image = updatedImage
+				return cli.Update(ctx, notebook)
+			}, duration, interval).Should(Succeed())
 
 			By("By checking that trusted-ca bundle is mounted")
 			// Assert that the volume mount and volume are added correctly
@@ -918,7 +944,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create network policies to restrict undesired traffic", func() {
 			By("By creating a new Notebook")
-			createNotebookWithSA(ctx, cli, notebook)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
 			By("By checking that the controller has created Network policy to allow only controller traffic")
 			Eventually(func() error {
@@ -1404,7 +1430,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 		It("Should clean up unauthenticated HTTPRoutes when enabling kube-rbac-proxy", func() {
 			By("Creating a notebook without kube-rbac-proxy initially")
 			notebook := createNotebook(Name, Namespace)
-			createNotebookWithSA(ctx, cli, notebook)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
 			By("Verifying an unauthenticated HTTPRoute is created")
 			unauthenticatedRoute := &gatewayv1.HTTPRoute{}
@@ -1530,7 +1556,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 		It("Should create a Notebook without kube-rbac-proxy proxy", func() {
 			By("By creating a new Notebook without inject-auth annotation")
-			createNotebookWithSA(ctx, cli, notebook)
+			Expect(cli.Create(ctx, notebook)).Should(Succeed())
 
 			By("By checking that no kube-rbac-proxy proxy container was injected")
 			Eventually(func() error {
@@ -1676,7 +1702,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("Creating Notebook")
 			notebook := createNotebook(notebookName, Namespace)
-			createNotebookWithSA(ctx, cli, notebook)
+			Expect(cli.Create(ctx, notebook)).To(Succeed())
 
 			By("Waiting for ds-pipeline-config Secret to be created")
 			Eventually(func() error {
@@ -1859,28 +1885,6 @@ func createExpectedServiceAccount(name, namespace string) corev1.ServiceAccount 
 			},
 		},
 	}
-}
-
-// createNotebookWithSA pre-creates a ServiceAccount with a dummy ImagePullSecret
-// before creating the notebook, so that RemoveReconciliationLock returns immediately
-// instead of blocking the single reconciler worker with retries (the SA never gets
-// real pull secrets in envtest). Use this for non-kube-rbac-proxy notebooks only;
-// kube-rbac-proxy tests rely on the reconciler creating the SA with ownerReferences.
-func createNotebookWithSA(ctx context.Context, cli client.Client, notebook *nbv1.Notebook) {
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      notebook.Name,
-			Namespace: notebook.Namespace,
-		},
-		ImagePullSecrets: []corev1.LocalObjectReference{
-			{Name: "default-dockercfg-dummy"},
-		},
-	}
-	err := cli.Create(ctx, sa)
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		Expect(err).NotTo(HaveOccurred())
-	}
-	Expect(cli.Create(ctx, notebook)).Should(Succeed())
 }
 
 // CompareNotebookServiceAccounts compares two ServiceAccount objects for testing

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -790,7 +790,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				if notebook.Annotations == nil {
 					notebook.Annotations = make(map[string]string)
 				}
-				notebook.Annotations[culler.STOP_ANNOTATION] = "true"
+				notebook.Annotations[culler.STOP_ANNOTATION] = trueString
 				return cli.Update(ctx, notebook)
 			}, duration, interval).Should(Succeed())
 

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -129,6 +129,19 @@ var _ = Describe("The Openshift Notebook controller", func() {
 			Expect(*httpRoute).To(BeMatchingK8sResource(expectedHTTPRoute, CompareNotebookHTTPRoutes))
 		})
 
+		It("Should remove the reconciliation lock without blocking the reconciler", func() {
+			By("By verifying the lock is removed promptly (non-blocking)")
+			nonBlockingTimeout := 5 * time.Second
+			Eventually(func() (map[string]string, error) {
+				key := types.NamespacedName{Name: Name, Namespace: Namespace}
+				err := cli.Get(ctx, key, notebook)
+				if err != nil {
+					return nil, err
+				}
+				return notebook.Annotations, nil
+			}, nonBlockingTimeout, interval).Should(Not(HaveKey(culler.STOP_ANNOTATION)))
+		})
+
 		It("Should reconcile the HTTPRoute when modified", func() {
 			By("By simulating a manual HTTPRoute modification")
 			patch := client.RawPatch(types.MergePatchType, []byte(`{"spec":{"rules":[{"backendRefs":[{"name":"foo","port":8888}]}]}}`))

--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -52,7 +52,7 @@ import (
 var _ = Describe("The Openshift Notebook controller", func() {
 	// Define utility constants for testing timeouts/durations and intervals.
 	const (
-		duration = 10 * time.Second
+		duration = 30 * time.Second
 		interval = 200 * time.Millisecond
 	)
 

--- a/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
@@ -728,11 +728,13 @@ func CheckAndMountCACertBundle(ctx context.Context, cli client.Client, notebook 
 			},
 		}
 		err = cli.Create(ctx, workbenchConfigMap)
-		if err != nil {
+		if err != nil && !apierrs.IsAlreadyExists(err) {
 			log.Info("Failed to create workbench-trusted-ca-bundle ConfigMap")
 			return nil
 		}
-		log.Info("Created workbench-trusted-ca-bundle ConfigMap")
+		if err == nil {
+			log.Info("Created workbench-trusted-ca-bundle ConfigMap")
+		}
 	}
 
 	cm := workbenchConfigMap


### PR DESCRIPTION
RemoveReconciliationLock uses a synchronous retry with Factor 5.0, blocking the single reconciler worker for ~6s when the ServiceAccount is not found (always the case in envtest). This delays processing of subsequent notebooks beyond the 10s test timeout on slower CI runners.

- Reduce retry backoff factor from 5.0 to 1.0 (worst-case blocking drops from ~6s to ~3s)
- Increase test Eventually timeout from 10s to 30s to accommodate CI runner variability

Fixes: https://github.com/opendatahub-io/kubeflow/issues/839

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
```
cd components/odh-notebook-controller
make test
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation-lock removal so notebook reconciliation no longer waits for a service account image pull secret.
  * Updated trusted CA certificate mounting to handle existing configuration resources without reporting a failure.

* **Tests**
  * Increased test timeout and expanded coverage for reconciliation, RBAC setup, and trusted CA mounting scenarios.

* **Chores**
  * Removed obsolete retry and backoff behavior related to image pull secret provisioning.
  * Reduced unnecessary controller logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->