### PR TITLE
fix(ci): use runner's pre-installed podman instead of manual install

### DIFF
--- a/.github/workflows/notebook_controller_integration_test.yaml
+++ b/.github/workflows/notebook_controller_integration_test.yaml
@@ -22,10 +22,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
-      - name: Verify podman
+      - name: Ensure compatible container runtime
         run: |
+          # Podman 5.x generates OCI runtime specs that crun 1.14.1 (shipped with
+          # Ubuntu 24.04) cannot handle, causing "unknown version specified" errors.
+          # Switch to runc which supports the newer spec versions. This only affects
+          # how RUN steps execute during image build — the output image is identical.
+          mkdir -p ~/.config/containers
+          printf '[engine]\nruntime = "runc"\n' > ~/.config/containers/containers.conf
           podman version
-          podman info --format '{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}'
+          runtime=$(podman info --format '{{.Host.OCIRuntime.Name}}')
+          echo "OCI runtime: $runtime ($(podman info --format '{{.Host.OCIRuntime.Version}}'))"
+          if [[ "$runtime" != "runc" ]]; then
+            echo "::error::Expected podman to use runc, got: $runtime"
+            exit 1
+          fi
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/notebook_controller_integration_test.yaml
+++ b/.github/workflows/notebook_controller_integration_test.yaml
@@ -22,27 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
-      - name: Install podman
+      - name: Verify podman
         run: |
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key \
-            | gpg --dearmor \
-            | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
-              https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" \
-            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get -qq -y install podman
           podman version
-
-          # temporary fix for https://github.com/containers/podman/issues/21024
-          wget https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/amd64/conmon_2.1.2~0_amd64.deb -O /tmp/conmon_2.1.2.deb
-          sudo apt install /tmp/conmon_2.1.2.deb
-
-          # Starting systemd user service
-          systemctl --user daemon-reload
-          systemctl --user start podman.socket
+          podman info --format '{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -22,10 +22,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
-      - name: Verify podman
+      - name: Ensure compatible container runtime
         run: |
+          # Podman 5.x generates OCI runtime specs that crun 1.14.1 (shipped with
+          # Ubuntu 24.04) cannot handle, causing "unknown version specified" errors.
+          # Switch to runc which supports the newer spec versions. This only affects
+          # how RUN steps execute during image build — the output image is identical.
+          mkdir -p ~/.config/containers
+          printf '[engine]\nruntime = "runc"\n' > ~/.config/containers/containers.conf
           podman version
-          podman info --format '{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}'
+          runtime=$(podman info --format '{{.Host.OCIRuntime.Name}}')
+          echo "OCI runtime: $runtime ($(podman info --format '{{.Host.OCIRuntime.Version}}'))"
+          if [[ "$runtime" != "runc" ]]; then
+            echo "::error::Expected podman to use runc, got: $runtime"
+            exit 1
+          fi
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4

--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -22,27 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7.0.1
 
-      - name: Install podman
+      - name: Verify podman
         run: |
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key \
-            | gpg --dearmor \
-            | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
-              https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" \
-            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-          sudo apt-get update -qq
-          sudo apt-get -qq -y install podman
           podman version
-
-          # temporary fix for https://github.com/containers/podman/issues/21024
-          wget https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_22.04/amd64/conmon_2.1.2~0_amd64.deb -O /tmp/conmon_2.1.2.deb
-          sudo apt install /tmp/conmon_2.1.2.deb
-
-          # Starting systemd user service
-          systemctl --user daemon-reload
-          systemctl --user start podman.socket
+          podman info --format '{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4


### PR DESCRIPTION
Remove the manual podman installation from kubic/unstable external repos and the hardcoded conmon 2.1.2 workaround. The ubuntu-latest runners ship a tested podman/crun stack that stays compatible with current OCI image specs, avoiding "unknown version specified" crun errors when base images (ubi9/go-toolset) are built with newer specs.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

just the CI runs attached in this PR

## Merge criteria:

Let's not squash the commits, please!

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Updated notebook controller integration workflows to configure Podman to use the `runc` runtime.
* Added verification of the Podman version and active OCI runtime details.
* Workflows now fail early when the expected runtime is unavailable, providing clearer diagnostics.
* Removed redundant Podman installation, repository setup, workaround, and socket startup steps from workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->