### PR TITLE
revert: Remove unnecessary DeepCopy from cache transform functions

### DIFF
--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -98,14 +98,12 @@ func init() {
 // to types that have a per-type Transform override in ByObject.
 func stripConfigMapData(i interface{}) (interface{}, error) {
 	if cm, ok := i.(*corev1.ConfigMap); ok {
-		cp := cm.DeepCopy()
-		cp.Data = nil
-		cp.BinaryData = nil
-		if cp.Annotations != nil {
-			delete(cp.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+		cm.Data = nil
+		cm.BinaryData = nil
+		if cm.Annotations != nil {
+			delete(cm.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 		}
-		cp.SetManagedFields(nil)
-		return cp, nil
+		cm.SetManagedFields(nil)
 	}
 	return i, nil
 }
@@ -116,14 +114,12 @@ func stripConfigMapData(i interface{}) (interface{}, error) {
 // to types that have a per-type Transform override in ByObject.
 func stripSecretData(i interface{}) (interface{}, error) {
 	if s, ok := i.(*corev1.Secret); ok {
-		cp := s.DeepCopy()
-		cp.Data = nil
-		cp.StringData = nil
-		if cp.Annotations != nil {
-			delete(cp.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+		s.Data = nil
+		s.StringData = nil
+		if s.Annotations != nil {
+			delete(s.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 		}
-		cp.SetManagedFields(nil)
-		return cp, nil
+		s.SetManagedFields(nil)
 	}
 	return i, nil
 }


### PR DESCRIPTION
## Summary

Reverts the DeepCopy added in #843. 

Since client-go v1.27, `TransformFunc` sees the object before any other actor, and [in-place mutation is explicitly safe](https://github.com/kubernetes/client-go/blob/v0.35.2/tools/cache/delta_fifo.go#L148-L164):

> "New in v1.27: TransformFunc sees the object before any other actor, and it is now safe to mutate the object in place instead of making a copy."

This repo uses client-go v0.35.2. The DeepCopy introduced unnecessary allocation overhead on every cached ConfigMap and Secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cached configuration and secret content so sensitive data is stripped more reliably before being processed.
  * Cleaned up associated metadata to reduce stale information being carried forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->