### PR TITLE
fix: Use DeepCopy in cache transform functions to prevent data races

### DIFF
--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -98,12 +98,14 @@ func init() {
 // to types that have a per-type Transform override in ByObject.
 func stripConfigMapData(i interface{}) (interface{}, error) {
 	if cm, ok := i.(*corev1.ConfigMap); ok {
-		cm.Data = nil
-		cm.BinaryData = nil
-		if cm.Annotations != nil {
-			delete(cm.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+		cp := cm.DeepCopy()
+		cp.Data = nil
+		cp.BinaryData = nil
+		if cp.Annotations != nil {
+			delete(cp.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 		}
-		cm.SetManagedFields(nil)
+		cp.SetManagedFields(nil)
+		return cp, nil
 	}
 	return i, nil
 }
@@ -114,12 +116,14 @@ func stripConfigMapData(i interface{}) (interface{}, error) {
 // to types that have a per-type Transform override in ByObject.
 func stripSecretData(i interface{}) (interface{}, error) {
 	if s, ok := i.(*corev1.Secret); ok {
-		s.Data = nil
-		s.StringData = nil
-		if s.Annotations != nil {
-			delete(s.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+		cp := s.DeepCopy()
+		cp.Data = nil
+		cp.StringData = nil
+		if cp.Annotations != nil {
+			delete(cp.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 		}
-		s.SetManagedFields(nil)
+		cp.SetManagedFields(nil)
+		return cp, nil
 	}
 	return i, nil
 }


### PR DESCRIPTION
## Summary

Fixes a data race in `stripConfigMapData` and `stripSecretData` transform functions introduced in #782.

The `cache.TransformFunc` contract requires that transform functions must not modify the input object in place. The SharedIndexInformer keeps references to both old and new objects during Update events. Mutating in-place corrupts the old-object reference, causing data races under concurrent reconciliation.

**Fix**: Return a `DeepCopy()` with modifications instead of mutating the original pointer.

## Changes

- `stripConfigMapData`: DeepCopy before mutating, return copy
- `stripSecretData`: DeepCopy before mutating, return copy

## Ref

- Reported by @mwaykole in https://github.com/opendatahub-io/odh-model-controller/pull/757#discussion_r3519838706
- Same fix applied to odh-model-controller and data-science-pipelines-operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook-related cache handling to avoid modifying cached resources in place.
  * Cached configuration and secret data is now cleaned on a copy before being returned, reducing the risk of unintended side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->