### PR TITLE
fix(gha): pin govulncheck to v1.3.0 to avoid Go 1.26 panic

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -30,7 +30,10 @@ jobs:
           cache-dependency-path: ${{ matrix.component }}/go.sum
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # TODO: Revert to @latest once govulncheck releases a fix for the
+        # ForEachElement panic with Go 1.26 (x/tools v0.46.0 bug).
+        # Tracking issue: https://github.com/golang/go/issues/80059
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run govulncheck
         id: vulncheck


### PR DESCRIPTION
govulncheck v1.4.0 panics with "ForEachElement called on type containing *types.TypeParam" when run with Go 1.26 due to a bug in its dependency golang.org/x/tools v0.46.0. This causes both govulncheck CI jobs to crash instead of producing vulnerability reports.

Pin to v1.3.0 (which uses x/tools v0.44.0) as a workaround until a fixed govulncheck release is available.

Upstream issue: https://github.com/golang/go/issues/80059

## How Has This Been Tested?

GHA run triggered here: https://github.com/jstourac/kubeflow/actions/runs/28158627385.

We are still failing but due to a real found issues, not due to a panic :white_check_mark: 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the vulnerability-check workflow to use a fixed tool version, helping keep automated security checks stable and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->