### PR TITLE
fix: reduce kube-rbac-proxy log verbosity from v=10 to v=0

### DIFF
--- a/components/notebook-controller/config/default/manager_auth_proxy_patch.yaml
+++ b/components/notebook-controller/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=0"
         ports:
         - containerPort: 8443
           name: https

--- a/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
@@ -210,7 +210,7 @@ func InjectKubeRbacProxy(notebook *nbv1.Notebook, kubeRbacProxyConfig KubeRbacPr
 			"--secure-listen-address=0.0.0.0:" + strconv.Itoa(NotebookKubeRbacProxyPort),
 			"--upstream=http://127.0.0.1:" + strconv.Itoa(NotebookPort) + "/",
 			"--logtostderr=true",
-			"--v=10", // TODO - TBD, this is too verbose
+			"--v=0",
 			"--proxy-endpoints-port=" + strconv.Itoa(NotebookKubeRbacProxyHealthPort),
 			"--config-file=" + KubeRbacProxyConfigFilePath,
 			"--tls-cert-file=" + KubeRbacProxyTLSCertFilePath,


### PR DESCRIPTION
The kube-rbac-proxy sidecar was hardcoded with --v=10, which is far too verbose for production use and generates excessive log volume. Lower it to --v=0 (the klog default), which still logs errors, warnings, and essential info while suppressing debug-level output.

Resolves an in-code TODO that acknowledged the verbosity was too high.

https://redhat.atlassian.net/browse/RHOAIENG-69555

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Just checked that the log level is truly lowered and the expected argument value is propagated.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced background authentication proxy logging to prevent excessive diagnostic output.
  * Notebook environments now produce less unnecessary log noise while maintaining normal operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->