### PR TITLE
fix(ci): add top-level permissions blocks to all workflows

### DIFF
--- a/.github/workflows/disconnected-readiness.yaml
+++ b/.github/workflows/disconnected-readiness.yaml
@@ -6,8 +6,12 @@ on:
       - stable
       - v1.10-branch
 
+permissions: {}
+
 jobs:
   check:
+    permissions:
+      contents: read
     uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@v1
     with:
       rules: ""

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -7,6 +7,8 @@ name: Go Vulnerability Check
       - main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   govulncheck:
     name: govulncheck

--- a/.github/workflows/notebook-controller-images-updater.yaml
+++ b/.github/workflows/notebook-controller-images-updater.yaml
@@ -35,6 +35,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 env:
   REPO_OWNER: ${{ inputs.organization }}
   TEMP_UPDATER_BRANCH: temp-${{ inputs.branch-name }}-${{ github.run_id }}

--- a/.github/workflows/notebook_controller_integration_test.yaml
+++ b/.github/workflows/notebook_controller_integration_test.yaml
@@ -11,6 +11,8 @@ on:
       - components/notebook-controller/**
   workflow_dispatch:
 
+permissions: {}
+
 env:
   IMG: notebook-controller
   TAG: integration-test
@@ -18,6 +20,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -11,9 +11,13 @@ on:
       - components/notebook-controller/**
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v7.0.1

--- a/.github/workflows/odh-kubeflow-release-pipeline.yaml
+++ b/.github/workflows/odh-kubeflow-release-pipeline.yaml
@@ -14,6 +14,8 @@ on:
         type: boolean
         default: false
 
+permissions: {}
+
 env:
   REPO_ORG: opendatahub-io
   REPO_NAME: kubeflow

--- a/.github/workflows/odh-kubeflow-release-tag.yaml
+++ b/.github/workflows/odh-kubeflow-release-tag.yaml
@@ -9,6 +9,8 @@ on:
       - ".tekton/odh-notebook-controller-push.yaml"
       - ".tekton/odh-kf-notebook-controller-push.yaml"
 
+permissions: {}
+
 env:
   REPO_ORG: opendatahub-io
   REPO_NAME: kubeflow

--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -12,12 +12,17 @@ on:
       - components/odh-notebook-controller/**
   workflow_dispatch:
 
+permissions: {}
+
 env:
   TAG: integration-test
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/odh_notebook_controller_unit_test.yaml
+++ b/.github/workflows/odh_notebook_controller_unit_test.yaml
@@ -11,9 +11,13 @@ on:
       - components/odh-notebook-controller/**
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v7.0.1

--- a/.github/workflows/operator_chaos_validation.yaml
+++ b/.github/workflows/operator_chaos_validation.yaml
@@ -23,6 +23,8 @@ name: Operator Chaos Validation
         required: false
         default: main
 
+permissions: {}
+
 jobs:
   operator-chaos:
     name: operator-chaos shift-left validation

--- a/.github/workflows/sync-branches.yaml
+++ b/.github/workflows/sync-branches.yaml
@@ -21,6 +21,9 @@ on:
         description: "To:"
         required: true
         type: string
+
+permissions: {}
+
 env:
   SOURCE_BRANCH: ${{ inputs.source }}
   TARGET_BRANCH: ${{ inputs.target }}
@@ -28,6 +31,8 @@ env:
 jobs:
   sync-branches:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Set up Git


### PR DESCRIPTION
Without a top-level permissions block the GITHUB_TOKEN defaults to
read-write on all scopes. Set `permissions: {}` (deny-all) at the
workflow level on the 11 workflows that lacked a restrictive
top-level declaration, and add explicit job-level permissions to
each job with only the scopes required (contents:read for tests,
packages:write for GHCR cache, contents:write for branch sync).

https://redhat.atlassian.net/browse/RHOAIENG-69565

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security for automated workflows by applying read-only permissions by default.
  * Added narrowly scoped write access where required for package publishing, branch synchronization, and repository updates.
  * Existing workflow behavior and build steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->