### PR TITLE
fix: TLS profile resilience (transient errors, adherence policy, watcher self-healing)

### DIFF
--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -187,12 +187,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	if profile, err = tlspkg.FetchAPIServerTLSProfile(context.Background(), bootstrapClient); err != nil {
+	bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer bootstrapCancel()
+	if profile, err = tlspkg.FetchAPIServerTLSProfile(bootstrapCtx, bootstrapClient); err != nil {
 		switch {
 		case apimeta.IsNoMatchError(err):
 			setupLog.Info("TLS profile not available, using hardened defaults (non-OpenShift cluster)")
 		case k8serr.IsNotFound(err):
 			setupLog.Info("APIServer resource not found, using hardened defaults")
+		case k8serr.IsServiceUnavailable(err),
+			k8serr.IsTimeout(err),
+			k8serr.IsTooManyRequests(err):
+			hasOpenShiftConfigAPI = true // register watcher so it self-heals when the API recovers
+			setupLog.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)
 		default:
 			setupLog.Error(err, "unable to read APIServer TLS profile, refusing to start with unknown TLS posture")
 			os.Exit(1)
@@ -211,6 +218,19 @@ func main() {
 		tlsOpts = append(tlsOpts, tlsConfigFn, func(c *tls.Config) {
 			c.NextProtos = nextProtos
 		})
+	}
+
+	// Fetch the TLS adherence policy (OpenShift only, requires the APIServer CRD)
+	tlsAdherenceFetched := false
+	var tlsAdherence configv1.TLSAdherencePolicy
+	if hasOpenShiftConfigAPI {
+		adherenceCtx, adherenceCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer adherenceCancel()
+		tlsAdherence, err = tlspkg.FetchAPIServerTLSAdherencePolicy(adherenceCtx, bootstrapClient)
+		if err != nil {
+			setupLog.Info("unable to fetch TLS adherence policy, watcher will retry", "error", err)
+		}
+		tlsAdherenceFetched = true // always register watcher; it self-heals when the API recovers (OCP ref: cluster-machine-approver)
 	}
 
 	// Setup controller manager
@@ -332,6 +352,13 @@ func main() {
 				setupLog.Info("TLS profile changed, initiating graceful shutdown to reload")
 				cancel()
 			},
+		}
+		if tlsAdherenceFetched {
+			watcher.InitialTLSAdherencePolicy = tlsAdherence
+			watcher.OnAdherencePolicyChange = func(_ context.Context, _, _ configv1.TLSAdherencePolicy) {
+				setupLog.Info("TLS adherence policy changed, initiating shutdown to reload")
+				cancel()
+			}
 		}
 		if err := watcher.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to register TLS security profile watcher")


### PR DESCRIPTION
Follow-up to #836 (TLS profile integration). Three improvements:

1. **Transient error handling**: IsServiceUnavailable/IsTimeout/IsTooManyRequests fall back to hardened defaults instead of crashing. Addresses review feedback from #845: no client.New graceful fallback (CrashLoopBackOff is correct when the k8s client can't be created).
2. **TLSAdherencePolicy support**: Fetches the OCP 5.0 adherence policy and wires it into SecurityProfileWatcher.
3. **Watcher self-healing**: On transient errors, the watcher still registers. When the API recovers, it detects the real profile and triggers a graceful restart automatically.

Supersedes #845 (closed due to branch history issues).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by applying a 10-second timeout to initial TLS profile/bootstrap retrievals.
  * Treated transient TLS-related API failures (e.g., service unavailable, timeouts, rate limiting) as recoverable, allowing startup to continue with hardened defaults and enabling self-healing once the API is back.
  * Added TLS adherence policy bootstrap and watcher behavior so adherence changes trigger the existing automatic shutdown/reload flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->