### PR TITLE
fix: add IsServerTimeout and DeadlineExceeded to TLS transient error handling

### DIFF
--- a/components/odh-notebook-controller/main.go
+++ b/components/odh-notebook-controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -197,7 +198,9 @@ func main() {
 			setupLog.Info("APIServer resource not found, using hardened defaults")
 		case k8serr.IsServiceUnavailable(err),
 			k8serr.IsTimeout(err),
-			k8serr.IsTooManyRequests(err):
+			k8serr.IsServerTimeout(err),
+			k8serr.IsTooManyRequests(err),
+			errors.Is(err, context.DeadlineExceeded):
 			hasOpenShiftConfigAPI = true // register watcher so it self-heals when the API recovers
 			setupLog.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)
 		default:


### PR DESCRIPTION
## Summary

Add two missing transient error cases to the TLS profile fetch error handling in odh-notebook-controller:
- `k8serr.IsServerTimeout`: server-side timeout (distinct from client-side `IsTimeout`)
- `context.DeadlineExceeded`: fires when the 10s bootstrap context times out

Without these, a slow API server during controller startup would hit the `default` case and `os.Exit(1)` instead of falling back to Intermediate TLS defaults.

Jira: [RHOAIENG-78984](https://redhat.atlassian.net/browse/RHOAIENG-78984)

[RHOAIENG-78984]: https://redhat.atlassian.net/browse/RHOAIENG-78984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling when TLS profile retrieval encounters server timeouts, rate limits, or deadline expirations.
  * The controller now continues using secure default TLS settings for these transient conditions instead of treating them as unknown errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->